### PR TITLE
`[release/2.4.0]` 디자인 최신화 | 캘린더 뷰 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,7 @@ yarn-error.log*
 .netlify
 
 # Claude Code (local-only)
-.claude/scheduled_tasks.lock
-.claude/worktrees/
+.claude/
 
 # oh-my-claudecode (local runtime state)
 .omc/

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,13 @@ yarn-error.log*
 # Local Netlify folder
 .netlify
 
+# Claude Code (local-only)
+.claude/scheduled_tasks.lock
+.claude/worktrees/
+
+# oh-my-claudecode (local runtime state)
+.omc/
+
 # Created by https://www.toptal.com/developers/gitignore/api/visualstudiocode
 # Edit at https://www.toptal.com/developers/gitignore?templates=visualstudiocode
 

--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,4 @@ fabric.properties
 .idea/**/azureSettings.xml
 
 # End of https://www.toptal.com/developers/gitignore/api/intellij
+.superpowers/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## 프로젝트
+
+Dev Event Web — 개발자 행사(웨비나·컨퍼런스·해커톤·네트워킹)를 큐레이션하는 한국어 웹 (https://dev-event.vercel.app/events). Next.js 12 / React 17 / TypeScript 4.6, pnpm 8+, Node 20 (`.nvmrc`는 20.15.1 고정).
+
+## 명령어
+
+```bash
+pnpm install        # 의존성 설치
+pnpm dev            # 개발 서버 http://localhost:5000  (주의: 3000 아님, 5000 포트)
+pnpm build          # 프로덕션 Next.js 빌드 (배포 전 / 대규모 리팩토링 후 권장)
+pnpm start          # 빌드 결과물 서빙
+pnpm lint           # next lint (첫 실행 시 ESLint 셋업 프롬프트 — "Strict" 선택)
+pnpm test           # jest (ts-jest + jsdom)
+pnpm test:watch     # jest watch 모드
+pnpm test -- <pattern>   # 단일 테스트 파일, 예: pnpm test -- buildCalendarMatrix
+npx tsc --noEmit    # 타입 체크만 (빌드 없이)
+```
+
+배포는 Vercel을 통해 진행 (`vercel build && vercel deploy [--prod]`). 정식 순서는 README에 정리되어 있어요.
+
+## 아키텍처 개요
+
+### 라우팅 & 데이터 레이어
+- **Pages Router** (`pages/`) — 모든 페이지는 `getServerSideProps`로 SSR 렌더링. 클라이언트 라우팅은 `router.push`(SSR을 다시 돌려야 하면 `shallow: false`). `/calender` 라우트는 `/events?view=calendar&year=&month=`로 307 리디렉트만 함 (예전 북마크 호환).
+- **외부 API**가 데이터의 진실 근원. `${process.env.BASE_SERVER_URL}/front/v2/...` 에서 받아옵니다. Next.js의 `pages/api/*`는 auth/세션/쿠키용 얇은 헬퍼로만 쓰이며, 데이터 레이어가 아닙니다.
+- **데이터 페치**: SWR 훅들이 `lib/hooks/useSWR.tsx`에 있음 (`useScheduledEvents`, `useMonthlyEvent`, `useMyEvent`, `useTags`, `useUser`). 각 훅은 `fallbackData`를 받아 SSR로 받아온 데이터를 즉시 hydrate하고 이후 SWR이 revalidate. **새 훅을 추가할 때 이 패턴을 따르세요** — 컴포넌트 내부에서 `fetch`를 직접 호출하지 말 것.
+- **HTTP**: `lib/api/`에 axios 인스턴스 — 비인증 콜은 `axiosInstance`, 인증 콜은 `axiosInstanceWithToken`. 에러 처리도 같은 디렉터리.
+
+### 상태 관리 (Context)
+모든 Provider는 `pages/_app.tsx`에서 다음 순서로 중첩됩니다: `AuthProvider → WindowProvider → EventProvider → ToastProvider`.
+- **`EventContext`**: 페이지 간 공유되는 필터 상태 (`jobGroupList`, `eventType`, `location`, `coast`, `search`, `date`, `url`). 필터 컴포넌트가 `update*`/`delete*`/`handle*` 메서드로 mutate합니다. `/events` 리스트 뷰와 캘린더 뷰가 이 상태를 공유하므로 뷰 토글 시에도 필터 칩이 유지됩니다.
+- **`WindowContext`**: viewport류 데이터 — `windowX`(픽셀 폭), `windowTheme`, `isNotice`, 그리고 숫자형 `modalState.currentModal` 스위치. 모달은 컴포넌트별 boolean이 아니라 `modalState.currentModal === <id>` 매칭으로 게이팅합니다. 새 모달 추가할 때 이 패턴을 유지하세요.
+  - **주의**: `handleWindowX`는 정의되어 있지만 어떤 resize 리스너도 이를 호출하지 않습니다. 컴포넌트에서 현재 viewport가 필요하면 자체 `window.innerWidth` + `resize` 리스너를 추가하세요 (예: `components/events/calendar/CalendarView.tsx`). `WindowContext.windowX > 0` 으로 분기하지 마세요 — 항상 0입니다.
+
+### 컨벤션
+- **import**: `tsconfig.json`의 `baseUrl: './'`로 프로젝트 루트 기준 절대 경로 임포트가 가능합니다 (`import { Event } from 'model/event'`). 가능한 한 절대 경로를 사용하고 `../../../` 같은 상대 경로는 피하세요. Prettier가 `.prettierrc.cjs`에 정의된 순서로 정렬합니다 (`react`, `classnames`, `@headlessui`, `next`, `jotai`, `@<...>`, 그 다음 relative).
+- **스타일**: SCSS Module (`Foo.tsx` 옆 `Foo.module.scss`). `classNames.bind(style)`을 `cn` 또는 `cx`로 별칭. 공유 SCSS 임포트 시 **반드시 풀 파일명 + 틸드**: `@import '~styles/_variables.scss'`. `@import '~styles/variables'` 같이 확장자/언더스코어 생략하면 sass-loader가 조용히 실패하면서 해시된 클래스명만 생성되고 실제 CSS 규칙은 비어버리는 함정이 있습니다.
+- **디자인 토큰**: `DESIGN.md`에 KTB(카카오테크 부트캠프) 기반 디자인 시스템 정리 — Pretendard 폰트, KTB Tech Blue `#0043FF`, Vapor gray 스케일, 12/24px border-radius. 공유 SCSS 변수/믹스인은 `styles/_variables.scss` / `_mixin.scss` / `_common.scss`.
+- **이미지**: `next/image` + `unoptimized` 조합으로 외부 썸네일 사용. 허용된 외부 호스트는 `next.config.js > images.domains`에 화이트리스트. 폴백 썸네일은 `/default/event-thumbnail-light.png`.
+- **SVG**: `@svgr/webpack`으로 React 컴포넌트로 import (이미 `next.config.js`에 설정).
+- **레이아웃**: 페이지가 `getLayout`을 export하면 wrap됩니다: `Events.getLayout = (page) => <Layout>{page}</Layout>`. `_app.tsx`가 이를 읽어서 적용합니다.
+
+### 도메인 모델 (`model/event.ts`)
+직관적이지 않은 필드 몇 가지:
+- `event_time_type: 'DATE' | 'RECRUIT'` — `DATE`는 실제 행사 날짜, `RECRUIT`는 모집/접수 기간 (보통 캘린더처럼 날짜 기반 UI에는 렌더하지 않음).
+- `use_start_date_time_yn` / `use_end_date_time_yn: 'Y' | 'N' | null` — `'N'`이면 날짜만 의미 있고 시간 부분은 무의미. 표시 로직에서 반드시 체크해야 합니다 (`components/common/item/Item.tsx > getEventDate` 참고).
+- 이벤트는 여러 날에 걸칠 수 있음 (`start_date_time` → `end_date_time`).
+
+### 캘린더 기능 (`components/events/calendar/`)
+기존 카드 리스트 위에 추가된 뷰. `/events` 페이지가 `getServerSideProps`에서 `?view=calendar` 여부로 분기해 `ScheduledEventList`(리스트) 또는 `CalendarView`(그리드)를 렌더. `CalendarView`는 viewport(`window.innerWidth <= 720`)를 자체 감지해 `CalendarGrid`(데스크탑 7×6) 또는 `CalendarDotGrid`(모바일 점 캘린더)를 선택. `ViewToggle` 칩은 리스트 모드에선 `EventFilter`의 칩 줄 안에, 캘린더 모드에선 `CalendarHeader` 안에 들어갑니다. 순수 로직 (`buildCalendarMatrix`, `layoutMultiDayEvents`, `tagColor`)은 `components/events/calendar/utils/__tests__/` 하위에 단위 테스트 됩니다.
+
+## 테스트
+
+지금은 순수 유틸 함수만 테스트로 커버되어 있습니다. Jest 설정은 `jest.config.js` (ts-jest + jsdom, SCSS는 `__mocks__/styleMock.js`로 모킹). 테스트는 대상 코드 옆 `__tests__/` 디렉터리에. 컴포넌트 테스트를 추가하려면 `@testing-library/react`를 설치해야 합니다 (현재 미설치).
+
+## 작업 노트
+
+- `main`이 배포 브랜치. 기능 작업은 `feature/*` 브랜치에서 진행하고 PR로 merge합니다.
+- `DESIGN.md`는 비주얼 디자인 계약 — 새 UI 만들 땐 그 토큰을 재사용 (primary: KTB Tech Blue, 폰트: Pretendard, 12/24px radius, `#E1E1E8` 보더).
+- `docs/superpowers/specs/`와 `docs/superpowers/plans/` 에 최근 작업의 디자인 스펙·구현 플랜이 있음 (events card / detail / filter / header 리뉴얼, events calendar view). 해당 영역 수정 시 참고용.
+- `.claude/`, `.omc/`, `.superpowers/`는 로컬 Claude/에이전트 상태이며 gitignore 대상입니다.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,413 @@
+<!--
+  omd:source = custom reference (kakaotechbootcamp.com)
+  omd:base-fingerprint = kakaotechbootcamp.com (Goorm Vapor Design System v0.21.4 + KTB brand tokens)
+  omd:project = Dev Event Web — 개발자 행사 큐레이션 (Next.js)
+  omd:notes = Structural template traced from the `kakao` reference DESIGN.md (9 sections).
+              Visual tokens replaced with real values extracted from kakaotechbootcamp.com's
+              live CSS (style.css + Vapor foundation v0.21.4). Course-card and course detail
+              page (cloud.html) patterns preserved as-is — domain swap to dev events only.
+-->
+
+# Design System Inspiration of KTB (카카오테크 부트캠프) — for Dev Event Web
+
+## 1. Visual Theme & Atmosphere
+
+KTB(카카오테크 부트캠프)는 교육 플랫폼이지만, 비주얼은 **테크 컴퍼니의 신뢰감**을 가져간다. 짙은 네이비(`#000040`)와 채도 높은 시그니처 블루(`#0043ff`)가 한 쌍으로 움직이고, 그 사이를 흰 캔버스가 떠받친다. KakaoTalk의 따뜻한 노랑과는 다른 결 — 부트캠프의 정체성은 "친근함"이 아니라 "단단함"이다.
+
+The design philosophy is **content-forward**, **token-disciplined**, and **media-rich**. course-card의 썸네일은 영상이 자동 재생되고, 카드 자체는 그림자 없이 라운디드 비디오 컨테이너 + 짧은 타이틀 + 캘린더 아이콘 한 줄로 끝난다. 정보는 시각적 노이즈 없이 직접적으로 전달된다 — chrome이 아니라 content가 무대 위에 선다.
+
+Typography는 **Pretendard 한 줄**로 통일한다. 한글 가독성, 모던한 자소 구조, 다국어 친화성을 모두 갖춘 Korean OFL 폰트. 영문/숫자도 같은 가족 안에서 처리되어 코드 스타일의 ad-hoc 폰트 스위칭이 없다. 헤딩에는 letter-spacing `-0.012rem`로 살짝 조여 약간의 prose density를 만든다 — 부트캠프 헤드라인이 "공식 문서" 느낌으로 읽히게.
+
+The overall aesthetic is **flat-but-confident**: 그림자 거의 없음, 미디어(영상/이미지)와 라운디드 컨테이너의 대비로 깊이를 만든다. 라운디드 스케일은 두 단계로 충분 — 카드 표면은 `12px` (border-radius-400), 디테일 페이지의 큰 surface는 `24px` (border-radius-600). 그 이상도 그 이하도 잘 안 쓴다.
+
+**Key Characteristics:**
+- KTB Tech Blue (`#0043ff`) as the singular brand accent — saturated, confident, not pastel
+- KTB Tech Navy (`#000040`) as the brand base — deeper than black, anchors the visual stack
+- Pretendard as the single typeface family (UI + display + body + caption)
+- Vapor Design System tokens (Goorm GDS v0.21.4) as the spacing/color/radius substrate
+- Course-card pattern: aspect-ratio 5/3 thumbnail + h5 title + icon-prefixed meta line
+- Detail hero: 4-column grid (1/4 square thumb + 3/4 info column) with `--border-radius-600` corners
+- Flat surfaces, no decorative shadow — depth from background tier shifts (white → gray-050)
+- `word-break: keep-all` everywhere — Korean text never breaks mid-word
+- Status badges with `pulse` keyframe glow for live/urgent states — the one allowed motion flourish
+
+## 2. Color Palette & Roles
+
+### Primary
+- **KTB Tech Blue** (`#0043ff`): Primary brand color. Buttons (`.btn-ktb`), urgent badges, link emphasis, CTA accent. 부트캠프 라이브 상태의 시각적 앵커.
+- **KTB Tech Navy** (`#000040`): Brand base. Wordmark, navy-tier badges, dark UI sections. Deeper than pure black for warmth at scale.
+- **KTB Tech Sky** (`#78CDFF`): Supporting accent. Soft callouts, secondary highlights.
+- **Pure White** (`#ffffff`): Body background, card surfaces, primary canvas.
+
+### KTB Gradient Accents (Display Only)
+모두 `linear-gradient(180deg, A 10%, B 100%)` 형태. Hero copy, marketing banner, featured event hero에만. **일반 카드/UI 텍스트에 절대 쓰지 말 것**.
+- Yellow: `#FFE600 → #FFB900`
+- Red/Pink: `#FF804E → #FF0073`
+- Pink: `#F57DF0 → #F000E3`
+- Violet: `#AF7DEB → #7A0CFF`
+- Blue: `#00B7F8 → #006EF7`
+- Sky: `#34B7F9 → #87E8DF`
+
+### Semantic (Vapor)
+- **Primary** (`rgb(29, 108, 224)` = `#1D6CE0`): Link text, primary text accents. Use with `var(--text-primary)`.
+- **Danger** (`rgb(217, 28, 41)`): Error states, destructive actions, deadline-imminent badges.
+- **Success** (`rgb(8, 120, 94)`): Confirmed registration, completed states.
+- **Warning** (`rgb(180, 82, 9)`): Attention-needed states, soft alerts.
+
+### Text Scale (Vapor)
+- **Text Normal** (`rgb(43, 45, 54)` = `#2B2D36`): Body, titles, primary content. The workhorse.
+- **Text Secondary** (`rgb(62, 64, 76)` = `#3E404C`): Card subtitles, secondary labels.
+- **Text Hint** (`rgb(108, 110, 126)` = `#6C6E7E`): Period meta line, helper text, captions.
+- **Text Alternative** (`rgb(82, 84, 99)` = `#525463`): Soft body in alternative surfaces.
+- **Text Hint Alternative** (`rgb(62, 64, 76)`): Hint text on dark/colored surfaces.
+- **Text Light** (`#ffffff`): Text on dark/colored backgrounds.
+
+### Neutral Scale (Vapor `gray-*`)
+| Token | Value | Use |
+|-------|-------|-----|
+| `--gray-000` | `#ffffff` | Page background, primary card surface |
+| `--gray-050` | `#F7F7FA` | Alternative background — section bands, hover wash |
+| `--gray-100` | `#F0F0F5` | Thumbnail placeholder bg, search field bg, soft fill |
+| `--gray-200` | `#E8E8EE` | Subtle dividers, disabled-field fill |
+| `--gray-300` | `#E1E1E8` | Standard border (`--border-color`) |
+| `--gray-400` | `#CDCED6` | Hover border (`--border-hover`), disabled stroke |
+| `--gray-500` | `#8C8F9F` | Icon default, placeholder text |
+| `--gray-600` | `#6C6E7E` | Hint text |
+| `--gray-700` | `#525463` | Secondary text on alt bg |
+| `--gray-800` | `#3E404C` | Secondary text |
+| `--gray-900` | `#2B2D36` | Body text, headings |
+| `--gray-950` | `#252730` | Strongest text emphasis |
+
+### Borders & Backgrounds
+- `--border-color` = `#E1E1E8` — default 1px borders
+- `--border-hover` = `#CDCED6` — hover state borders
+- `--background-normal` = `#ffffff` — primary surface
+- `--background-alternative` = `#F7F7FA` — section banding, common-card surface
+
+## 3. Typography Rules
+
+### Font Family
+- **Single Family**: `Pretendard, -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", Roboto, "Noto Sans KR", "Malgun Gothic", sans-serif`
+- **Monospace** (only when code is shown): `"SF Mono", SFMono-Regular, Menlo, Consolas, monospace`
+
+Pretendard is OFL — load via `https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css`. 모든 weight를 한 번에 로드하지 말고 사용하는 400/500/700/800만 selectively load.
+
+### Hierarchy (Vapor `--font-size-*` + `--line-height-*`)
+
+| Role | Size | Line | Weight | Letter Spacing | Notes |
+|------|------|------|--------|----------------|-------|
+| Display | 2.375rem (38px) | 3rem | 700-800 | normal | Marketing hero, gradient-accented copy only |
+| Heading H1 | 2rem (32px) | 2.25rem | 700 | normal | Page title (events 목록, 상세 hero) |
+| Heading H2 | 1.5rem (24px) | 2rem | 700 | normal | Section header (월별 묶음, 카테고리) |
+| Heading H3 | 1.25rem (20px) | 1.875rem | 700 | normal | Sub-section / event detail tab title |
+| Heading H4 | 1.125rem (18px) | 1.625rem | 700 | normal | Card group titles |
+| Heading H5 (Card Title) | 1rem (16px) | 1.5rem | 700 | `-0.012rem` | **course-card / event-card 타이틀** — single line ellipsis |
+| Body | 1rem (16px) | 1.5rem | 400-500 | normal | Default body, descriptions |
+| Subtitle 1 (Meta) | 0.875rem (14px) | 1.375rem | 400-500 | normal | Card period line, secondary meta |
+| Caption | 0.75rem (12px) | 1.125rem | 400-500 | normal | Timestamps, badge text, smallest labels |
+| Micro | 0.625rem (10px) | 0.875rem | 500 | normal | Tag chips, tab labels |
+
+### Principles
+- **One family, one rhythm**: Pretendard로 통일. 다른 폰트를 섞지 말 것. 영문 헤딩만 영문 폰트로 바꾸는 식의 ad-hoc 스위칭 금지.
+- **Heading letter-spacing**: 카드/페이지 헤딩에 `-0.012rem` 적용해 한글 자소 사이를 살짝 조인다. 본문에는 적용하지 않는다.
+- **Weight discipline**: 400(body) / 500(emphasized body, meta) / 700(headings, card titles) / 800(display). 600/900 사용하지 않는다 — Pretendard variable이지만 토큰에 없는 weight는 ship하지 않는다.
+- **`word-break: keep-all`**: 한글이 단어 단위로 줄바꿈되도록 `body`에 글로벌 적용. CJK 가독성의 기본기.
+
+## 4. Component Stylings
+
+### Buttons
+
+**Primary (`.btn-ktb`)**
+- Background: `#0043ff` (`--ktb-tech-blue`)
+- Hover background: `#0238D1` (`--ktb-tech-navy-hover`)
+- Text: `#ffffff`
+- Padding: `var(--space-150) var(--space-300)` (12px 24px)
+- Radius: `var(--border-radius-400)` (12px)
+- Font: 1rem / weight 700
+- Use: Primary CTA — "행사 등록하러 가기", "신청", "참여"
+
+**Secondary / Outline**
+- Background: transparent
+- Text: `#2B2D36` (`--text-normal`)
+- Border: 1px solid `#E1E1E8` (`--border-color`)
+- Hover border: `#CDCED6` (`--border-hover`)
+- Radius: `var(--border-radius-400)` (12px)
+- Use: Secondary actions — "취소", "필터 초기화"
+
+**Ghost / Tertiary**
+- Background: transparent
+- Text: `#1D6CE0` (`--text-primary`)
+- Border: none
+- Use: Inline links, tab triggers
+
+**Danger**
+- Background: `#D91C29` (`--text-danger`)
+- Text: `#ffffff`
+- Radius: `var(--border-radius-400)`
+- Use: 신청 취소, 삭제
+
+### Course / Event Card (Defining Component — Hero of the System)
+
+The card is **the** unit of the events list. Trace this spec exactly.
+
+```
+.event-card                          ← container (a.event-link wraps everything)
+├── .event-thumb                     ← media area
+│   ├── .event-status-badge          ← absolute top-left badge (live/마감임박/모집중)
+│   ├── video.event-video            ← autoplay loop muted playsinline (desktop)
+│   └── picture > img                ← static fallback (mobile / no-video)
+└── .event-info
+    ├── .event-name                  ← h5 — single-line ellipsis title
+    ├── .event-period                ← subtitle-1 — calendar icon + date range
+    └── .badge-container             ← chip row (카테고리, 지역, 온라인/오프라인)
+```
+
+**`.event-card`**
+- Width: 100% of grid cell
+- Background: `#ffffff`
+- Border: **none** (the card is shape-less — its thumb defines the silhouette)
+- Hover: `.event-card:hover .event-video { transform: scale(1.05); }` — only the media zooms
+
+**`.event-thumb`**
+- `width: 100%; aspect-ratio: 5 / 3; overflow: hidden;`
+- `border-radius: var(--border-radius-400)` (12px)
+- `background-color: var(--gray-100)` (`#F0F0F5`) — placeholder while video loads
+- `position: relative` — anchor for absolute badge
+
+**`.event-status-badge`**
+- `position: absolute; top: var(--space-200); left: var(--space-200);` (16px / 16px)
+- `z-index: 1`
+- Use `.badge-ktb-blue` (live / 진행중), `.badge-ktb-navy` (예정), `.badge-ktb-danger` (마감임박) with `pulse-*` keyframe
+
+**`.event-video`**
+- `width: 100%; height: 100%; object-fit: cover; position: absolute; top: 0; left: 0;`
+- `transition: transform 0.3s ease;` ← THE hover signature
+- Mobile: replace with `<picture>` static image (no autoplay on cellular)
+
+**`.event-info`** (content block below thumb)
+- `padding-top: var(--space-150)` (12px above title)
+- No padding sides — aligns flush with thumb edge
+
+**`.event-name`**
+- `h5` element
+- Color: `var(--text-normal)` (`#2B2D36`)
+- Font: 1rem (16px) / weight 700 / letter-spacing `-0.012rem`
+- `margin-bottom: var(--space-050)` (4px)
+- Single-line ellipsis: `white-space: nowrap; overflow: hidden; text-overflow: ellipsis;`
+
+**`.event-period`** (subtitle-1 meta line with calendar icon)
+- Color: `var(--text-hint)` (`#6C6E7E`)
+- Font: 0.875rem (14px) / weight 400
+- `display: flex; align-items: center; gap: var(--space-050)` (4px between icon and text)
+- `margin-bottom: var(--space-150)` (12px)
+- Icon: 16×16 inline SVG, `fill: currentColor`
+
+**`.badge-container`**
+- `display: flex; flex-wrap: wrap; gap: var(--space-050)` (4px)
+- Chip child style: see Tags / Badges below
+
+### Tags / Badges (chips inside cards)
+
+- Background: `var(--gray-100)` (`#F0F0F5`)
+- Text: `var(--text-hint-alternative)` (`#3E404C`)
+- Padding: `var(--space-025) var(--space-100)` (2px 8px)
+- Radius: `var(--border-radius-200)` (6px) — flatter than card radius, signals "secondary"
+- Font: 0.75rem (12px) / weight 500
+- `badge-contrast` variant: bg `rgba(62, 64, 76, .32)` over media
+
+### Cards & Containers (`.common-card`)
+
+For event detail page sections (description, schedule, registration info).
+
+- Background: `var(--background-alternative)` (`#F7F7FA`)
+- Border: **none**
+- Radius: `var(--border-radius-600)` (24px) — bigger than the list card for hierarchical contrast
+- Padding: `var(--space-300)` (24px)
+- Shadow: **none** — flat-by-default
+
+### Event Detail Hero (`.hero-main-row--course` pattern)
+
+The signature 4-column grid for `/event/detail/[eventId]`.
+
+```
+┌───────────┬──────────────────────────────────┐
+│  thumb    │   info-column                    │
+│  1/4      │   3/4                            │
+│  square   │   ┌──────────────────┐           │
+│           │   │ event-title (h1) │           │
+│           │   │ event-description│           │
+│           │   │ btn-ktb (primary)│           │
+│           │   └──────────────────┘           │
+└───────────┴──────────────────────────────────┘
+```
+
+- Container: `display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); column-gap: var(--space-300);` (24px gap)
+- `.thumb-container`: `grid-column: 1 / 2; aspect-ratio: 1 / 1; border-radius: var(--border-radius-600);` (24px) `background-color: var(--background-alternative);`
+- `.info-column`: `grid-column: 2 / 5;`
+- `.event-header-detail`: `display: flex; flex-direction: column; gap: var(--space-100);` (8px between title and description)
+- `.event-title`: `color: var(--text-normal); margin: 0;` — page-level h1
+- `.event-description`: `color: var(--text-hint); margin: 0;`
+- Mobile: thumb stacks above info, full-width
+
+### Inputs & Forms
+- Border: 1px solid `var(--border-color)` (`#E1E1E8`)
+- Radius: `var(--border-radius-400)` (12px)
+- Focus: border becomes `var(--text-normal)` (`#2B2D36`) — no glow, no shadow
+- Text: `var(--text-normal)`, Placeholder: `var(--gray-500)` (`#8C8F9F`)
+- Search bar: `var(--gray-100)` (`#F0F0F5`) bg, `var(--border-radius-400)` radius — borderless variant
+
+### Navigation
+- Top nav height: 7.5rem (120px) — generous, accommodates logo + utility row + tab row
+- Body has `padding-top: 7.5rem` global offset
+- Tab item: `--text-hint` default, `--text-normal` + 2px bottom border on active
+- Font: 1rem / weight 500 / 700 on active
+
+## 5. Layout Principles
+
+### Spacing System (Vapor `--space-*`)
+
+| Token | rem | px | Common Use |
+|-------|-----|----|------------|
+| `--space-000` | 0 | 0 | Reset |
+| `--space-025` | 0.125 | 2 | Hairline gaps in chips |
+| `--space-050` | 0.25 | 4 | Icon-to-text gap, chip gap |
+| `--space-075` | 0.375 | 6 | Tight chip padding-y |
+| `--space-100` | 0.5 | 8 | Card stack gap, badge padding-x |
+| `--space-150` | 0.75 | 12 | Section internal gap, title-to-meta |
+| `--space-175` | 0.875 | 14 | Off-step adjustments |
+| `--space-200` | 1 | 16 | **Standard horizontal padding**, badge top/left |
+| `--space-225` | 1.125 | 18 | Off-step adjustments |
+| `--space-250` | 1.25 | 20 | Section padding-y small |
+| `--space-300` | 1.5 | 24 | **Card padding, grid column-gap, common-card padding** |
+| `--space-400` | 2 | 32 | Section gap medium |
+| `--space-500` | 2.5 | 40 | Section gap large |
+| `--space-600` | 3 | 48 | Hero vertical padding |
+| `--space-700` | 3.5 | 56 | Title margin-bottom on landing |
+| `--space-800` | 4 | 64 | **content-section padding-y** |
+
+### Grid & Container
+- Max content width: **1104px** (laptop) — match existing project token
+- Horizontal padding: 16px (mobile) / 64px (tablet) / 48px (laptop)
+- Events list grid: `grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: var(--space-300);` — responsive course-card row
+- Detail hero: 4-column grid, see Hero spec above
+
+### Whitespace Philosophy
+- **Card-as-island**: Cards float in whitespace, no card-to-card borders. The thumb radius does the visual separation.
+- **Section banding**: Alternate `--background-normal` (white) and `--background-alternative` (`#F7F7FA`) for scroll rhythm. No 3rd background tier.
+- **Generous top padding**: 7.5rem body offset for fixed nav — never overlap content.
+- **`word-break: keep-all`**: 한글 문장이 단어 중간에서 끊기지 않게. 모든 텍스트 컨테이너에 적용.
+
+### Border Radius Scale (Vapor `--border-radius-*`)
+- `--border-radius-100` (8px): Chips/tags on solid surfaces
+- `--border-radius-200` (6px): Small badge chips
+- `--border-radius-400` (**12px**): **Standard for course-card thumb, buttons, inputs** — THE workhorse radius
+- `--border-radius-600` (**24px**): **Common-card / detail hero containers** — THE elevated radius
+- Pill (9999px): Status badges, count badges
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow | **Default — everything**. Cards, list items, buttons, badges |
+| Pulse Glow (Special) | `box-shadow: 0 0 0 0 rgba(...0.6) → 0 0 0 8px rgba(...0)` keyframe | Live/urgent status badges only |
+| Subtle (Level 2) | `0px 2px 6px rgba(0,0,0,0.08)` | Dropdown menus, popovers (rare) |
+| Elevated (Level 3) | `0px 4px 12px rgba(0,0,0,0.12)` | Modal dialogs, bottom sheets (rare) |
+
+**Shadow Philosophy**: KTB는 flat 디자인 시스템이다. 카드, 버튼, 일반 surface에 그림자를 쓰지 않는다. 깊이는 두 가지 수단으로만 만든다 — (1) 배경 색 tier 전환 (`gray-000` → `gray-050` → `gray-100`), (2) `pulse-*` 키프레임으로 라이브 상태 강조. 일반 hover에 box-shadow 추가 금지 — hover는 미디어 scale로만.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use KTB Tech Blue (`#0043ff`) as the **single** primary brand accent
+- Use Pretendard as the **single** typeface family — UI / display / body / monospace exempt
+- Use `var(--border-radius-400)` (12px) for cards/buttons/inputs and `var(--border-radius-600)` (24px) for detail surfaces
+- Apply `letter-spacing: -0.012rem` to headings/card titles (not body)
+- Apply `word-break: keep-all` globally for Korean text integrity
+- Use `transform: scale(1.05)` on `.event-video` for the only card-hover signature
+- Use `pulse-blue` / `pulse-navy` / `pulse-danger` keyframe **only** on status badges that indicate live/urgent state
+- Use Vapor design tokens (`--space-*`, `--gray-*`, `--text-*`, `--border-radius-*`) — never hardcode values when a token exists
+- Stack thumb (1/4 square) + info column (3/4) for detail hero on desktop; collapse to vertical on mobile
+- Render `<video autoplay loop muted playsinline>` for course/event thumbnails on desktop; fall back to `<picture>` on mobile (cellular-safe)
+
+### Don't
+- **Don't add box-shadow to cards or buttons** — KTB is flat. The pulse keyframe is the only shadow.
+- **Don't mix fonts** — Pretendard handles 영문/숫자/한글 모두. ad-hoc 영문 폰트 스위칭 금지.
+- **Don't use KTB gradient accents on functional UI** — gradient은 hero/marketing display 전용. 일반 카드/버튼/타이틀에 금지.
+- **Don't use pure black (`#000000`) for text** — `--text-normal` (`#2B2D36`) for body, `--ktb-tech-navy` (`#000040`) only for wordmark/brand surfaces.
+- **Don't break the card silhouette** — 카드에 border를 두르지 말 것. thumb의 radius와 whitespace로 분리.
+- **Don't add multi-line card titles** — `.event-name`은 single-line ellipsis. 두 줄이 필요하면 카드 grid를 다시 짠다.
+- **Don't autoplay video on mobile** — cellular cost. Use `<picture>` with `source media="(max-width: 576px)"`.
+- **Don't use weights outside 400/500/700/800** — Pretendard variable이지만 토큰 밖 weight는 ship하지 않는다.
+- **Don't replace pulse keyframe with hover shadow** — 라이브 상태와 hover는 다른 감각. pulse는 자동 반복, hover는 사용자 의도.
+
+## 8. Responsive Behavior
+
+### Breakpoints
+| Name | Width | Key Changes |
+|------|-------|-------------|
+| Mobile | <576px | Single-column cards, thumb uses `<picture>` (no autoplay), 16px h-padding |
+| Tablet | 576-768px | 2-column event grid, video autoplay activates, 64px h-padding |
+| Laptop | 768-1104px | 3-4 column event grid, full hero 4-col detail layout |
+| Desktop | >1104px | Content max-width 1104px, generous whitespace outside |
+
+### Touch Targets
+- Card link: entire `.event-card` is tappable (anchor wraps everything)
+- Button minimum: 44×44px tap target — use `min-height: 2.75rem` for icon-only buttons
+- Tab item: minimum 56px height with padding
+
+### Collapsing Strategy
+- **Event detail hero**: desktop 4-column grid → mobile vertical stack (thumb full-width, info below)
+- **Events list**: 4 columns (desktop) → 3 (laptop) → 2 (tablet) → 1 (mobile) — via `auto-fill, minmax(280px, 1fr)`
+- **Top nav**: full nav on desktop → hamburger on mobile, height stays 7.5rem
+- **`.common-card` padding**: `--space-300` (24px) desktop → `--space-200` (16px) mobile
+
+### Image / Video Behavior
+- Thumbnails: aspect-ratio 5/3 (list card) or 1/1 (detail thumb)
+- Desktop: autoplay loop muted video with static `<picture>` fallback
+- Mobile (<576px): static `<picture>` only — no autoplay
+- Profile/avatar (when applicable): 48px rounded square (12px radius), not circles
+- Decorative event banner imagery: `object-fit: cover` inside fixed-aspect container
+
+## 9. Agent Prompt Guide
+
+### Quick Color Reference
+- Primary CTA bg: KTB Tech Blue (`#0043ff`)
+- Primary CTA hover bg: KTB Navy Hover (`#0238D1`)
+- Primary CTA text: White (`#ffffff`)
+- Body bg: White (`#ffffff` = `--gray-000`)
+- Alternative bg: `#F7F7FA` (`--background-alternative`)
+- Card placeholder bg: `#F0F0F5` (`--gray-100`)
+- Heading text: `#2B2D36` (`--text-normal`)
+- Body text: `#2B2D36` (`--text-normal`)
+- Secondary text: `#3E404C` (`--text-secondary`)
+- Hint/Meta text: `#6C6E7E` (`--text-hint`)
+- Link: `#1D6CE0` (`--text-primary`)
+- Border: `#E1E1E8` (`--border-color`)
+- Border hover: `#CDCED6` (`--border-hover`)
+- Error: `#D91C29` (`--text-danger`)
+- Success: `#08785E` (`--text-success`)
+
+### Example Component Prompts
+
+- **Event Card**: "Create an event card: anchor wrapping `.event-thumb` (aspect-ratio 5/3, 12px radius, `#F0F0F5` placeholder bg, `<video autoplay loop muted playsinline>` on desktop with `<picture>` mobile fallback, absolute top-left status badge at 16px) + `.event-info` (padding-top 12px, h5 `.event-name` 16px weight 700 `#2B2D36` single-line ellipsis with letter-spacing -0.012rem, then `.event-period` subtitle 14px `#6C6E7E` with calendar SVG icon 16×16 gap 4px, then `.badge-container` flex-wrap gap 4px). On hover, only the video transforms `scale(1.05)` with 0.3s ease transition. No card border, no shadow."
+
+- **Primary Button**: "Create a `.btn-ktb` primary button: bg `#0043ff`, hover bg `#0238D1`, text `#ffffff` weight 700 size 1rem, padding 12px 24px, border-radius 12px. No box-shadow."
+
+- **Detail Hero**: "Build the event detail hero: 4-column grid, column-gap 24px. Column 1 (grid-column 1/2): square thumbnail container, aspect-ratio 1/1, border-radius 24px, bg `#F7F7FA`. Columns 2-4 (grid-column 2/5): info column with vertical stack (gap 8px) — h1 `.event-title` color `#2B2D36` margin 0, then `.event-description` color `#6C6E7E` margin 0, then `.btn-ktb` primary button. On mobile, stack thumb full-width above info column."
+
+- **Common Card Container**: "Create a `.common-card`: bg `#F7F7FA`, border-radius 24px, padding 24px, no border, no shadow. Use for grouping event detail sub-sections (schedule, registration info, requirements)."
+
+- **Status Badge with Pulse**: "Create a pulsing `.badge-ktb-blue`: bg `#0043ff`, text white, padding 4px 8px, border-radius pill (9999px), font 12px weight 500. Apply `animation: pulse-blue 2s infinite;` where `@keyframes pulse-blue` goes from `box-shadow: 0 0 0 0 rgba(0, 67, 255, 0.6)` to `0 0 0 8px rgba(0, 67, 255, 0)` to `0 0 0 0 rgba(0, 67, 255, 0)`."
+
+- **Chip / Tag**: "Create a chip: bg `#F0F0F5`, text `#3E404C` weight 500 size 12px, padding 2px 8px, border-radius 6px. Use inside `.badge-container` of an event card to show category/region/online tags."
+
+### Iteration Guide
+1. **Pretendard is the single font** — UI/display/body/caption all share one family. Never mix fonts.
+2. **Two radii do 90% of the work**: 12px (`--border-radius-400`) for list cards/buttons/inputs, 24px (`--border-radius-600`) for detail surfaces.
+3. **The card is shape-less; the thumb carries the silhouette**. Don't add borders or shadows to cards.
+4. **Hover is media-only**: `.event-video { transform: scale(1.05); transition: transform 0.3s ease; }` — nothing else changes on hover.
+5. **Status badges pulse, nothing else does**: `pulse-blue` / `pulse-navy` / `pulse-danger` keyframes are the only motion language outside of media zoom.
+6. **Gradient accents are display-only**: hero copy, marketing banner. Never on functional UI.
+7. **Section banding**: white (`--gray-000`) ↔ near-white (`--background-alternative` `#F7F7FA`). Just two background tiers, alternated.
+8. **Korean-first typography**: `letter-spacing: -0.012rem` on headings, `word-break: keep-all` globally.
+9. **Token-discipline**: Reach for `var(--space-*)` / `var(--gray-*)` / `var(--text-*)` / `var(--border-radius-*)` before typing a hex or px. If the value isn't in the token table above, ask before adding.

--- a/__mocks__/styleMock.js
+++ b/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/components/common/banner/banner.module.scss
+++ b/components/common/banner/banner.module.scss
@@ -3,7 +3,7 @@
 
 .banner {
   position: relative;
-  height: 30rem;
+  height: 28rem;
   width: 100%;
   display: flex;
   flex-direction: column;
@@ -16,10 +16,10 @@
   overflow: hidden;
 
   &__title {
-    font-size: 3.8rem;
-    font-weight: 700;
-    line-height: 5.1rem;
-    letter-spacing: 0em;
+    font-size: 3rem;
+    font-weight: 800;
+    line-height: 1.2;
+    letter-spacing: -0.012rem;
     text-align: center;
     color: #ffffff;
     padding: 0px;
@@ -28,17 +28,17 @@
   }
 
   &__desc {
-    font-weight: 400;
-    font-size: 1.23rem;
-    line-height: 1.813rem;
+    font-weight: 500;
+    font-size: 1.125rem;
+    line-height: 1.5;
     text-align: center;
-    color: #ffffff;
-    padding-top: 1.938rem;
+    color: rgba(255, 255, 255, 0.85);
+    padding-top: 1.5rem;
     padding-bottom: 0px;
     margin: 0px;
     z-index: 1;
     &--bold {
-      font-weight: bold;
+      font-weight: 700;
     }
   }
 
@@ -57,16 +57,19 @@
   @media (max-width: 1075px) {
     .banner {
       width: 100%;
-      height: 28rem;
+      height: 24rem;
+      &__title {
+        font-size: 2.75rem;
+      }
     }
   }
   @media (max-width: 800px) {
     .banner {
       width: 100%;
-      height: 26rem;
+      height: 22rem;
       &__title {
-        font-size: 3.4rem;
-        line-height: 4.5rem;
+        font-size: 2.5rem;
+        line-height: 1.2;
       }
       &__desc {
         font-size: 1rem;
@@ -78,10 +81,10 @@
 @include tablet {
   .banner {
     width: 100%;
-    height: 24rem;
+    height: 22rem;
     &__title {
-      font-size: 3rem;
-      line-height: 4rem;
+      font-size: 2.125rem;
+      line-height: 1.2;
     }
     &__desc {
       font-size: 1rem;
@@ -90,10 +93,10 @@
   @media (max-width: 500px) {
     .banner {
       width: 100%;
-      height: 22rem;
+      height: 20rem;
       &__title {
-        font-size: 2.3rem;
-        line-height: 3rem;
+        font-size: 1.875rem;
+        line-height: 1.2;
       }
       &__desc {
         font-size: 1rem;
@@ -103,8 +106,8 @@
   @media (max-width: 400px) {
     .banner {
       &__title {
-        font-size: 2.1rem;
-        line-height: 3rem;
+        font-size: 1.75rem;
+        line-height: 1.2;
       }
       &__desc {
         font-size: 0.9rem;
@@ -118,8 +121,8 @@
     width: 100%;
     height: 18rem;
     &__title {
-      font-size: 2rem;
-      line-height: 2.5rem;
+      font-size: 1.75rem;
+      line-height: 1.2;
     }
     &__desc {
       font-size: 0.9rem;

--- a/components/common/buttons/FillButton.module.scss
+++ b/components/common/buttons/FillButton.module.scss
@@ -6,12 +6,42 @@
   @extend %button-base;
   color: var(--vapor-gray-000);
   background-color: var(--vapor-gray-900);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  transition: background-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
+
+  &:focus-visible {
+    outline: 2px solid var(--ktb-tech-blue);
+    outline-offset: 2px;
+  }
 
   // 색상 변형
   &.color {
     &--primary {
       background-color: var(--ktb-tech-blue);
       font-size: 14px;
+      font-weight: 700;
+      box-shadow:
+        0 1px 2px rgba(0, 67, 255, 0.20),
+        0 2px 6px rgba(0, 67, 255, 0.18);
+
+      &:hover {
+        background-color: #0035CC;
+        transform: translateY(-1px);
+        box-shadow:
+          0 2px 4px rgba(0, 67, 255, 0.24),
+          0 6px 12px rgba(0, 67, 255, 0.20);
+        opacity: 1;
+      }
+      &:active {
+        background-color: #002CA8;
+        transform: translateY(0);
+        box-shadow:
+          0 1px 2px rgba(0, 67, 255, 0.18) inset,
+          0 1px 2px rgba(0, 67, 255, 0.18);
+      }
     }
 
     &--gray {

--- a/components/common/buttons/FillButton.module.scss
+++ b/components/common/buttons/FillButton.module.scss
@@ -4,24 +4,24 @@
 
 .button {
   @extend %button-base;
-  color: var(--background-1);
-  background-color: var(--gray-1);
-  
+  color: var(--vapor-gray-000);
+  background-color: var(--vapor-gray-900);
+
   // 색상 변형
   &.color {
     &--primary {
-      background-color: var(--primary);
+      background-color: var(--ktb-tech-blue);
       font-size: 14px;
     }
-    
+
     &--gray {
-      background-color: var(--gray-1);
+      background-color: var(--vapor-gray-900);
       font-size: 14px;
     }
-    
+
     &--white {
-      background-color: var(--background-1);
-      color: var(--primary);
+      background-color: var(--vapor-gray-000);
+      color: var(--ktb-tech-blue);
       font-size: 14px;
     }
   }

--- a/components/common/buttons/WithdrawOkButton.module.scss
+++ b/components/common/buttons/WithdrawOkButton.module.scss
@@ -1,24 +1,25 @@
 .withdraw {
-  display: flex;
+  display: inline-flex;
   justify-content: center;
   align-items: center;
   gap: 0.5rem;
-  width: 95px; // 7.4375rem; // 119px
-  height: 3rem; // 48px
-  background: #ffffff;
-  border: 1px solid #ef737b;
-  border-radius: 6px;
+  height: 44px;
+  padding: 0 20px;
+  background: var(--vapor-gray-000);
+  border: 1px solid var(--vapor-text-danger);
+  border-radius: 12px;
 
-  /* font */
   font-style: normal;
-  font-weight: 600;
-  font-size: 1rem; // 16px
+  font-weight: 700;
+  font-size: 0.9375rem;
   line-height: 100%;
   text-align: center;
-  letter-spacing: -0.02em;
-  color: #e8424c;
+  letter-spacing: -0.012rem;
+  color: var(--vapor-text-danger);
+  cursor: pointer;
+  transition: background-color 0.15s ease;
 
   &:hover {
-    background: #fcf2f3;
+    background: var(--vapor-gray-050);
   }
 }

--- a/components/common/date/DateBoard.module.scss
+++ b/components/common/date/DateBoard.module.scss
@@ -8,13 +8,13 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  background-color: var(--background-1);
-  border: 1.5px solid;
-  border-color: var(--gray-4);
-  border-radius: 2.9881px;
+  background-color: var(--vapor-gray-000);
+  border: 1px solid;
+  border-color: var(--vapor-gray-300);
+  border-radius: 8px;
 
   &:hover {
-    border-color: rgba(170, 184, 255, 1);
+    border-color: var(--vapor-gray-400);
   }
 
   .key {
@@ -30,16 +30,16 @@
     transition: all 0.1s linear;
     &:hover {
       cursor: pointer;
-      background-color: var(--background-2);
+      background-color: var(--vapor-gray-050);
     }
   }
 
   .key--left {
-    border-radius: 2.9881px 0 0 2.9881px;
+    border-radius: 8px 0 0 8px;
   }
 
   .key--right {
-    border-radius: 0 2.9881px 2.9881px 0;
+    border-radius: 0 8px 8px 0;
   }
 
   .key--disactive {
@@ -65,7 +65,7 @@
       flex-direction: row;
       align-items: center;
       font-size: 1rem;
-      color: var(--gray-1);
+      color: var(--vapor-gray-900);
       font-weight: 400;
       cursor: pointer;
     }
@@ -81,10 +81,11 @@
       animation-name: appearIn;
       animation-duration: 0.2s;
       animation-timing-function: linear;
-      background-color: var(--background-1);
-      border-radius: 2.9881px;
-      border: 1.5px solid;
-      border-color: var(--gray-4);
+      background-color: var(--vapor-gray-000);
+      border-radius: 8px;
+      border: 1px solid;
+      border-color: var(--vapor-gray-300);
+      box-shadow: 0 8px 24px rgba(0, 0, 64, 0.08);
       z-index: 50;
 
       &__year {
@@ -93,7 +94,7 @@
         display: flex;
         justify-content: space-between;
         align-items: center;
-        color: var(--gray-1);
+        color: var(--vapor-gray-900);
 
         .year__text {
           line-height: 14px;
@@ -135,9 +136,9 @@
 }
 
 .container__focus {
-  border-color: var(--primary);
+  border-color: var(--ktb-tech-blue);
   &:hover {
-    border-color: var(--primary);
+    border-color: var(--ktb-tech-blue);
   }
 }
 

--- a/components/common/date/DateElement.module.scss
+++ b/components/common/date/DateElement.module.scss
@@ -17,19 +17,19 @@
     font-weight: 500;
     margin: 5px;
     border: 1px solid;
-    color: var(--gray-1);
-    border-color: var(--gray-4);
+    color: var(--vapor-gray-900);
+    border-color: var(--vapor-gray-300);
 
     &:hover {
       cursor: pointer;
-      background-color: var(--background-2);
+      background-color: var(--vapor-gray-050);
     }
   }
 
   &__invalid {
     user-select: none;
-    color: var(--gray-5);
-    border-color: var(--gray-5);
+    color: var(--vapor-gray-400);
+    border-color: var(--vapor-gray-200);
     background-color: transparent;
     &:hover {
       cursor: auto;
@@ -37,15 +37,15 @@
     }
   }
   .light--selected {
-    border-color: var(--primary);
-    background-color: rgba(237, 239, 255, 1);
-    color: var(--primary);
+    border-color: var(--ktb-tech-blue);
+    background-color: rgba(0, 67, 255, 0.08);
+    color: var(--ktb-tech-blue);
   }
 
   .dark--selected {
-    border-color: var(--primary);
-    background-color: rgba(34, 35, 38, 1);
-    color: var(--primary);
+    border-color: var(--ktb-tech-blue);
+    background-color: var(--vapor-gray-950);
+    color: var(--ktb-tech-blue);
   }
 }
 
@@ -63,18 +63,18 @@
       font-weight: 500;
       margin: 5px;
       border: 1px solid;
-      color: var(--gray-1);
-      border-color: var(--gray-4);
+      color: var(--vapor-gray-900);
+      border-color: var(--vapor-gray-300);
 
       &:hover {
         cursor: pointer;
-        background-color: var(--background-2);
+        background-color: var(--vapor-gray-050);
       }
     }
     &__invalid {
       user-select: none;
-      color: var(--gray-5);
-      border-color: var(--gray-5);
+      color: var(--vapor-gray-400);
+      border-color: var(--vapor-gray-200);
       background-color: transparent;
       &:hover {
         cursor: auto;
@@ -82,15 +82,15 @@
       }
     }
     .light--selected {
-      border-color: var(--primary);
-      background-color: rgba(237, 239, 255, 1);
-      color: var(--primary);
+      border-color: var(--ktb-tech-blue);
+      background-color: rgba(0, 67, 255, 0.08);
+      color: var(--ktb-tech-blue);
     }
 
     .dark--selected {
-      border-color: var(--primary);
-      background-color: rgba(34, 35, 38, 1);
-      color: var(--primary);
+      border-color: var(--ktb-tech-blue);
+      background-color: var(--vapor-gray-950);
+      color: var(--ktb-tech-blue);
     }
   }
 }

--- a/components/common/dropdown/BasicDropdown.module.scss
+++ b/components/common/dropdown/BasicDropdown.module.scss
@@ -16,16 +16,16 @@
     height: 40px;
     padding: 0 1.125rem 0 1.125rem;
     font-size: 1rem;
-    color: var(--gray-1);
+    color: var(--vapor-gray-900);
     font-weight: 400;
     cursor: pointer;
-    background-color: var(--background-1);
-    border: 1.5px solid;
-    border-color: var(--gray-4);
+    background-color: var(--vapor-gray-000);
+    border: 1px solid;
+    border-color: var(--vapor-gray-300);
     box-sizing: border-box;
-    border-radius: 2.9881px;
+    border-radius: 8px;
     &:hover {
-      border-color: rgba(170, 184, 255, 1);
+      border-color: var(--vapor-gray-400);
     }
   }
 
@@ -38,10 +38,11 @@
     animation-duration: 0.2s;
     animation-timing-function: linear;
     max-height: 12rem;
-    background-color: var(--background-1);
-    border-radius: 2.9881px;
-    border: 1.5px solid;
-    border-color: var(--gray-4);
+    background-color: var(--vapor-gray-000);
+    border-radius: 8px;
+    border: 1px solid;
+    border-color: var(--vapor-gray-300);
+    box-shadow: 0 8px 24px rgba(0, 0, 64, 0.08);
     z-index: 50;
     overflow-y: scroll;
 
@@ -52,24 +53,24 @@
       align-items: center;
       width: 100%;
       height: 2.5rem;
-      color: var(--gray-1);
+      color: var(--vapor-gray-900);
 
       &:hover {
         cursor: pointer;
-        background-color: var(--background-2);
+        background-color: var(--vapor-gray-050);
       }
     }
 
     .selected__light {
       font-weight: 700;
-      color: var(--primary);
-      background-color: rgba(237, 239, 255, 1);
+      color: var(--ktb-tech-blue);
+      background-color: rgba(0, 67, 255, 0.08);
     }
 
     .selected__dark {
       font-weight: 700;
-      color: var(--primary);
-      background-color: rgba(34, 35, 38, 1);
+      color: var(--ktb-tech-blue);
+      background-color: var(--vapor-gray-950);
     }
 
     &::-webkit-scrollbar {
@@ -79,7 +80,7 @@
     &::-webkit-scrollbar-thumb {
       width: 5px;
       border-radius: 4px;
-      background-color: #c4c4c4;
+      background-color: var(--vapor-gray-400);
     }
 
     &::-webkit-scrollbar-track {
@@ -88,7 +89,7 @@
     }
   }
   .dropdown__header__focus {
-    border-color: var(--primary);
+    border-color: var(--ktb-tech-blue);
   }
 }
 

--- a/components/common/input/BasicInput.module.scss
+++ b/components/common/input/BasicInput.module.scss
@@ -10,27 +10,26 @@
     width: 100%;
     height: 100%;
     outline: none;
-    background-color: var(--background-1);
-    border: 1.5px solid;
-    border-color: var(--gray-4);
-    border-radius: 2.9881px;
+    background-color: var(--vapor-gray-000);
+    border: 1px solid;
+    border-color: var(--vapor-gray-300);
+    border-radius: 8px;
     box-sizing: border-box;
     &:hover {
-      border-color: rgba(170, 184, 255, 1);
+      border-color: var(--vapor-gray-400);
     }
     &:focus {
-      border-color: var(--primary);
+      border-color: var(--ktb-tech-blue);
     }
   }
 
   input[type='text'] {
     padding-left: 55px;
-    color: var(--gray-1);
+    color: var(--vapor-gray-900);
   }
 
   input::-webkit-input-placeholder {
-    font-weight: bold;
-    color: var(--gray-3);
+    color: var(--vapor-gray-500);
     font-weight: 500;
   }
 

--- a/components/common/item/Item.module.scss
+++ b/components/common/item/Item.module.scss
@@ -2,12 +2,23 @@
 @import '~styles/_variables.scss';
 @import '~styles/_common.scss';
 
+// ===== Pulse keyframes (DESIGN.md §7) — live/urgent badges only =====
+@keyframes pulse-blue {
+  0%   { box-shadow: 0 0 0 0 rgba(0, 67, 255, 0.55); }
+  70%  { box-shadow: 0 0 0 8px rgba(0, 67, 255, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(0, 67, 255, 0); }
+}
+@keyframes pulse-danger {
+  0%   { box-shadow: 0 0 0 0 rgba(217, 28, 41, 0.55); }
+  70%  { box-shadow: 0 0 0 8px rgba(217, 28, 41, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(217, 28, 41, 0); }
+}
+
 .item__container {
   width: 100%;
-  @include flex-start;
-  padding: 20px 24px 20px 0;
+  padding: 24px 0;
   background-color: transparent;
-  border-bottom: 1px solid var(--gray-4);
+  border-bottom: 1px solid var(--vapor-gray-300);
 
   .item {
     width: 100%;
@@ -19,38 +30,22 @@
     &__content {
       width: 100%;
       display: grid;
+      grid-template-columns: 280px 1fr;
+      gap: 32px;
       align-items: center;
-      justify-content: start;
       position: relative;
-      grid-template-columns: 1fr 4fr;
-
-      &__flag {
-        width: 37px;
-        height: 56px;
-        position: absolute;
-        top: 0;
-        left: 0;
-        animation: appearIn 0.05s linear;
-
-        span {
-          z-index: 3;
-          padding-top: 20px;
-          @include flex-center;
-          font-weight: 700;
-          font-size: 0.89rem;
-          color: $white;
-        }
-      }
 
       &__img {
-        width: 252px;
-        height: 144px;
+        width: 280px;
+        aspect-ratio: 5 / 3;
         position: relative;
+        border-radius: 12px;
+        overflow: hidden;
 
         &__mask {
-          border-radius: 4px;
+          border-radius: 12px;
           overflow: hidden;
-          transition: all $transition-timing $transition-duration;
+          transition: transform $transition-duration $transition-timing;
         }
 
         &__done {
@@ -61,108 +56,126 @@
           top: 0;
           background-color: rgba(0, 0, 0, 0.4);
           overflow: hidden;
-          border-radius: 4px;
+          border-radius: 12px;
+          z-index: 1;
         }
       }
 
       &__body {
         display: flex;
         flex-direction: column;
-        padding-left: 32px;
-        justify-content: space-between;
+        justify-content: center;
+        min-width: 0;
+        position: relative;
+        padding-right: 88px;
 
         .wrap {
           .host {
-            font-size: 16px;
-            color: var(--gray-1);
+            font-size: 14px;
+            font-weight: 500;
+            color: var(--vapor-gray-600);
+            margin-bottom: 6px;
           }
 
           .host__done {
-            font-size: 16px;
-            color: var(--gray-2);
+            font-size: 14px;
+            font-weight: 500;
+            color: var(--vapor-gray-500);
+            margin-bottom: 6px;
           }
         }
       }
 
       &_title__container {
         width: 100%;
-        margin: 4px 0 12px 0;
-        @include flex-start;
+        margin: 0 0 10px 0;
+        display: flex;
+        align-items: flex-start;
+        gap: 8px;
       }
 
       &__title {
-        display: block;
-        font-weight: 600;
-        font-size: 22px;
-        color: var(--gray-1);
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        font-weight: 700;
+        font-size: 20px;
+        line-height: 1.4;
+        letter-spacing: -0.012rem;
+        color: var(--vapor-gray-900);
         text-align: left;
-        @include text-ellipsis;
-        margin-right: 10px;
+        flex: 1;
+        word-break: keep-all;
       }
 
       &__title__done {
-        display: block;
-        font-weight: 700;
-        font-size: 18px;
-        color: var(--gray-2);
-        text-align: left;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
         overflow: hidden;
-        margin-right: 10px;
-      }
-
-      .done__tag {
-        min-width: 40px;
-        position: relative;
+        font-weight: 700;
+        font-size: 20px;
+        line-height: 1.4;
+        letter-spacing: -0.012rem;
+        color: var(--vapor-gray-600);
+        text-align: left;
+        flex: 1;
+        word-break: keep-all;
       }
 
       &__desc {
         width: 100%;
         font-weight: 400;
-        font-size: 14px;
-        color: var(--gray-2);
-        @include flex-start;
+        font-size: 15px;
+        color: var(--vapor-gray-700);
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
 
         &__tags {
-          @include flex-start;
+          display: flex;
           flex-wrap: wrap;
+          gap: 6px;
           width: 100%;
         }
       }
 
       .wrap {
-        color: var(--gray-1);
+        color: var(--vapor-gray-900);
 
         .date {
-          @include flex-start;
-          display: initial;
-          padding-right: 8px;
-          font-size: 16px;
-          padding-left: 0;
-          margin-left: 0;
+          display: flex;
+          align-items: baseline;
+          gap: 8px;
+          font-size: 15px;
           font-weight: 500;
+          color: var(--vapor-gray-700);
 
           &__type {
             white-space: nowrap;
-            //margin-right: 12px;
-            margin-right: 8px;
-            color: var(--gray-3);
+            color: var(--vapor-gray-500);
+            font-weight: 500;
+            flex-shrink: 0;
           }
 
           &__type__done {
-            width: 3rem;
-            color: var(--gray-3);
+            white-space: nowrap;
+            color: var(--vapor-gray-400);
+            font-weight: 500;
+            flex-shrink: 0;
           }
 
           &__date {
             white-space: nowrap;
-            color: var(--gray-2);
-            font-weight: 400;
+            color: var(--vapor-gray-700);
+            font-weight: 500;
           }
 
           &__date__done {
             white-space: nowrap;
-            color: var(--gray-3);
-            font-weight: 400;
+            color: var(--vapor-gray-500);
+            font-weight: 500;
           }
 
           &__date__mobile {
@@ -177,7 +190,9 @@
     }
 
     &__buttons {
-      @include flex-start;
+      display: flex;
+      align-items: center;
+      gap: 4px;
       position: absolute;
       top: 0;
       right: 0;
@@ -187,20 +202,21 @@
         height: 36px;
         border: none;
         background-color: transparent;
-        border-radius: 5px;
+        border-radius: 8px;
         @include flex-center;
+        color: var(--vapor-gray-500);
 
         &:hover {
           cursor: pointer;
-          background-color: var(--gray-5);
+          background-color: var(--vapor-gray-100);
         }
       }
 
       .laptop {
-        display: block;
+        display: flex;
 
         &:first-child {
-          margin-right: 4px;
+          margin-right: 2px;
         }
       }
 
@@ -211,108 +227,164 @@
   }
 }
 
+// ===== Thumbnail badge wrapper (hosts DdayTag) =====
+.item__content__img__badge {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  z-index: 2;
+}
+
+// ===== Tablet / Mobile — vertical KTB course-card =====
 @media (max-width: 1200px) {
   .item__container {
     display: block;
     border-bottom: none;
     padding: 0;
-    overflow: hidden;
-
-    .item__content_title__container {
-      margin-bottom: 12px;
-    }
-
-    .item__content__title {
-      margin-right: 0;
-    }
+    overflow: visible;
 
     .item__content {
       display: block;
-
-      &__body {
-        .wrap {
-          .host {
-            font-size: 14px;
-          }
-
-          .host__done {
-            font-size: 14px;
-          }
-        }
-      }
-
-      .wrap {
-        @include flex-between;
-
-        .date {
-          font-size: 14px;
-          white-space: pre-line;
-
-          .date__date,
-          &.date__date__done {
-            white-space: pre-line;
-          }
-        }
-      }
+      grid-template-columns: none;
+      gap: 0;
+      position: relative;
     }
 
     .item__content__img {
-      aspect-ratio: 16/9;
-      width: inherit;
-      height: inherit;
-      max-height: 190px;
+      width: 100%;
+      aspect-ratio: 5 / 3;
+      max-height: none;
+      border-radius: 12px;
+    }
+
+    .item__content__img__mask,
+    .item__content__img__done {
+      border-radius: 12px;
     }
 
     .item__content__body {
-      margin-top: 16px;
+      margin-top: 12px;
       padding: 0;
+      padding-right: 0;
+      position: static;
       justify-content: inherit;
+
+      .wrap {
+        .host {
+          font-size: 13px;
+          margin-bottom: 4px;
+        }
+
+        .host__done {
+          font-size: 13px;
+          margin-bottom: 4px;
+        }
+      }
     }
 
-    .item__content--top {
-      color: var(--gray-1);
-      font-size: 14px;
+    .item__content_title__container {
+      margin-bottom: 4px;
     }
 
     .item__content__title {
-      font-size: 18px;
+      display: block;
+      -webkit-line-clamp: unset;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      font-size: 16px;
+      font-weight: 700;
+      line-height: 1.4;
+      letter-spacing: -0.012rem;
+      margin-right: 0;
+    }
+
+    .item__content__title__done {
+      display: block;
+      -webkit-line-clamp: unset;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      font-size: 16px;
+      font-weight: 700;
+      line-height: 1.4;
+      letter-spacing: -0.012rem;
+      margin-right: 0;
     }
 
     .item__content__desc {
-      display: block;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      font-size: 14px;
+      color: var(--vapor-gray-600);
     }
 
     .item__content__desc__tags {
-      @include flex-start;
-      padding-top: 6px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px;
+      padding-top: 0;
+    }
+
+    .wrap {
+      .date {
+        display: flex;
+        align-items: baseline;
+        gap: 6px;
+        font-size: 14px;
+        white-space: normal;
+        word-break: keep-all;
+        flex-wrap: nowrap;
+
+        &__type,
+        &__type__done {
+          flex-shrink: 0;
+          font-weight: 500;
+        }
+
+        .date__date,
+        .date__date__done {
+          flex: 1;
+          min-width: 0;
+          white-space: normal;
+          word-break: keep-all;
+          overflow-wrap: anywhere;
+          line-height: 1.5;
+        }
+      }
     }
 
     .item__buttons {
-      position: relative;
+      position: absolute;
+      top: 12px;
+      right: 12px;
+
+      .button {
+        width: 32px;
+        height: 32px;
+        background-color: rgba(255, 255, 255, 0.85);
+        backdrop-filter: blur(4px);
+
+        &:hover {
+          background-color: rgba(255, 255, 255, 1);
+        }
+      }
+
+      .laptop {
+        display: none;
+      }
+
+      .mobile {
+        display: flex;
+      }
     }
   }
+
 }
 
 @media (max-width: 550px) {
   .item__container {
     max-width: inherit;
-  }
-}
-
-@keyframes moveUp {
-  0% {
-    transform: translateY(0);
-  }
-  100% {
-    transform: translateY(-5px);
-  }
-}
-
-@keyframes appearIn {
-  0% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
   }
 }

--- a/components/common/item/Item.module.scss
+++ b/components/common/item/Item.module.scss
@@ -106,7 +106,9 @@
         color: var(--vapor-gray-900);
         text-align: left;
         flex: 1;
+        min-width: 0;
         word-break: keep-all;
+        overflow-wrap: anywhere;
       }
 
       &__title__done {
@@ -121,7 +123,9 @@
         color: var(--vapor-gray-600);
         text-align: left;
         flex: 1;
+        min-width: 0;
         word-break: keep-all;
+        overflow-wrap: anywhere;
       }
 
       &__desc {

--- a/components/common/item/Item.tsx
+++ b/components/common/item/Item.tsx
@@ -1,5 +1,4 @@
 import style from 'components/common/item/Item.module.scss';
-import ShareModal from 'components/common/modal/ShareModal';
 import DdayTag from 'components/common/tag/DdayTag';
 import FilterTag from 'components/common/tag/FilterTag';
 import {
@@ -10,6 +9,7 @@ import {
 } from 'components/icons';
 import { EventContext } from 'context/event';
 import { WindowContext } from 'context/window';
+import { useToast } from 'context/toast';
 import { DateUtil } from 'lib/utils/dateUtil';
 import * as ga from 'lib/utils/gTag';
 import { Event } from 'model/event';
@@ -18,7 +18,6 @@ import React, { useContext, useEffect, useState } from 'react';
 import classNames from 'classnames/bind';
 import Image from 'next/image';
 import Link from 'next/link';
-import SaveModal from "../modal/SaveModal";
 
 const cn = classNames.bind(style);
 
@@ -53,24 +52,28 @@ const Item = ({
   childLast,
   parentLast,
 }: Props) => {
-  const [isShareModalOpen, setIsShareModalOpen] = useState<boolean>(false);
   const [isLast, setIsLast] = useState<boolean>(false);
   const [isDone, setIsDone] = useState<boolean>(isEventDone());
   const [isNew, setIsNew] = useState<boolean>(isEventNew());
   const { windowX } = useContext(WindowContext);
   const { search } = useContext(EventContext);
+  const { pushToast } = useToast();
 
-  const handleShare = () => {
-    setIsShareModalOpen(true);
-    navigator.clipboard.writeText(data.event_link);
+  const handleShare = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    try {
+      await navigator.clipboard.writeText(data.event_link);
+      pushToast('링크가 복사되었어요');
+    } catch (err) {
+      console.error(err);
+      pushToast('링크 복사에 실패했어요');
+    }
     ga.event({
       action: 'web_event_공유버튼클릭',
       event_category: 'web_event',
       event_label: '공유',
     });
-    setTimeout(() => {
-      setIsShareModalOpen(false);
-    }, 1300);
   };
 
   const getEventDate = () => {
@@ -123,7 +126,6 @@ const Item = ({
   }, [search]);
   return (
     <div className={cn('item__container', `${isLast && 'item__last'}`)}>
-      {isShareModalOpen && <ShareModal />}
       <div className={cn('item')}>
         <Link href={`/event/detail/${String(data.id)}`}>
           <a

--- a/components/common/item/Item.tsx
+++ b/components/common/item/Item.tsx
@@ -5,8 +5,6 @@ import FilterTag from 'components/common/tag/FilterTag';
 import {
   BookmarkIcon,
   BookmarkIconMobile,
-  EndBulletIcon,
-  NewBulletIcon,
   ShareIcon,
   ShareIconMobile,
 } from 'components/icons';
@@ -28,6 +26,11 @@ const DateType = {
   dateTime: 'dateTime',
   date: 'date',
   time: 'time',
+};
+
+const shortenYear = (s: string | undefined): string => {
+  if (!s) return '';
+  return s.replace(/\b(?:19|20)(\d{2})/g, '$1');
 };
 
 type Props = {
@@ -156,22 +159,14 @@ const Item = ({
                   layout="fill"
                 />
                 {isDone && <div className={cn('item__content__img__done')} />}
-                {isDone ? (
-                  <div className={cn('item__content__flag')}>
-                    <EndBulletIcon
-                      color={'rgba(203, 203, 206, 1)'}
-                      backgroundColor={'rgba(49, 50, 52, 1)'}
+                {!isDone && (
+                  <div className={cn('item__content__img__badge')}>
+                    <DdayTag
+                      startDateTime={data.start_date_time}
+                      endDateTime={data.end_date_time}
                     />
                   </div>
-                ) : null}
-                {isNew ? (
-                  <div className={cn('item__content__flag')}>
-                    <NewBulletIcon
-                      color={'rgba(203, 203, 206, 1)'}
-                      backgroundColor={'rgba(44, 76, 239, 1)'}
-                    />
-                  </div>
-                ) : null}
+                )}
               </div>
               <div className={cn('item__content__body')}>
                 <div>
@@ -236,12 +231,6 @@ const Item = ({
                         ? `${data.title.slice(0, 45)}...`
                         : data.title}
                     </div>
-                    {isDone ? null : (
-                      <DdayTag
-                        startDateTime={data.start_date_time}
-                        endDateTime={data.end_date_time}
-                      />
-                    )}
                   </div>
                 </div>
                 <div className={cn('item__content__desc')}>
@@ -253,7 +242,7 @@ const Item = ({
                           isDone ? 'date__type__done' : 'date__type'
                         )}
                       >
-                        {data.event_time_type === 'DATE' ? '일시 ' : '접수 '}
+                        {data.event_time_type === 'DATE' ? '일시' : '접수'}
                       </span>
                       {/* 행사 시작 시간 */}
                       <span
@@ -261,7 +250,7 @@ const Item = ({
                           isDone ? `date__date__done` : 'date__date'
                         )}
                       >
-                        {getEventDate()}
+                        {shortenYear(getEventDate())}
                       </span>
                       {/* 행사 종료 시간 */}
                       <span
@@ -271,7 +260,7 @@ const Item = ({
                             : 'date__date__mobile'
                         )}
                       >
-                        {getEventDate()}
+                        {shortenYear(getEventDate())}
                       </span>
                     </div>
                   </span>

--- a/components/common/item/Item.tsx
+++ b/components/common/item/Item.tsx
@@ -8,7 +8,6 @@ import {
   ShareIconMobile,
 } from 'components/icons';
 import { EventContext } from 'context/event';
-import { WindowContext } from 'context/window';
 import { useToast } from 'context/toast';
 import { DateUtil } from 'lib/utils/dateUtil';
 import * as ga from 'lib/utils/gTag';
@@ -55,7 +54,6 @@ const Item = ({
   const [isLast, setIsLast] = useState<boolean>(false);
   const [isDone, setIsDone] = useState<boolean>(isEventDone());
   const [isNew, setIsNew] = useState<boolean>(isEventNew());
-  const { windowX } = useContext(WindowContext);
   const { search } = useContext(EventContext);
   const { pushToast } = useToast();
 
@@ -229,9 +227,7 @@ const Item = ({
                           : 'item__content__title'
                       )}
                     >
-                      {data.title.length >= 30 && windowX <= 750
-                        ? `${data.title.slice(0, 45)}...`
-                        : data.title}
+                      {data.title}
                     </div>
                   </div>
                 </div>

--- a/components/common/item/List.tsx
+++ b/components/common/item/List.tsx
@@ -2,6 +2,7 @@ import Item from 'components/common/item/Item';
 import style from 'components/common/item/List.module.scss';
 import LoginModal from 'components/common/modal/LoginModal';
 import { AuthContext } from 'context/auth';
+import { useToast } from 'context/toast';
 import dayjs from 'dayjs';
 import { deleteMyEventApi } from 'lib/api/delete';
 import { createMyEventApi } from 'lib/api/post';
@@ -12,7 +13,6 @@ import { Event, EventDate } from 'model/event';
 import { mutate } from 'swr';
 import React, { useState } from 'react';
 import classNames from 'classnames/bind';
-import SaveModal from '../modal/SaveModal';
 
 const cn = classNames.bind(style);
 
@@ -23,9 +23,8 @@ type Props = {
 
 const List = ({ data, parentLast }: Props) => {
   const authContext = React.useContext(AuthContext);
+  const { pushToast } = useToast();
   const [loginModalIsOpen, setLoginModalIsOpen] = useState(false);
-  const [showSaveModal, setShowSaveModal] = useState(false);
-  const [saveMessage, setSaveMessage] = useState('');
 
   const param = { filter: '' };
   const { myEvent } = useMyEvent(param, authContext.isLoggedIn);
@@ -95,17 +94,10 @@ const List = ({ data, parentLast }: Props) => {
     }
   };
 
-  // 북마크 모달 표시
   const handleFavorite = (isRemoving: boolean) => {
-    setSaveMessage(
-      isRemoving ? '북마크에서 제거되었습니다.' : '북마크에 추가되었습니다.'
+    pushToast(
+      isRemoving ? '북마크에서 제거되었어요' : '북마크에 추가되었어요'
     );
-    setShowSaveModal(true);
-
-    // 2초 후 모달 자동 숨김
-    setTimeout(() => {
-      setShowSaveModal(false);
-    }, 2000);
   };
 
   const createMyEvent = async ({ eventId }: { eventId: string }) => {
@@ -195,8 +187,6 @@ const List = ({ data, parentLast }: Props) => {
           />
         );
       })}
-
-      <SaveModal isVisible={showSaveModal} message={saveMessage} />
 
       <div className={cn('skeleton')} />
       <LoginModal

--- a/components/common/modal/NoticeModal.module.scss
+++ b/components/common/modal/NoticeModal.module.scss
@@ -28,8 +28,9 @@
 
       .notice__title {
         font-size: 16px;
-        font-weight: bold;
-        color: var(--primary);
+        font-weight: 700;
+        letter-spacing: -0.012rem;
+        color: var(--ktb-tech-blue);
         margin-right: 4px;
       }
     }
@@ -43,7 +44,7 @@
       border-radius: 50%;
 
       &:hover {
-        background-color: rgb(213, 215, 229);
+        background-color: var(--vapor-gray-100);
         cursor: pointer;
       }
     }
@@ -90,7 +91,7 @@
 }
 
 .notice--light {
-  background-color: rgba(237, 239, 255, 1);
+  background-color: rgba(0, 67, 255, 0.08);
 }
 
 @keyframes appearIn {

--- a/components/common/modal/NoticeModal.tsx
+++ b/components/common/modal/NoticeModal.tsx
@@ -35,7 +35,7 @@ function NoticeModal() {
           <CalenderLogo />
         </div>
         <div className={cn('icon')} onClick={hideModal}>
-          <DeleteIcon color={'rgba(49, 50, 52, 1)'} />
+          <DeleteIcon color={'rgb(43, 45, 54)'} />
         </div>
       </div>
     </div>

--- a/components/common/tag/DdayTag.module.scss
+++ b/components/common/tag/DdayTag.module.scss
@@ -1,24 +1,46 @@
 @import '~styles/_mixin.scss';
 
+@keyframes pulse-blue {
+  0%   { box-shadow: 0 0 0 0 rgba(0, 67, 255, 0.55); }
+  70%  { box-shadow: 0 0 0 8px rgba(0, 67, 255, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(0, 67, 255, 0); }
+}
+@keyframes pulse-danger {
+  0%   { box-shadow: 0 0 0 0 rgba(217, 28, 41, 0.55); }
+  70%  { box-shadow: 0 0 0 8px rgba(217, 28, 41, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(217, 28, 41, 0); }
+}
+
 .tag {
-  border: none;
-  font-size: 14px;
-  color: var(--gray-2);
-  background-color: var(--background-2);
-  border-radius: 18px;
-  display: flex;
+  display: inline-flex;
   justify-content: center;
   align-items: center;
-  padding: 4px 8px;
+  border: none;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0;
+  color: #ffffff;
+  border-radius: 9999px;
+  padding: 4px 10px;
+  white-space: nowrap;
+  flex-shrink: 0;
 
-  &--bold {
-    font-weight: 500;
-    color: var(--primary);
+  &--ongoing {
+    background-color: var(--ktb-tech-blue);
+    animation: pulse-blue 2s infinite;
   }
 
-  @media (max-width: 1199px) {
-    min-width: 38px;
-    font-size: 12px;
-    margin-left: 8px;
+  &--approach {
+    background-color: var(--vapor-text-danger);
+    animation: pulse-danger 2s infinite;
+  }
+
+  &--scheduled {
+    background-color: var(--ktb-tech-navy);
+  }
+
+  @media (max-width: 1200px) {
+    font-size: 10px;
+    padding: 3px 8px;
   }
 }

--- a/components/common/tag/DdayTag.tsx
+++ b/components/common/tag/DdayTag.tsx
@@ -10,8 +10,10 @@ type Props = {
   endDateTime: string;
 };
 
+type DdayType = 'approach' | 'scheduled' | 'ongoing' | 'null';
+
 function DdayTag({ startDateTime, endDateTime }: Props) {
-  const calculateEventDday = () => {
+  const calculateEventDday = (): { type: DdayType; diff: number } => {
     const todayDate = DateUtil.setDateTimeToDate();
     const startDate = DateUtil.setDateTimeToDate(startDateTime);
     const endDate = DateUtil.setDateTimeToDate(endDateTime);
@@ -33,23 +35,17 @@ function DdayTag({ startDateTime, endDateTime }: Props) {
     }
   };
 
-  const getEventDdayTag = () => {
-    const type = calculateEventDday();
+  const { type, diff } = calculateEventDday();
 
-    switch (type.type) {
-      case 'approach':
-        return <div>D-{type.diff}</div>;
-      case 'scheduled':
-        return <div>D-{type.diff}</div>;
-      case 'ongoing':
-        return <div className={cn('tag--bold')}>Today</div>;
-      default:
-        return null;
-    }
-  };
+  if (type === 'null') return null;
 
-  const tag = getEventDdayTag();
-  return tag ? <div className={cn('tag')}>{tag}</div> : null;
+  const label = type === 'ongoing' ? 'Today' : `D-${diff}`;
+
+  return (
+    <div className={cn('tag', `tag--${type}`)}>
+      {label}
+    </div>
+  );
 }
 
 export default DdayTag;

--- a/components/common/tag/FilterTag.module.scss
+++ b/components/common/tag/FilterTag.module.scss
@@ -2,104 +2,65 @@
 @import '~styles/_color.scss';
 
 .tag {
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
+  display: inline-flex;
+  align-items: center;
   border: none;
-  color: var(--gray-1);
-  background-color: var(--gray-5);
+  color: var(--vapor-gray-800);
+  background-color: var(--vapor-gray-100);
   cursor: pointer;
   font-weight: 500;
   text-align: center;
-  margin-right: 8px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  border-radius: 8px;
+  padding: 4px 10px;
+  font-size: 13px;
+  line-height: 1.4;
+  letter-spacing: -0.012rem;
+  margin: 0;
 
   &.size--large {
-    font-size: 14px;
-    line-height: 16px;
-    padding: 4px 12px;
-    border-radius: 4px;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
+    font-size: 13px;
+    padding: 4px 10px;
   }
 
   &.size--regular {
-    font-size: 14px;
-    line-height: 16px;
-    padding: 4px 12px;
-    border-radius: 4px;
-
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
+    font-size: 13px;
+    padding: 4px 10px;
   }
 }
 
 @include tablet {
   .tag {
-    display: flex;
-    flex-direction: row;
-    align-items: flex-start;
-    border: none;
-    color: var(--gray-1);
-    background-color: var(--gray-5);
-    cursor: pointer;
-    font-weight: 500;
-    text-align: center;
-    margin: 4px 5px 0 0;
+    border-radius: 6px;
+    padding: 3px 8px;
+    font-size: 12px;
 
     &.size--large {
-      font-size: 14px;
-      line-height: 16px;
-      padding: 4px 12px;
-      border-radius: 4px;
-      overflow: hidden;
-      white-space: nowrap;
-      text-overflow: ellipsis;
+      font-size: 12px;
+      padding: 3px 8px;
     }
-
     &.size--regular {
-      font-size: 14px;
-      line-height: 16px;
-      padding: 4px 12px;
-      border-radius: 4px;
-      overflow: hidden;
-      white-space: nowrap;
-      text-overflow: ellipsis;
+      font-size: 12px;
+      padding: 3px 8px;
     }
   }
 }
 
 @include mobile {
   .tag {
-    display: block;
-    flex-direction: row;
-    align-items: flex-start;
-    padding: 5px 11px 6px 11px;
-    font-size: 10px;
-    font-weight: 500;
-    border-radius: 20px;
-    margin: 4px 5px 0 0;
+    border-radius: 6px;
+    padding: 2px 8px;
+    font-size: 12px;
 
     &.size--large {
-      font-size: 14px;
-      line-height: 16px;
-      padding: 5px 6px;
-      border-radius: 4px;
-      overflow: hidden;
-      white-space: nowrap;
-      text-overflow: ellipsis;
+      font-size: 12px;
+      padding: 2px 8px;
     }
-
     &.size--regular {
-      font-size: 14px;
-      line-height: 16px;
-      padding: 5px 6px;
-      border-radius: 4px;
-
-      overflow: hidden;
-      white-space: nowrap;
-      text-overflow: ellipsis;
+      font-size: 12px;
+      padding: 2px 8px;
     }
   }
 }

--- a/components/common/tag/JobGroupTag.module.scss
+++ b/components/common/tag/JobGroupTag.module.scss
@@ -2,27 +2,38 @@
 
 .tag {
   min-width: 40px;
-  padding-right: 16px;
-  padding-left: 16px;
+  padding: 0 16px;
   height: 36px;
   font-weight: 500;
   color: var(--vapor-gray-800);
-  border: 1px solid;
-  border-color: var(--vapor-gray-300);
-  border-radius: 25px;
-  display: flex;
+  background-color: #fff;
+  border: 1px solid var(--vapor-gray-300);
+  border-radius: 999px;
+  display: inline-flex;
   justify-content: center;
   align-items: center;
-  margin-right: 10px;
-  margin-top: 10px;
+  cursor: pointer;
+  user-select: none;
+  transition: background-color 0.15s ease, border-color 0.15s ease,
+              color 0.15s ease, transform 0.12s ease,
+              box-shadow 0.15s ease;
+
+  &:focus-visible {
+    outline: 2px solid var(--ktb-tech-blue);
+    outline-offset: 2px;
+  }
+
+  &:active {
+    transform: scale(0.97);
+  }
 }
 
 .tag--light {
   &:hover {
     border-color: var(--ktb-tech-blue);
     color: var(--ktb-tech-blue);
-    background-color: rgba(0, 67, 255, 0.08);
-    cursor: pointer;
+    background-color: rgba(0, 67, 255, 0.06);
+    box-shadow: 0 1px 2px rgba(0, 67, 255, 0.12);
   }
 }
 
@@ -31,32 +42,28 @@
     border-color: var(--ktb-tech-blue);
     color: var(--ktb-tech-blue);
     background-color: var(--vapor-gray-950);
-    cursor: pointer;
   }
 }
 
 .checked--light {
   border-color: var(--ktb-tech-blue);
   color: var(--ktb-tech-blue);
-  background-color: rgba(0, 67, 255, 0.08);
+  background-color: rgba(0, 67, 255, 0.10);
+  font-weight: 600;
+  box-shadow: 0 1px 2px rgba(0, 67, 255, 0.14);
 }
 
 .checked--dark {
   border-color: var(--ktb-tech-blue);
   color: var(--ktb-tech-blue);
   background-color: var(--vapor-gray-950);
+  font-weight: 600;
 }
 
 @include laptop {
   @media (max-width: 950px) {
     .tag {
-      min-width: 40px;
-      padding-right: 14px;
-      padding-left: 14px;
-      height: 36px;
-      border-radius: 24px;
-      margin-right: 9px;
-      margin-top: 9px;
+      padding: 0 14px;
       font-size: 14px;
     }
   }
@@ -65,12 +72,8 @@
 @include tablet {
   .tag {
     min-width: 38px;
-    padding-right: 13px;
-    padding-left: 13px;
+    padding: 0 13px;
     height: 34px;
-    border-radius: 22px;
-    margin-right: 8px;
-    margin-top: 8px;
     font-size: 14px;
   }
 }
@@ -78,12 +81,8 @@
 @include mobile {
   .tag {
     min-width: 36px;
-    padding-right: 11px;
-    padding-left: 11px;
+    padding: 0 12px;
     height: 32px;
-    border-radius: 14px;
-    margin-right: 6px;
-    margin-top: 6px;
     font-size: 13.5px;
   }
 }

--- a/components/common/tag/JobGroupTag.module.scss
+++ b/components/common/tag/JobGroupTag.module.scss
@@ -6,9 +6,9 @@
   padding-left: 16px;
   height: 36px;
   font-weight: 500;
-  color: var(--gray-1);
+  color: var(--vapor-gray-800);
   border: 1px solid;
-  border-color: var(--gray-4);
+  border-color: var(--vapor-gray-300);
   border-radius: 25px;
   display: flex;
   justify-content: center;
@@ -19,32 +19,32 @@
 
 .tag--light {
   &:hover {
-    border-color: var(--primary);
-    color: var(--primary);
-    background-color: rgba(237, 239, 255, 1);
+    border-color: var(--ktb-tech-blue);
+    color: var(--ktb-tech-blue);
+    background-color: rgba(0, 67, 255, 0.08);
     cursor: pointer;
   }
 }
 
 .tag--dark {
   &:hover {
-    border-color: var(--primary);
-    color: var(--primary);
-    background-color: rgba(34, 35, 38, 1);
+    border-color: var(--ktb-tech-blue);
+    color: var(--ktb-tech-blue);
+    background-color: var(--vapor-gray-950);
     cursor: pointer;
   }
 }
 
 .checked--light {
-  border-color: rgba(44, 76, 239, 1);
-  color: rgba(44, 76, 239, 1);
-  background-color: #edefff;
+  border-color: var(--ktb-tech-blue);
+  color: var(--ktb-tech-blue);
+  background-color: rgba(0, 67, 255, 0.08);
 }
 
 .checked--dark {
-  border-color: rgba(79, 108, 255, 1);
-  color: rgba(79, 108, 255, 1);
-  background-color: rgba(34, 35, 38, 1);
+  border-color: var(--ktb-tech-blue);
+  color: var(--ktb-tech-blue);
+  background-color: var(--vapor-gray-950);
 }
 
 @include laptop {

--- a/components/common/toast/ToastStack.module.scss
+++ b/components/common/toast/ToastStack.module.scss
@@ -1,0 +1,75 @@
+.stack {
+  position: fixed;
+  left: 50%;
+  bottom: 32px;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column-reverse;
+  align-items: center;
+  gap: 8px;
+  z-index: 9999;
+  pointer-events: none;
+
+  @media (max-width: 600px) {
+    bottom: 24px;
+    width: calc(100% - 32px);
+    max-width: 400px;
+  }
+}
+
+.toast {
+  pointer-events: auto;
+  min-width: 200px;
+  max-width: 360px;
+  padding: 12px 20px;
+  border-radius: 999px;
+  background-color: rgba(23, 25, 35, 0.92);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.4;
+  letter-spacing: -0.012rem;
+  text-align: center;
+  box-shadow:
+    0 6px 16px rgba(0, 0, 0, 0.18),
+    0 1px 0 rgba(255, 255, 255, 0.04) inset;
+  animation: toast-in 0.32s cubic-bezier(0.22, 1, 0.36, 1) both,
+    toast-out 0.28s cubic-bezier(0.4, 0, 1, 1) forwards;
+  animation-delay: 0s, 2.1s;
+
+  @media (max-width: 600px) {
+    width: 100%;
+    min-width: 0;
+    max-width: none;
+    font-size: 13px;
+    padding: 11px 18px;
+  }
+
+  &__text {
+    display: inline-block;
+  }
+}
+
+@keyframes toast-in {
+  0% {
+    opacity: 0;
+    transform: translateY(16px) scale(0.96);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes toast-out {
+  0% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-4px) scale(0.98);
+  }
+}

--- a/components/common/toast/ToastStack.tsx
+++ b/components/common/toast/ToastStack.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect } from 'react';
+import classNames from 'classnames/bind';
+import style from './ToastStack.module.scss';
+
+const cx = classNames.bind(style);
+
+export interface ToastItem {
+  id: number;
+  message: string;
+}
+
+interface ToastStackProps {
+  toasts: ToastItem[];
+  onDismiss: (id: number) => void;
+  duration?: number;
+}
+
+function ToastRow({
+  toast,
+  onDismiss,
+  duration,
+}: {
+  toast: ToastItem;
+  onDismiss: (id: number) => void;
+  duration: number;
+}) {
+  useEffect(() => {
+    const timer = window.setTimeout(() => onDismiss(toast.id), duration);
+    return () => window.clearTimeout(timer);
+  }, [toast.id, onDismiss, duration]);
+
+  return (
+    <div className={cx('toast')}>
+      <span className={cx('toast__text')}>{toast.message}</span>
+    </div>
+  );
+}
+
+function ToastStack({ toasts, onDismiss, duration = 2400 }: ToastStackProps) {
+  return (
+    <div className={cx('stack')} aria-live="polite" aria-atomic="true">
+      {toasts.map((toast) => (
+        <ToastRow
+          key={toast.id}
+          toast={toast}
+          onDismiss={onDismiss}
+          duration={duration}
+        />
+      ))}
+    </div>
+  );
+}
+
+export default ToastStack;

--- a/components/events/calendar/CalendarDotGrid.tsx
+++ b/components/events/calendar/CalendarDotGrid.tsx
@@ -1,0 +1,91 @@
+import { useMemo } from 'react';
+import dayjs from 'dayjs';
+import classNames from 'classnames/bind';
+import { Event } from 'model/event';
+import { TagResponse } from 'model/tag';
+import { buildCalendarMatrix } from './utils/buildCalendarMatrix';
+import { tagColor } from './utils/tagColor';
+import style from './CalendarView.module.scss';
+
+const cn = classNames.bind(style);
+const MAX_DOTS = 3;
+
+type Props = {
+  year: number;
+  month: number;
+  events: Event[];
+  selectedDate: string | null;
+  onSelectDate: (dateISO: string) => void;
+};
+
+const CalendarDotGrid = ({ year, month, events, selectedDate, onSelectDate }: Props) => {
+  const matrix = useMemo(() => buildCalendarMatrix(year, month), [year, month]);
+  const todayISO = dayjs().format('YYYY-MM-DD');
+
+  const eventsByDate = useMemo(() => {
+    const map = new Map<string, Event[]>();
+    events
+      .filter((e) =>
+        e.event_time_type === 'DATE' &&
+        e.use_start_date_time_yn !== 'N' &&
+        e.start_date_time
+      )
+      .forEach((e) => {
+        const start = dayjs(e.start_date_time);
+        const end   = e.end_date_time ? dayjs(e.end_date_time) : start;
+        let cursor = start;
+        while (cursor.isBefore(end) || cursor.isSame(end, 'day')) {
+          const iso = cursor.format('YYYY-MM-DD');
+          if (!map.has(iso)) map.set(iso, []);
+          map.get(iso)!.push(e);
+          cursor = cursor.add(1, 'day');
+        }
+      });
+    return map;
+  }, [events]);
+
+  return (
+    <div className={cn('dot__grid')}>
+      {matrix.flat().map((cell) => {
+        const isToday = cell.date === todayISO && !cell.isOutside;
+        const isSelected = cell.date === selectedDate;
+        const dayEvents = eventsByDate.get(cell.date) ?? [];
+        const visible = dayEvents.slice(0, MAX_DOTS);
+        const overflow = dayEvents.length - visible.length;
+
+        return (
+          <div
+            key={cell.date}
+            className={cn('dot__cell', {
+              outside: cell.isOutside,
+              today: isToday,
+              selected: isSelected,
+              sun: cell.dow === 0,
+              sat: cell.dow === 6,
+            })}
+            role="button"
+            tabIndex={0}
+            aria-label={`${cell.month}월 ${cell.day}일 행사 ${dayEvents.length}건`}
+            onClick={() => onSelectDate(cell.date)}
+            onKeyDown={(e) => { if (e.key === 'Enter') onSelectDate(cell.date); }}
+          >
+            <span>{cell.day}</span>
+            {(visible.length > 0 || overflow > 0) && (
+              <div className={cn('dot__dots')}>
+                {visible.map((e, i) => (
+                  <i
+                    key={`${e.id}-${i}`}
+                    style={{ background: tagColor(e.tags.map((t: TagResponse) => t.tag_name)) }}
+                  />
+                ))}
+                {overflow > 0 && <i className={cn('plus')} />}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default CalendarDotGrid;

--- a/components/events/calendar/CalendarGrid.tsx
+++ b/components/events/calendar/CalendarGrid.tsx
@@ -1,0 +1,125 @@
+import dayjs from 'dayjs';
+import classNames from 'classnames/bind';
+import { Event } from 'model/event';
+import { TagResponse } from 'model/tag';
+import { buildCalendarMatrix } from './utils/buildCalendarMatrix';
+import { layoutMultiDayEvents, EventSegment } from './utils/layoutMultiDayEvents';
+import { tagColor } from './utils/tagColor';
+import style from './CalendarView.module.scss';
+import { useMemo } from 'react';
+
+const cn = classNames.bind(style);
+
+const MAX_CHIPS_PER_CELL = 2;
+const WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토'];
+
+type Props = {
+  year: number;
+  month: number;
+  events: Event[];
+  onSelectDate: (dateISO: string) => void;
+};
+
+const CalendarGrid = ({ year, month, events, onSelectDate }: Props) => {
+  const matrix = useMemo(() => buildCalendarMatrix(year, month), [year, month]);
+  const segmentsByWeek = useMemo(
+    () => layoutMultiDayEvents(events, matrix),
+    [events, matrix]
+  );
+  const todayISO = dayjs().format('YYYY-MM-DD');
+
+  const renderWeek = (weekIdx: number) => {
+    const week = matrix[weekIdx];
+    const weekSegments = segmentsByWeek[weekIdx];
+
+    // Map each column to all segments that occupy it (for overflow counting)
+    const segmentsByCol: EventSegment[][] = Array.from({ length: 7 }, () => []);
+    weekSegments.forEach((seg) => {
+      for (let c = seg.startCol; c <= seg.endCol; c++) {
+        segmentsByCol[c].push(seg);
+      }
+    });
+
+    return week.map((cell, col) => {
+      const isToday = cell.date === todayISO && !cell.isOutside;
+      const segsHere = segmentsByCol[col];
+      const segsStartingHere = segsHere.filter((seg) => seg.startCol === col);
+      const visibleSegs = segsStartingHere.slice(0, MAX_CHIPS_PER_CELL);
+      const overflow = segsHere.length - visibleSegs.length;
+
+      return (
+        <div
+          key={cell.date}
+          className={cn('grid__cell', { outside: cell.isOutside })}
+          role="button"
+          tabIndex={0}
+          aria-label={`${cell.month}월 ${cell.day}일 행사 ${segsHere.length}건`}
+          onClick={() => onSelectDate(cell.date)}
+          onKeyDown={(e) => { if (e.key === 'Enter') onSelectDate(cell.date); }}
+        >
+          <span
+            className={cn('grid__num', {
+              sun: cell.dow === 0 && !cell.isOutside,
+              sat: cell.dow === 6 && !cell.isOutside,
+              outside: cell.isOutside,
+            })}
+          >
+            <span className={cn({ grid__numToday: isToday })}>{cell.day}</span>
+          </span>
+          {visibleSegs.map((seg) => {
+            const color = tagColor(seg.event.tags.map((t: TagResponse) => t.tag_name));
+            const spanLen = seg.endCol - seg.startCol + 1;
+            const hasLeftJoin = !seg.isStart;
+            const hasRightJoin = !seg.isEnd;
+            return (
+              <div
+                key={`${seg.eventId}-${seg.weekIndex}-${seg.startCol}`}
+                className={cn(
+                  'grid__chip',
+                  {
+                    'grid__chip--start': hasRightJoin && !hasLeftJoin,
+                    'grid__chip--mid':   hasLeftJoin && hasRightJoin,
+                    'grid__chip--end':   hasLeftJoin && !hasRightJoin,
+                  }
+                )}
+                style={{
+                  background: hexToBg(color, 0.08),
+                  color,
+                  borderLeft: `2px solid ${color}`,
+                  gridColumn: `span ${spanLen}`,
+                }}
+                title={seg.event.title}
+              >
+                {seg.event.title}
+              </div>
+            );
+          })}
+          {overflow > 0 && (
+            <span className={cn('grid__more')}>+{overflow} 더보기</span>
+          )}
+        </div>
+      );
+    });
+  };
+
+  return (
+    <>
+      <div className={cn('grid__weekdays')}>
+        {WEEKDAYS.map((d) => <div key={d}>{d}</div>)}
+      </div>
+      <div className={cn('grid')}>
+        {matrix.map((_, w) => renderWeek(w))}
+      </div>
+    </>
+  );
+};
+
+function hexToBg(hex: string, alpha: number): string {
+  const h = hex.replace('#', '');
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+export default CalendarGrid;

--- a/components/events/calendar/CalendarHeader.tsx
+++ b/components/events/calendar/CalendarHeader.tsx
@@ -1,0 +1,45 @@
+import { useRouter } from 'next/router';
+import dayjs from 'dayjs';
+import classNames from 'classnames/bind';
+import ViewToggle from './ViewToggle';
+import style from './CalendarView.module.scss';
+
+const cn = classNames.bind(style);
+
+type Props = { year: number; month: number };
+
+const CalendarHeader = ({ year, month }: Props) => {
+  const router = useRouter();
+
+  const navigate = (deltaMonths: number | 'today') => {
+    let nextYear = year;
+    let nextMonth = month;
+    if (deltaMonths === 'today') {
+      const now = dayjs();
+      nextYear = now.year();
+      nextMonth = now.month() + 1;
+    } else {
+      const next = dayjs(`${year}-${String(month).padStart(2, '0')}-01`).add(deltaMonths, 'month');
+      nextYear = next.year();
+      nextMonth = next.month() + 1;
+    }
+    router.push({
+      pathname: '/events',
+      query: { ...router.query, view: 'calendar', year: nextYear, month: nextMonth },
+    });
+  };
+
+  return (
+    <div className={cn('header')}>
+      <div className={cn('header__nav')}>
+        <button type="button" className={cn('header__navBtn')} aria-label="이전 달" onClick={() => navigate(-1)}>‹</button>
+        <span className={cn('header__monthLabel')}>{year}년 {month}월</span>
+        <button type="button" className={cn('header__navBtn')} aria-label="다음 달" onClick={() => navigate(1)}>›</button>
+        <button type="button" className={cn('header__todayBtn')} onClick={() => navigate('today')}>오늘</button>
+      </div>
+      <ViewToggle current="calendar" />
+    </div>
+  );
+};
+
+export default CalendarHeader;

--- a/components/events/calendar/CalendarView.module.scss
+++ b/components/events/calendar/CalendarView.module.scss
@@ -1,0 +1,285 @@
+.viewToggle {
+  display: inline-flex;
+  background: #F0F0F5;
+  padding: 4px;
+  border-radius: 10px;
+}
+
+.viewToggle__btn {
+  border: 0;
+  background: transparent;
+  padding: 6px 14px;
+  border-radius: 7px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #6C6E7E;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+
+  &.on {
+    background: #fff;
+    color: #2B2D36;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+  }
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.header__nav {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.header__monthLabel {
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: -0.012em;
+}
+
+.header__navBtn {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  border: 1px solid #E1E1E8;
+  background: #fff;
+  cursor: pointer;
+  font-size: 16px;
+  color: #6C6E7E;
+  &:hover { border-color: #CDCED6; }
+}
+
+.header__todayBtn {
+  margin-left: 8px;
+  padding: 6px 12px;
+  border-radius: 8px;
+  border: 1px solid #E1E1E8;
+  background: #fff;
+  color: #2B2D36;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.grid__weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  margin-bottom: 8px;
+
+  div {
+    font-size: 12px;
+    font-weight: 600;
+    color: #6C6E7E;
+    text-align: center;
+    padding: 8px 0;
+    min-width: 0;
+  }
+  div:first-child { color: #D91C29; }
+  div:last-child  { color: #1D6CE0; }
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 1px;
+  background: #E8E8EE;
+  border: 1px solid #E8E8EE;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.grid__cell {
+  background: #fff;
+  min-height: 110px;
+  min-width: 0;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+  &:hover { background: #F7F7FA; }
+
+  &.outside { background: #F7F7FA; color: #8C8F9F; }
+}
+
+.grid__num {
+  font-size: 13px;
+  font-weight: 600;
+  padding: 2px 4px;
+
+  &.sun { color: #D91C29; }
+  &.sat { color: #1D6CE0; }
+  &.outside { color: #8C8F9F; }
+}
+
+.grid__numToday {
+  background: #0043FF;
+  color: #fff !important;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+}
+
+.grid__chip {
+  font-size: 11px;
+  padding: 3px 6px;
+  border-radius: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 500;
+  line-height: 1.3;
+}
+.grid__chip--start { border-radius: 4px 0 0 4px; margin-right: -9px; padding-right: 12px; }
+.grid__chip--mid   { border-radius: 0; margin-left: -9px; margin-right: -9px; padding-left: 12px; padding-right: 12px; }
+.grid__chip--end   { border-radius: 0 4px 4px 0; margin-left: -9px; padding-left: 12px; }
+
+.grid__more {
+  font-size: 11px;
+  color: #6C6E7E;
+  padding: 2px 6px;
+}
+
+.dot__grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 2px;
+}
+
+.dot__cell {
+  aspect-ratio: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 600;
+  border-radius: 8px;
+  gap: 2px;
+  cursor: pointer;
+  position: relative;
+
+  &.outside { color: #8C8F9F; }
+  &.today   { background: #0043FF; color: #fff; }
+  &.selected { outline: 2px solid #0043FF; outline-offset: -2px; }
+  &.sun:not(.today):not(.outside) { color: #D91C29; }
+  &.sat:not(.today):not(.outside) { color: #1D6CE0; }
+}
+
+.dot__dots {
+  display: flex;
+  gap: 1.5px;
+
+  i {
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    display: inline-block;
+  }
+  i.plus { background: #8C8F9F; }
+}
+
+.sheet__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 9000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.sheet {
+  background: #fff;
+  border-radius: 12px;
+  padding: 20px;
+  max-width: 480px;
+  width: 90vw;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.sheet__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.sheet__title {
+  font-size: 16px;
+  font-weight: 800;
+  letter-spacing: -0.012em;
+}
+
+.sheet__close {
+  background: none;
+  border: 0;
+  font-size: 18px;
+  cursor: pointer;
+  color: #6C6E7E;
+}
+
+.sheet__empty {
+  text-align: center;
+  color: #6C6E7E;
+  padding: 32px 0;
+  font-size: 13px;
+}
+
+.sheet__item {
+  display: flex;
+  gap: 12px;
+  padding: 12px 0;
+  border-bottom: 1px solid #F0F0F5;
+  cursor: pointer;
+
+  &:last-child { border-bottom: 0; }
+
+  .sheet__bar { width: 3px; flex-shrink: 0; border-radius: 2px; }
+  .sheet__body {
+    .sheet__itemTitle { font-size: 14px; font-weight: 700; margin-bottom: 4px; }
+    .sheet__itemMeta  { font-size: 12px; color: #6C6E7E; }
+  }
+}
+
+@media (max-width: 720px) {
+  .sheet {
+    align-self: flex-end;
+    max-width: 100vw;
+    width: 100vw;
+    border-radius: 16px 16px 0 0;
+    max-height: 70vh;
+  }
+  .sheet__overlay { align-items: flex-end; }
+}
+
+.container {
+  background: #fff;
+  border: 1px solid #E1E1E8;
+  border-radius: 12px;
+  padding: 24px;
+  margin: 16px 0 40px;
+}
+
+@media (max-width: 720px) {
+  .container {
+    padding: 12px;
+    margin: 8px 0 32px;
+  }
+}

--- a/components/events/calendar/CalendarView.tsx
+++ b/components/events/calendar/CalendarView.tsx
@@ -1,0 +1,59 @@
+import { useState, useEffect } from 'react';
+import classNames from 'classnames/bind';
+import { Event } from 'model/event';
+import CalendarHeader from './CalendarHeader';
+import CalendarGrid from './CalendarGrid';
+import CalendarDotGrid from './CalendarDotGrid';
+import DayDetailSheet from './DayDetailSheet';
+import style from './CalendarView.module.scss';
+
+const cn = classNames.bind(style);
+const MOBILE_BREAKPOINT = 720;
+
+type Props = {
+  year: number;
+  month: number;
+  events: Event[];
+};
+
+const CalendarView = ({ year, month, events }: Props) => {
+  const [isMobile, setIsMobile] = useState<boolean>(false);
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+
+  useEffect(() => {
+    const update = () => setIsMobile(window.innerWidth <= MOBILE_BREAKPOINT);
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, []);
+
+  return (
+    <div className={cn('container')}>
+      <CalendarHeader year={year} month={month} />
+      {isMobile ? (
+        <CalendarDotGrid
+          year={year}
+          month={month}
+          events={events}
+          selectedDate={selectedDate}
+          onSelectDate={(d) => setSelectedDate(d)}
+        />
+      ) : (
+        <CalendarGrid
+          year={year}
+          month={month}
+          events={events}
+          onSelectDate={(d) => setSelectedDate(d)}
+        />
+      )}
+      <DayDetailSheet
+        isOpen={!!selectedDate}
+        selectedDate={selectedDate}
+        events={events}
+        onClose={() => setSelectedDate(null)}
+      />
+    </div>
+  );
+};
+
+export default CalendarView;

--- a/components/events/calendar/DayDetailSheet.tsx
+++ b/components/events/calendar/DayDetailSheet.tsx
@@ -1,0 +1,78 @@
+import Modal from 'react-modal';
+import dayjs from 'dayjs';
+import Link from 'next/link';
+import classNames from 'classnames/bind';
+import { Event } from 'model/event';
+import { TagResponse } from 'model/tag';
+import { tagColor } from './utils/tagColor';
+import style from './CalendarView.module.scss';
+
+const cn = classNames.bind(style);
+const DOW = ['일', '월', '화', '수', '목', '금', '토'];
+
+type Props = {
+  isOpen: boolean;
+  selectedDate: string | null;
+  events: Event[];
+  onClose: () => void;
+};
+
+const DayDetailSheet = ({ isOpen, selectedDate, events, onClose }: Props) => {
+  if (!selectedDate) return null;
+  const d = dayjs(selectedDate);
+  const dayEvents = events.filter((e) => {
+    if (e.event_time_type !== 'DATE') return false;
+    if (e.use_start_date_time_yn === 'N') return false;
+    if (!e.start_date_time) return false;
+    const start = dayjs(e.start_date_time);
+    const end = e.end_date_time ? dayjs(e.end_date_time) : start;
+    return (d.isSame(start, 'day') || d.isAfter(start, 'day')) &&
+           (d.isSame(end, 'day')   || d.isBefore(end, 'day'));
+  });
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onRequestClose={onClose}
+      className={cn('sheet')}
+      overlayClassName={cn('sheet__overlay')}
+      ariaHideApp={false}
+    >
+      <div className={cn('sheet__header')}>
+        <span className={cn('sheet__title')}>
+          {d.month() + 1}월 {d.date()}일 ({DOW[d.day()]}) · 행사 {dayEvents.length}건
+        </span>
+        <button type="button" className={cn('sheet__close')} aria-label="닫기" onClick={onClose}>✕</button>
+      </div>
+
+      {dayEvents.length === 0 ? (
+        <div className={cn('sheet__empty')}>이 날은 등록된 행사가 없어요</div>
+      ) : (
+        <div>
+          {dayEvents.map((e) => {
+            const color = tagColor(e.tags.map((t: TagResponse) => t.tag_name));
+            const start = dayjs(e.start_date_time);
+            const end   = e.end_date_time ? dayjs(e.end_date_time) : start;
+            const isMulti = !start.isSame(end, 'day');
+            const meta = isMulti
+              ? `${start.format('M/D')} ~ ${end.format('M/D')} · ${e.organizer}`
+              : `${start.format('M월 D일 HH:mm')} · ${e.organizer}`;
+            return (
+              <Link href={`/event/detail/${e.id}`} key={e.id}>
+                <a className={cn('sheet__item')}>
+                  <div className={cn('sheet__bar')} style={{ background: color }} />
+                  <div className={cn('sheet__body')}>
+                    <div className={cn('sheet__itemTitle')}>{e.title}</div>
+                    <div className={cn('sheet__itemMeta')}>{meta}</div>
+                  </div>
+                </a>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </Modal>
+  );
+};
+
+export default DayDetailSheet;

--- a/components/events/calendar/ViewToggle.tsx
+++ b/components/events/calendar/ViewToggle.tsx
@@ -1,0 +1,58 @@
+import { useRouter } from 'next/router';
+import dayjs from 'dayjs';
+import classNames from 'classnames/bind';
+import style from './CalendarView.module.scss';
+
+const cn = classNames.bind(style);
+
+export type ViewMode = 'list' | 'calendar';
+
+type Props = { current: ViewMode };
+
+const ViewToggle = ({ current }: Props) => {
+  const router = useRouter();
+
+  const switchTo = (mode: ViewMode) => {
+    if (mode === current) return;
+    if (mode === 'list') {
+      const { view, year, month, ...rest } = router.query;
+      router.push({ pathname: '/events', query: rest });
+    } else {
+      const now = dayjs();
+      router.push({
+        pathname: '/events',
+        query: {
+          ...router.query,
+          view: 'calendar',
+          year: router.query.year ?? now.year(),
+          month: router.query.month ?? now.month() + 1,
+        },
+      });
+    }
+  };
+
+  return (
+    <div className={cn('viewToggle')} role="tablist" aria-label="보기 전환">
+      <button
+        type="button"
+        role="tab"
+        aria-selected={current === 'list'}
+        className={cn('viewToggle__btn', { on: current === 'list' })}
+        onClick={() => switchTo('list')}
+      >
+        📋 리스트
+      </button>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={current === 'calendar'}
+        className={cn('viewToggle__btn', { on: current === 'calendar' })}
+        onClick={() => switchTo('calendar')}
+      >
+        📅 캘린더
+      </button>
+    </div>
+  );
+};
+
+export default ViewToggle;

--- a/components/events/calendar/utils/__tests__/buildCalendarMatrix.test.ts
+++ b/components/events/calendar/utils/__tests__/buildCalendarMatrix.test.ts
@@ -1,0 +1,35 @@
+import { buildCalendarMatrix, CalendarCell } from '../buildCalendarMatrix';
+
+describe('buildCalendarMatrix', () => {
+  it('returns 6 weeks × 7 days = 42 cells', () => {
+    const matrix = buildCalendarMatrix(2026, 5);
+    expect(matrix).toHaveLength(6);
+    matrix.forEach((week) => expect(week).toHaveLength(7));
+  });
+
+  it('marks outside-month cells with isOutside=true (2026-05)', () => {
+    const matrix = buildCalendarMatrix(2026, 5);
+    // 2026/5/1 is Friday — first row has 5 outside cells (4/26~4/30)
+    expect(matrix[0][0]).toEqual<CalendarCell>({
+      date: '2026-04-26', year: 2026, month: 4, day: 26, dow: 0, isOutside: true,
+    });
+    expect(matrix[0][5]).toEqual<CalendarCell>({
+      date: '2026-05-01', year: 2026, month: 5, day: 1, dow: 5, isOutside: false,
+    });
+  });
+
+  it('handles year boundary (2025-12 → 2026-01 outside cells)', () => {
+    const matrix = buildCalendarMatrix(2025, 12);
+    const last = matrix[matrix.length - 1];
+    const outsideAfter = last.filter((c) => c.isOutside && c.year === 2026);
+    expect(outsideAfter.length).toBeGreaterThan(0);
+    expect(outsideAfter[0].month).toBe(1);
+  });
+
+  it('handles leap year February 2024 correctly', () => {
+    const matrix = buildCalendarMatrix(2024, 2);
+    const inMonth = matrix.flat().filter((c) => !c.isOutside);
+    expect(inMonth).toHaveLength(29);
+    expect(inMonth[inMonth.length - 1].day).toBe(29);
+  });
+});

--- a/components/events/calendar/utils/__tests__/layoutMultiDayEvents.test.ts
+++ b/components/events/calendar/utils/__tests__/layoutMultiDayEvents.test.ts
@@ -1,0 +1,77 @@
+import { layoutMultiDayEvents, EventSegment } from '../layoutMultiDayEvents';
+import { buildCalendarMatrix } from '../buildCalendarMatrix';
+import { Event } from 'model/event';
+
+const baseEvent = (overrides: Partial<Event>): Event => ({
+  id: '1', title: 'Test', description: '', organizer: 'Org',
+  event_link: '', cover_image_link: '', display_sequence: 0,
+  event_time_type: 'DATE', start_day_week: '월', end_day_week: '월',
+  start_date_time: '', end_date_time: '',
+  tags: [], create_date_time: '',
+  use_end_date_time_yn: 'Y', use_start_date_time_yn: 'Y',
+  ...overrides,
+});
+
+describe('layoutMultiDayEvents', () => {
+  const matrix2026May = buildCalendarMatrix(2026, 5);
+
+  it('produces single segment for single-day event', () => {
+    const events = [baseEvent({ id: '1', start_date_time: '2026-05-12T10:00:00', end_date_time: '2026-05-12T18:00:00' })];
+    const result = layoutMultiDayEvents(events, matrix2026May);
+    const allSegments = result.flat();
+    expect(allSegments).toHaveLength(1);
+    expect(allSegments[0]).toMatchObject({ isStart: true, isEnd: true, eventId: '1' });
+  });
+
+  it('produces single segment for multi-day event within one week', () => {
+    // 5/5 (화) ~ 5/7 (목) — all in week starting 5/3 (일)
+    const events = [baseEvent({ id: '1', start_date_time: '2026-05-05T00:00:00', end_date_time: '2026-05-07T23:59:59' })];
+    const result = layoutMultiDayEvents(events, matrix2026May);
+    const segments = result.flat();
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toMatchObject({ isStart: true, isEnd: true, startCol: 2, endCol: 4, weekIndex: 1 });
+  });
+
+  it('splits multi-day event crossing week boundary into two segments', () => {
+    // 5/15 (금) ~ 5/18 (월) — crosses sat→sun boundary
+    const events = [baseEvent({ id: 'cross', start_date_time: '2026-05-15T00:00:00', end_date_time: '2026-05-18T23:59:59' })];
+    const result = layoutMultiDayEvents(events, matrix2026May);
+    const segments = result.flat();
+    expect(segments).toHaveLength(2);
+    expect(segments[0]).toMatchObject({ isStart: true, isEnd: false });
+    expect(segments[1]).toMatchObject({ isStart: false, isEnd: true });
+  });
+
+  it('includes outside cells when event spans month boundary', () => {
+    // 5/30 (토) ~ 6/1 (월) — last segment is in outside cells of week 5
+    const events = [baseEvent({ id: 'border', start_date_time: '2026-05-30T00:00:00', end_date_time: '2026-06-01T23:59:59' })];
+    const result = layoutMultiDayEvents(events, matrix2026May);
+    const segments = result.flat();
+    expect(segments.length).toBeGreaterThanOrEqual(1);
+    const hasOutside = segments.some((s) => s.isOutside);
+    expect(hasOutside).toBe(true);
+  });
+
+  it('skips events with event_time_type=RECRUIT', () => {
+    const events = [baseEvent({ id: 'r', event_time_type: 'RECRUIT', start_date_time: '2026-05-12T00:00:00', end_date_time: '2026-05-12T23:59:59' })];
+    const result = layoutMultiDayEvents(events, matrix2026May);
+    expect(result.flat()).toHaveLength(0);
+  });
+
+  it('skips events with use_start_date_time_yn=N', () => {
+    const events = [baseEvent({ id: 'n', start_date_time: '2026-05-12T00:00:00', end_date_time: '2026-05-12T23:59:59', use_start_date_time_yn: 'N' })];
+    const result = layoutMultiDayEvents(events, matrix2026May);
+    expect(result.flat()).toHaveLength(0);
+  });
+
+  it('sorts overlapping events by display_sequence then start_date_time', () => {
+    const events = [
+      baseEvent({ id: 'B', display_sequence: 2, start_date_time: '2026-05-12T10:00:00', end_date_time: '2026-05-12T12:00:00' }),
+      baseEvent({ id: 'A', display_sequence: 1, start_date_time: '2026-05-12T11:00:00', end_date_time: '2026-05-12T13:00:00' }),
+    ];
+    const result = layoutMultiDayEvents(events, matrix2026May);
+    const segs = result.flat();
+    expect(segs[0].eventId).toBe('A');
+    expect(segs[1].eventId).toBe('B');
+  });
+});

--- a/components/events/calendar/utils/__tests__/tagColor.test.ts
+++ b/components/events/calendar/utils/__tests__/tagColor.test.ts
@@ -1,0 +1,25 @@
+import { tagColor, DEFAULT_TAG_COLOR } from '../tagColor';
+
+describe('tagColor', () => {
+  it('maps 컨퍼런스 to KTB Blue', () => {
+    expect(tagColor(['컨퍼런스'])).toBe('#0043FF');
+  });
+  it('maps 웨비나 to Success green', () => {
+    expect(tagColor(['웨비나'])).toBe('#08785E');
+  });
+  it('maps 해커톤 to Warning orange', () => {
+    expect(tagColor(['해커톤'])).toBe('#B45209');
+  });
+  it('maps 네트워킹 to Violet', () => {
+    expect(tagColor(['네트워킹'])).toBe('#7A0CFF');
+  });
+  it('returns default color when no tag matches', () => {
+    expect(tagColor(['알수없는태그'])).toBe(DEFAULT_TAG_COLOR);
+  });
+  it('returns default color for empty tags', () => {
+    expect(tagColor([])).toBe(DEFAULT_TAG_COLOR);
+  });
+  it('uses first matching tag when multiple tags', () => {
+    expect(tagColor(['알수없음', '컨퍼런스', '웨비나'])).toBe('#0043FF');
+  });
+});

--- a/components/events/calendar/utils/buildCalendarMatrix.ts
+++ b/components/events/calendar/utils/buildCalendarMatrix.ts
@@ -1,0 +1,34 @@
+import dayjs from 'dayjs';
+
+export interface CalendarCell {
+  date: string;     // 'YYYY-MM-DD'
+  year: number;
+  month: number;    // 1~12
+  day: number;
+  dow: number;      // 0=Sun ... 6=Sat
+  isOutside: boolean;
+}
+
+export function buildCalendarMatrix(year: number, month: number): CalendarCell[][] {
+  const firstOfMonth = dayjs(`${year}-${String(month).padStart(2, '0')}-01`);
+  const startDow = firstOfMonth.day(); // 0~6
+  const gridStart = firstOfMonth.subtract(startDow, 'day');
+
+  const matrix: CalendarCell[][] = [];
+  for (let w = 0; w < 6; w++) {
+    const week: CalendarCell[] = [];
+    for (let d = 0; d < 7; d++) {
+      const cur = gridStart.add(w * 7 + d, 'day');
+      week.push({
+        date: cur.format('YYYY-MM-DD'),
+        year: cur.year(),
+        month: cur.month() + 1,
+        day: cur.date(),
+        dow: cur.day(),
+        isOutside: cur.month() + 1 !== month || cur.year() !== year,
+      });
+    }
+    matrix.push(week);
+  }
+  return matrix;
+}

--- a/components/events/calendar/utils/layoutMultiDayEvents.ts
+++ b/components/events/calendar/utils/layoutMultiDayEvents.ts
@@ -1,0 +1,79 @@
+import dayjs from 'dayjs';
+import { Event } from 'model/event';
+import { CalendarCell } from './buildCalendarMatrix';
+
+export interface EventSegment {
+  eventId: string;
+  event: Event;
+  weekIndex: number;   // 0~5
+  startCol: number;    // 0~6 (inclusive)
+  endCol: number;      // 0~6 (inclusive)
+  isStart: boolean;    // true if this segment includes the event's original start day
+  isEnd: boolean;      // true if this segment includes the event's original end day
+  isOutside: boolean;  // segment falls entirely in outside cells of the matrix
+}
+
+function isRenderable(e: Event): boolean {
+  if (e.event_time_type !== 'DATE') return false;
+  if (e.use_start_date_time_yn === 'N') return false;
+  if (!e.start_date_time) return false;
+  return true;
+}
+
+export function layoutMultiDayEvents(
+  events: Event[],
+  matrix: CalendarCell[][],
+): EventSegment[][] {
+  const segmentsByWeek: EventSegment[][] = matrix.map(() => []);
+
+  const sorted = [...events]
+    .filter(isRenderable)
+    .sort((a, b) => {
+      const ds = a.display_sequence - b.display_sequence;
+      if (ds !== 0) return ds;
+      return a.start_date_time.localeCompare(b.start_date_time);
+    });
+
+  const gridStart = dayjs(matrix[0][0].date);
+  const gridEnd   = dayjs(matrix[5][6].date);
+
+  for (const event of sorted) {
+    const start = dayjs(event.start_date_time);
+    const end   = event.end_date_time ? dayjs(event.end_date_time) : start;
+
+    // clip to grid
+    const clipStart = start.isBefore(gridStart) ? gridStart : start;
+    const clipEnd   = end.isAfter(gridEnd)      ? gridEnd   : end;
+    if (clipEnd.isBefore(clipStart)) continue;
+
+    for (let w = 0; w < matrix.length; w++) {
+      const weekStart = dayjs(matrix[w][0].date);
+      const weekEnd   = dayjs(matrix[w][6].date);
+
+      if (clipEnd.isBefore(weekStart) || clipStart.isAfter(weekEnd)) continue;
+
+      const segStart = clipStart.isBefore(weekStart) ? weekStart : clipStart;
+      const segEnd   = clipEnd.isAfter(weekEnd)      ? weekEnd   : clipEnd;
+      const startCol = segStart.diff(weekStart, 'day');
+      const endCol   = segEnd.diff(weekStart, 'day');
+
+      const segmentIsOutside = Array.from(
+        { length: endCol - startCol + 1 },
+        (_, i) => matrix[w][startCol + i].isOutside,
+      ).some(Boolean);
+
+      segmentsByWeek[w].push({
+        eventId: event.id,
+        event,
+        weekIndex: w,
+        startCol,
+        endCol,
+        isStart: segStart.isSame(start, 'day'),
+        isEnd:   segEnd.isSame(end, 'day'),
+        isOutside: segmentIsOutside,
+      });
+    }
+  }
+
+  return segmentsByWeek;
+}

--- a/components/events/calendar/utils/tagColor.ts
+++ b/components/events/calendar/utils/tagColor.ts
@@ -1,0 +1,19 @@
+export const DEFAULT_TAG_COLOR = '#525463';
+
+const COLOR_MAP: Array<{ keywords: string[]; color: string }> = [
+  { keywords: ['컨퍼런스', 'conference', 'conf'],         color: '#0043FF' },
+  { keywords: ['웨비나', '세미나', 'webinar', 'seminar'], color: '#08785E' },
+  { keywords: ['해커톤', '공모전', 'hackathon'],           color: '#B45209' },
+  { keywords: ['네트워킹', '밋업', 'meetup'],              color: '#7A0CFF' },
+];
+
+export function tagColor(tagNames: string[]): string {
+  for (const tagName of tagNames) {
+    const lower = tagName.toLowerCase();
+    const match = COLOR_MAP.find(({ keywords }) =>
+      keywords.some((k) => lower.includes(k.toLowerCase()))
+    );
+    if (match) return match.color;
+  }
+  return DEFAULT_TAG_COLOR;
+}

--- a/components/features/filters/ByJobGroup/FilterByJobGroup.module.scss
+++ b/components/features/filters/ByJobGroup/FilterByJobGroup.module.scss
@@ -5,6 +5,17 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-start;
+  align-items: center;
+  gap: 8px;
   font-family: 'Pretendard Variable';
-  margin: 2.688rem 0;
+  margin: 2.25rem 0 1.5rem;
+
+  @include tablet {
+    gap: 6px;
+    margin: 1.5rem 0 1rem;
+  }
+  @include mobile {
+    gap: 6px;
+    margin: 1.25rem 0 0.75rem;
+  }
 }

--- a/components/features/filters/EventFilter.module.scss
+++ b/components/features/filters/EventFilter.module.scss
@@ -26,7 +26,8 @@
       font-weight: 700;
       font-size: 40px;
       line-height: 3rem;
-      color: var(--gray-1);
+      letter-spacing: -0.012rem;
+      color: var(--vapor-gray-900);
     }
   }
   .filter {
@@ -137,7 +138,7 @@
             border-radius: 5px;
             &:hover {
               cursor: pointer;
-              background-color: var(--gray-5);
+              background-color: var(--vapor-gray-100);
             }
           }
           &__date {
@@ -187,7 +188,7 @@
           border-radius: 5px;
           &:hover {
             cursor: pointer;
-            background-color: var(--gray-5);
+            background-color: var(--vapor-gray-100);
           }
         }
         &__date {
@@ -285,7 +286,7 @@
 
           &:hover {
             cursor: pointer;
-            background-color: var(--gray-5);
+            background-color: var(--vapor-gray-100);
           }
         }
         &__date {

--- a/components/features/filters/EventFilter.tsx
+++ b/components/features/filters/EventFilter.tsx
@@ -1,4 +1,5 @@
 import DateBoard from 'components/common/date/DateBoard';
+import ViewToggle, { ViewMode } from 'components/events/calendar/ViewToggle';
 import FilterByCoast from 'components/features/filters/ByCoast/FilterByCoast';
 import FilterByEventType from 'components/features/filters/ByEventType/FilterByEventType';
 import FilterByJobGroup from 'components/features/filters/ByJobGroup/FilterByJobGroup';
@@ -42,10 +43,11 @@ function EventFilter() {
           <span className={cn('block__desc')}>전체 행사</span>
           <Register />
         </div>
-        <div className={cn('block')}>
+        <div className={cn('block')} style={{ marginBottom: '12px' }}>
           <div className={cn('block__taglist')}>
             <FilterByJobGroup context={context} />
           </div>
+          <ViewToggle current={(router.query.view === 'calendar' ? 'calendar' : 'list') as ViewMode} />
         </div>
         <div className={cn('filter')}>
           <div className={cn('filter__search')}>

--- a/components/features/filters/jobGroup.ts
+++ b/components/features/filters/jobGroup.ts
@@ -9,34 +9,30 @@ export const jobGroups = [
   },
   {
     tag_id: 2,
-    tag_name: '백엔드',
-  },
-  {
-    tag_id: 3,
-    tag_name: '프론트엔드',
-  },
-  {
-    tag_id: 4,
-    tag_name: '모바일',
-  },
-  {
-    tag_id: 5,
     tag_name: '클라우드',
   },
   {
-    tag_id: 6,
-    tag_name: '빅데이터',
-  },
-  {
-    tag_id: 7,
+    tag_id: 3,
     tag_name: '블록체인',
   },
   {
-    tag_id: 8,
-    tag_name: 'DevOps',
+    tag_id: 4,
+    tag_name: '보안',
   },
   {
-    tag_id: 9,
-    tag_name: '기타',
+    tag_id: 5,
+    tag_name: '교육',
+  },
+  {
+    tag_id: 6,
+    tag_name: '기술일반',
+  },
+  {
+    tag_id: 7,
+    tag_name: '모임',
+  },
+  {
+    tag_id: 8,
+    tag_name: '대회/공모전',
   },
 ];

--- a/components/features/register/Register.module.scss
+++ b/components/features/register/Register.module.scss
@@ -8,7 +8,7 @@
   
   &:hover {
     transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(44, 76, 239, 0.2);
+    box-shadow: 0 4px 12px rgba(0, 67, 255, 0.18);
   }
   
   &:active {

--- a/components/layout/header/Header.module.scss
+++ b/components/layout/header/Header.module.scss
@@ -9,7 +9,7 @@
   left: 0;
   z-index: 99;
   min-height: 3.5rem;
-  border-bottom: 1px solid $light-gray-4;
+  border-bottom: 1px solid var(--vapor-gray-300);
   background-color: hsla(0, 0%, 100%, .88);
   backdrop-filter: saturate(150%) blur(32px);
 
@@ -56,10 +56,10 @@
     .toggle__container {
       height: 2.7rem;
       width: 2.7rem;
-      border-radius: 5px;
+      border-radius: 8px;
 
       &:hover {
-        background-color: var(--gray-5);
+        background-color: var(--vapor-gray-100);
       }
     }
 
@@ -83,79 +83,96 @@
     cursor: pointer;
 
     svg path {
-      fill: var(--gray-2);
+      fill: var(--vapor-gray-500);
     }
   }
 
   .profile-menu {
-    animation-name: appearIn;
-    animation-duration: 0.2s;
-    animation-timing-function: linear;
-
-    border-radius: 10px;
-    width: 136px;
-    height: 135px;
-    padding: 0;
-    left: 50%;
-    top: 42px;
-    margin-left: -102px;
-    text-align: center;
     position: absolute;
-    z-index: 1;
-    background-color: #fff;
-    box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
+    top: 44px;
+    right: 0;
+    left: auto;
+    margin-left: 0;
+    width: 200px;
+    padding: 6px;
+    border-radius: 14px;
+    background-color: var(--vapor-gray-000);
+    box-shadow:
+      0 0 0 1px rgba(0, 0, 64, 0.06),
+      0 12px 32px rgba(0, 0, 64, 0.10),
+      0 4px 8px rgba(0, 0, 64, 0.04);
+    z-index: 100;
+    transform-origin: top right;
+    animation: profileMenuIn 0.2s cubic-bezier(0.22, 1, 0.36, 1) both;
+    text-align: left;
 
     &__item {
-      padding: 0.5rem 1.813rem 0.5rem 1.813rem;
-      background-color: #fff;
+      padding: 11px 12px;
+      background-color: transparent;
       display: flex;
       flex-direction: row;
       align-items: center;
-      font-size: 0.875rem;
-      color: #757575;
-      font-weight: 400;
+      justify-content: flex-start;
+      font-size: 14px;
+      font-weight: 600;
+      line-height: 1.4;
+      letter-spacing: -0.012rem;
+      color: var(--vapor-gray-800);
       cursor: pointer;
-      height: 45px;
+      border-radius: 8px;
+      transition: background-color 0.15s ease, color 0.15s ease,
+        transform 0.1s ease;
+      -webkit-tap-highlight-color: transparent;
+      user-select: none;
 
       &:hover {
-        background: #ebebeb;
+        background-color: var(--vapor-gray-050);
       }
-      &:focus {
-        background-color: #ebebeb;
+      &:active {
+        background-color: var(--vapor-gray-100);
+        transform: scale(0.98);
+      }
+      &:focus-visible {
+        background-color: var(--vapor-gray-050);
+        outline: 2px solid var(--ktb-tech-blue);
+        outline-offset: -2px;
+      }
+
+      &:last-child {
+        position: relative;
+        margin-top: 5px;
+        color: var(--vapor-text-danger);
+
+        &::before {
+          content: '';
+          position: absolute;
+          top: -3px;
+          left: 8px;
+          right: 8px;
+          height: 1px;
+          background-color: var(--vapor-gray-200);
+          pointer-events: none;
+        }
+
+        &:hover {
+          background-color: rgba(220, 38, 38, 0.06);
+        }
+        &:active {
+          background-color: rgba(220, 38, 38, 0.1);
+        }
       }
     }
-
-    &__item:first-child {
-      border-top-left-radius: 10px;
-      border-top-right-radius: 10px;
-    }
-    &__item:last-child {
-      border-bottom-left-radius: 10px;
-      border-bottom-right-radius: 10px;
-    }
-  }
-
-  .profile-menu::after {
-    content: ' ';
-    position: absolute;
-    bottom: 100%;
-    left: 102px;
-    margin-left: -10px;
-    border-width: 10px;
-    border-style: solid;
-    border-color: transparent transparent #ffffff transparent;
   }
 }
 
-@keyframes appearIn {
-  0% {
-    height: 0px;
-    opacity: 0%;
+@keyframes profileMenuIn {
+  from {
+    opacity: 0;
+    transform: translateY(-6px) scale(0.98);
   }
-
-  100% {
-    height: 135px;
-    opacity: 100%;
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
   }
 }
 

--- a/components/layout/header/HeaderTab.module.scss
+++ b/components/layout/header/HeaderTab.module.scss
@@ -15,11 +15,12 @@
     .tab-text {
       font-size: 14px;
       line-height: 14px;
-      color: var(--gray-2);
+      color: var(--vapor-gray-600);
       font-weight: 500;
 
       &.active {
-        color: #313234;
+        color: var(--vapor-gray-900);
+        font-weight: 700;
       }
     }
   }
@@ -41,7 +42,7 @@
   font-weight: 700;
   letter-spacing: -0.3px;
   color: #fff;
-  background-color: #3182f6;
+  background-color: var(--ktb-tech-blue);
   border-radius: 4px;
   vertical-align: 1px;
   

--- a/components/myEvent/MyEventBody.tsx
+++ b/components/myEvent/MyEventBody.tsx
@@ -1,5 +1,6 @@
 import MyEventDoneList from 'components/myEvent/MyEventDoneList';
 import MyEventScheduledList from 'components/myEvent/MyEventScheduledList';
+import MyEventTabs from 'components/myEvent/MyEventTabs';
 import React from 'react';
 import { useRouter } from 'next/router';
 import Letter from '../features/letter/Letter';
@@ -12,6 +13,7 @@ const MyEventBody = () => {
 
   return (
     <>
+      <MyEventTabs />
       {ongoing && <MyEventScheduledList />}
       {done && <MyEventDoneList />}
       <Letter />

--- a/components/myEvent/MyEventDoneList.tsx
+++ b/components/myEvent/MyEventDoneList.tsx
@@ -9,8 +9,6 @@ import { mutate } from 'swr';
 import React, { useEffect, useState } from 'react';
 import { ThreeDots } from 'react-loader-spinner';
 import classNames from 'classnames/bind';
-import Image from 'next/image';
-import { useRouter } from 'next/router';
 import MyEventEmpty from './MyEventEmpty';
 
 const cn = classNames.bind(style);
@@ -93,52 +91,9 @@ const MyEventDoneList = () => {
     });
   };
 
-  const router = useRouter();
-  const [tabMenu, setTabMenu] = useState({
-    ongoing: false,
-    done: false,
-  });
-
-  useEffect(() => {
-    setTabMenu({
-      ongoing: router.query.tab === 'ongoing' || router.query.tab == null,
-      done: router.query.tab === 'done',
-    });
-  }, [router.query.tab]);
-
   return (
     <>
       <div className={cn('section__list')}>
-        <div className={cn('wrapper')}>
-          <div className={cn('wrapper__status')}>
-            <div className={cn('wrapper__status__count')}>
-              {oldEvent.length}개
-            </div>
-            <div
-              className={cn('wrapper__status__type')}
-              onClick={() => {
-                setTabMenu({ ongoing: true, done: false });
-                router.push('/myevent');
-                ga.event({
-                  action: 'web_event_진행중인행사탭클릭',
-                  event_category: 'web_myevent',
-                  event_label: '내이벤트',
-                });
-              }}
-            >
-              <Image
-                className={cn('check_box_done')}
-                src={'/icon/check_box.svg'}
-                alt="done event"
-                priority={true}
-                width={18}
-                height={18}
-              />
-              <div className={cn('wrapper__status__txt')}>진행중인 행사 보기</div>
-            </div>
-          </div>
-        </div>
-
         {/* 로딩중 */}
         {!myEvent && !isError && oldEvent && (
           <div className={cn('null-container')}>

--- a/components/myEvent/MyEventScheduledList.tsx
+++ b/components/myEvent/MyEventScheduledList.tsx
@@ -10,8 +10,6 @@ import React, { useState } from 'react';
 import { useEffect } from 'react';
 import { ThreeDots } from 'react-loader-spinner';
 import classNames from 'classnames/bind';
-import Image from 'next/image';
-import { useRouter } from 'next/router';
 import MyEventEmpty from './MyEventEmpty';
 
 const cn = classNames.bind(style);
@@ -89,52 +87,9 @@ const MyEventScheduledList = () => {
     });
   };
 
-  const router = useRouter();
-  const [tabMenu, setTabMenu] = useState({
-    ongoing: false,
-    done: false,
-  });
-
-  useEffect(() => {
-    setTabMenu({
-      ongoing: router.query.tab === 'ongoing' || router.query.tab == null,
-      done: router.query.tab === 'done',
-    });
-  }, [router.query.tab]);
-
   return (
     <>
       <div className={cn('section__list')}>
-        <div className={cn('wrapper')}>
-          <div className={cn('wrapper__status')}>
-            <div className={cn('wrapper__status__count')}>
-              {futureEvent.length}개
-            </div>
-            <div
-              className={cn('wrapper__status__type')}
-              onClick={() => {
-                setTabMenu({ ongoing: true, done: false });
-                router.push('/myevent?tab=done');
-                ga.event({
-                  action: 'web_event_진행중인행사탭클릭',
-                  event_category: 'web_myevent',
-                  event_label: '내이벤트',
-                });
-              }}
-            >
-              <Image
-                className={cn('check_box_done')}
-                src={'/icon/check_box.svg'}
-                alt="done event"
-                priority={true}
-                width={18}
-                height={18}
-              />
-              <div className={cn('wrapper__status__txt')}>종료 행사 보기</div>
-            </div>
-          </div>
-        </div>
-
         {/* 로딩중 */}
         {!myEvent && !isError && futureEvent && (
           <div className={cn('null-container')}>

--- a/components/myEvent/MyEventTabs.tsx
+++ b/components/myEvent/MyEventTabs.tsx
@@ -1,0 +1,82 @@
+import { useMyEvent } from 'lib/hooks/useSWR';
+import { DateUtil } from 'lib/utils/dateUtil';
+import * as ga from 'lib/utils/gTag';
+import { MyEvent } from 'model/event';
+import style from 'styles/MyEvent.module.scss';
+import React, { useMemo } from 'react';
+import classNames from 'classnames/bind';
+import { useRouter } from 'next/router';
+
+const cn = classNames.bind(style);
+
+const resolveEndDate = (event: MyEvent['dev_event']) => {
+  if (event.use_start_date_time_yn && !event.use_end_date_time_yn) {
+    return event.start_date_time;
+  }
+  return event.end_date_time;
+};
+
+const MyEventTabs = () => {
+  const router = useRouter();
+  const { myEvent } = useMyEvent({ filter: '' }, true);
+
+  const activeTab = router.query.tab === 'done' ? 'done' : 'ongoing';
+
+  const { ongoingCount, doneCount } = useMemo(() => {
+    if (!myEvent) return { ongoingCount: 0, doneCount: 0 };
+    let ongoing = 0;
+    let done = 0;
+    (myEvent as MyEvent[]).forEach((event) => {
+      if (DateUtil.isDone(resolveEndDate(event.dev_event))) done += 1;
+      else ongoing += 1;
+    });
+    return { ongoingCount: ongoing, doneCount: done };
+  }, [myEvent]);
+
+  const goOngoing = () => {
+    if (activeTab === 'ongoing') return;
+    ga.event({
+      action: 'web_event_진행중인행사탭클릭',
+      event_category: 'web_myevent',
+      event_label: '내이벤트',
+    });
+    router.push('/myevent');
+  };
+
+  const goDone = () => {
+    if (activeTab === 'done') return;
+    ga.event({
+      action: 'web_event_종료행사탭클릭',
+      event_category: 'web_myevent',
+      event_label: '내이벤트',
+    });
+    router.push('/myevent?tab=done');
+  };
+
+  return (
+    <nav className={cn('tabs')} role="tablist" aria-label="북마크 행사 상태">
+      <button
+        type="button"
+        role="tab"
+        aria-selected={activeTab === 'ongoing'}
+        onClick={goOngoing}
+        className={cn('tab', activeTab === 'ongoing' && 'tab--active')}
+      >
+        진행중
+        <span className={cn('tab__count')}>{ongoingCount}</span>
+      </button>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={activeTab === 'done'}
+        onClick={goDone}
+        className={cn('tab', activeTab === 'done' && 'tab--active')}
+      >
+        종료
+        <span className={cn('tab__count')}>{doneCount}</span>
+      </button>
+    </nav>
+  );
+};
+
+export default MyEventTabs;

--- a/context/toast.tsx
+++ b/context/toast.tsx
@@ -1,0 +1,44 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+import ToastStack, { ToastItem } from 'components/common/toast/ToastStack';
+
+interface ToastContextValue {
+  pushToast: (message: string) => void;
+}
+
+const ToastContext = createContext<ToastContextValue>({
+  pushToast: () => undefined,
+});
+
+export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+
+  const pushToast = useCallback((message: string) => {
+    setToasts((prev) => [
+      ...prev,
+      { id: Date.now() + Math.random(), message },
+    ]);
+  }, []);
+
+  const dismissToast = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((toast) => toast.id !== id));
+  }, []);
+
+  const value = useMemo(() => ({ pushToast }), [pushToast]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <ToastStack toasts={toasts} onDismiss={dismissToast} />
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = () => useContext(ToastContext);

--- a/docs/superpowers/plans/2026-05-11-event-detail-renewal.md
+++ b/docs/superpowers/plans/2026-05-11-event-detail-renewal.md
@@ -1,0 +1,899 @@
+# Event Detail Page Renewal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `/event/detail/[eventId]` 페이지를 DESIGN.md(KTB Vapor) 토큰으로 리뉴얼하고 행사 목록 카드와 시각적 연속성을 확보한다.
+
+**Architecture:** SCSS module 전면 리라이트 + JSX 마이크로 변경(DdayTag 마운트 / FilterTag 치환 / 아이콘 컬러 토큰화). 데스크탑(≥1200) hero는 `400px 1fr` 2-column 5:3 썸네일 + flex info, 모바일(≤1199)은 stacked. 본문은 흰 캔버스 flat + divider, 빈 상태만 gray-050 카드.
+
+**Tech Stack:** Next.js 12 / React 17 / SCSS modules / `classnames/bind` / 기존 `DdayTag` · `FilterTag` 컴포넌트 재사용.
+
+**User preferences:** 사용자는 작업 중 git commit을 원하지 않음. 각 Task 끝의 commit step은 선택사항이며 사용자 확인 없이 자동 commit하지 않는다.
+
+---
+
+## File Structure
+
+**Modified files:**
+- `styles/EventDetail.module.scss` — 전면 리라이트
+- `pages/event/detail/[eventId].tsx` — JSX 마이크로 변경
+
+**Reused (변경 없음):**
+- `components/common/tag/DdayTag.tsx` / `.module.scss` — 이미 DESIGN.md 적용
+- `components/common/tag/FilterTag.tsx` / `.module.scss` — 이미 DESIGN.md 적용
+- `components/icons/ShareIcon.tsx`, `BookmarkIcon.tsx` — color prop만 토큰화
+- `styles/_color.scss`, `styles/Theme.scss` — 이미 정비됨
+
+---
+
+## Task 1: 토큰 cleanup baseline
+
+**의도:** 본격 리라이트 전에 현재 SCSS의 하드코딩 색상값을 토큰으로 1:1 치환한다. 이걸 먼저 분리하면 후속 작업에서 토큰 누락을 잡기 쉽다.
+
+**Files:**
+- Modify: `styles/EventDetail.module.scss` (전 영역 치환)
+
+- [ ] **Step 1: 다음 매핑으로 일괄 치환**
+
+| Before | After |
+|--------|-------|
+| `var(--text-1)` | `var(--vapor-gray-900)` |
+| `var(--background-1)` | `var(--vapor-gray-000)` |
+| `var(--gray-2)` (meta-label/value) | `var(--vapor-gray-700)` |
+| `var(--gray-2)` (placeholder body) | `var(--vapor-gray-600)` |
+| `#2c4cef` | `var(--ktb-tech-blue)` |
+| `#1e3bcf` | `var(--ktb-tech-navy-hover)` |
+| `#ebebeb` | `var(--vapor-gray-300)` |
+| `#e1e2e6` | `var(--vapor-gray-300)` |
+| `#d3d4d8` | `var(--vapor-gray-300)` |
+| `#f5f5f5` | `var(--vapor-gray-100)` |
+| `#f5f7ff` | `var(--vapor-gray-050)` |
+| `#f9f9f9` | `var(--vapor-gray-050)` |
+| `#e53e3e` | `var(--vapor-text-danger)` |
+
+- [ ] **Step 2: 검증** — `grep -n '#[0-9a-fA-F]\{3,6\}' styles/EventDetail.module.scss` 결과가 비어있어야 한다. 비어있지 않으면 누락 토큰 찾아 추가 치환.
+
+- [ ] **Step 3: 빌드 sanity** — `pnpm lint` 통과, 페이지 새로고침 시 시각적 regression 없음.
+
+---
+
+## Task 2: Hero 데스크탑 레이아웃 (≥1200px)
+
+**의도:** hero 영역을 5:3 썸네일(400px 고정) + flex info 컬럼으로 재구성한다. 행사 목록 카드와 동일한 비율로 시각적 연속성을 만든다.
+
+**Files:**
+- Modify: `styles/EventDetail.module.scss` (`.event-detail__header`, `&__image-section`, `&__image`, `&__info-section` 블록)
+
+- [ ] **Step 1: `&__header` 데스크탑 블록 교체**
+
+`@media (min-width: 1200px)` 블록을 다음으로 교체:
+
+```scss
+@media (min-width: 1200px) {
+  flex-direction: row;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 64px 32px;
+  gap: 32px;
+  min-height: auto;
+}
+```
+
+- [ ] **Step 2: `&__image-section` 데스크탑 블록 교체**
+
+```scss
+@media (min-width: 1200px) {
+  width: 400px;
+  flex-shrink: 0;
+}
+```
+
+aspect-ratio는 공통부에서 `5 / 3`로 통일 (기존 `400 / 223` 제거):
+
+```scss
+&__image-section {
+  position: relative;
+  aspect-ratio: 5 / 3;
+  // ... 나머지 미디어쿼리 블록
+}
+```
+
+- [ ] **Step 3: `&__image` border-radius·border 변경**
+
+```scss
+&__image {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border-radius: 12px;
+  overflow: hidden;
+}
+```
+
+기존 `border: 1px solid` 라인은 제거 (KTB flat surfaces 철학).
+
+- [ ] **Step 4: `&__info-section` 데스크탑 블록 교체**
+
+```scss
+@media (min-width: 1200px) {
+  flex: 1;
+  padding: 0;
+  padding-right: 88px;
+  position: relative;
+}
+```
+
+`gap: 16px;`는 공통부에 유지.
+
+---
+
+## Task 3: Hero action 버튼 + organizer + title + meta + CTA 스타일
+
+**Files:**
+- Modify: `styles/EventDetail.module.scss` (`&__header-actions`, `&__organizer`, `&__title`, `&__meta`, `&__actions` 블록)
+
+- [ ] **Step 1: `&__header-actions` 데스크탑 블록 단순화**
+
+```scss
+&__header-actions {
+  display: flex;
+  gap: 4px;
+
+  @media (min-width: 1200px) {
+    position: absolute;
+    top: 0;
+    right: 0;
+  }
+
+  // 모바일/태블릿 처리는 Task 5에서 (썸네일 위로 이동)
+
+  .icon-btn {
+    width: 36px;
+    height: 36px;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background-color 0.2s ease;
+    padding: 4px;
+    color: var(--vapor-gray-500);
+
+    &:hover {
+      background-color: var(--vapor-gray-100);
+    }
+
+    svg {
+      width: 20px;
+      height: 20px;
+      flex-shrink: 0;
+    }
+  }
+}
+```
+
+기존 모바일 (`top: -10px`, `top: -2px`) absolute 매직넘버 블록은 Task 5에서 다시 정의하므로 일단 삭제.
+
+- [ ] **Step 2: `&__organizer` 블록 교체**
+
+```scss
+&__organizer {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+
+  .organizer-text {
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 1.4;
+    color: var(--vapor-gray-600);
+  }
+}
+```
+
+`.organizer-badge`는 코드에서 주석 처리돼 있으므로 SCSS 블록도 제거.
+
+- [ ] **Step 3: `&__title` 블록 교체**
+
+```scss
+&__title {
+  font-weight: 700;
+  font-size: 32px;
+  line-height: 1.3;
+  letter-spacing: -0.012rem;
+  color: var(--vapor-gray-900);
+  margin: 0;
+  word-break: keep-all;
+
+  @media (max-width: 1199px) {
+    font-size: 24px;
+  }
+
+  @media (max-width: 600px) {
+    font-size: 20px;
+  }
+
+  @media (max-width: 320px) {
+    font-size: 18px;
+  }
+}
+```
+
+- [ ] **Step 4: `&__meta` 블록 교체**
+
+```scss
+&__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+
+  .meta-item {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+
+    .meta-label {
+      font-weight: 500;
+      font-size: 14px;
+      line-height: 1.5;
+      color: var(--vapor-gray-500);
+      flex-shrink: 0;
+    }
+
+    .meta-value {
+      font-weight: 500;
+      font-size: 14px;
+      line-height: 1.5;
+      color: var(--vapor-gray-700);
+    }
+  }
+}
+```
+
+- [ ] **Step 5: `&__actions` 블록 교체**
+
+```scss
+&__actions {
+  display: flex;
+  align-items: center;
+  margin-top: 8px;
+
+  .apply-btn {
+    font-weight: 700;
+    font-size: 16px;
+    line-height: 1.4;
+    letter-spacing: -0.012rem;
+    color: #ffffff;
+    background: var(--ktb-tech-blue);
+    border: none;
+    border-radius: 12px;
+    padding: 12px 24px;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+    align-self: flex-start;
+    min-height: 48px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
+
+    &:hover {
+      background: var(--ktb-tech-navy-hover);
+    }
+
+    @media (max-width: 1199px) {
+      width: 100%;
+    }
+  }
+}
+```
+
+기존 `transform: translateY(-1px)` hover와 active reset 라인 제거.
+
+---
+
+## Task 4: 태그 컴포넌트를 FilterTag로 치환
+
+**의도:** hero의 태그를 행사 목록과 동일한 `FilterTag` 컴포넌트로 통일. 별도 `.event-tag` 스타일 제거.
+
+**Files:**
+- Modify: `pages/event/detail/[eventId].tsx`
+- Modify: `styles/EventDetail.module.scss` (`&__tags`, `.event-tag` 블록)
+
+- [ ] **Step 1: TSX 상단 import 추가**
+
+```tsx
+import FilterTag from 'components/common/tag/FilterTag';
+```
+
+- [ ] **Step 2: 태그 렌더링 부분 (현재 `event-detail__tags` 안 `<span>` 매핑) 교체**
+
+기존:
+```tsx
+<div className={cx('event-detail__tags')}>
+  {eventData.tags?.map((tag, index) => (
+    <span key={index} className={cx('event-tag')}>
+      {tag.tag_name}
+    </span>
+  ))}
+</div>
+```
+
+신규:
+```tsx
+<div className={cx('event-detail__tags')}>
+  {eventData.tags?.map((tag, index) => (
+    <FilterTag
+      key={index}
+      label={tag.tag_name}
+      size="regular"
+      type="location"
+    />
+  ))}
+</div>
+```
+
+- [ ] **Step 3: SCSS `&__tags` 블록 교체**
+
+```scss
+&__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+
+  @media (max-width: 600px) {
+    gap: 4px;
+  }
+}
+```
+
+기존 `.event-tag` 블록 전체 제거 (수평 스크롤, border, padding 등) — FilterTag가 자체 스타일링.
+
+---
+
+## Task 5: Hero 모바일/태블릿 (≤1199px) — action 버튼 썸네일 위로 이동
+
+**의도:** 좁은 viewport에서 action 버튼이 썸네일 좌상단에 오버레이되도록 (목록 카드와 동일 패턴). info 컬럼의 `padding-right`도 해제.
+
+**Files:**
+- Modify: `styles/EventDetail.module.scss`
+
+- [ ] **Step 1: `&__header` 모바일 블록 정리**
+
+```scss
+@media (max-width: 1199px) {
+  flex-direction: column;
+  padding: 32px 32px;
+  gap: 32px;
+  min-height: auto;
+}
+
+@media (max-width: 600px) {
+  padding: 24px 16px !important;
+  gap: 24px;
+}
+
+@media (max-width: 320px) {
+  padding: 24px 16px !important;
+  gap: 16px;
+}
+```
+
+- [ ] **Step 2: `&__image-section` 모바일 블록 정리**
+
+```scss
+@media (max-width: 1199px) {
+  width: 100%;
+}
+
+@media (max-width: 600px) {
+  max-height: none;
+}
+
+@media (max-width: 320px) {
+  max-height: none;
+}
+```
+
+(max-height 매직넘버 제거 — aspect-ratio가 비율 보장)
+
+- [ ] **Step 3: `&__info-section` 모바일 블록 정리**
+
+```scss
+@media (max-width: 1199px) {
+  width: 100%;
+  position: relative;
+  padding-right: 0;
+}
+```
+
+- [ ] **Step 4: `&__header-actions` 모바일 블록 (썸네일 위 오버레이) 추가**
+
+`&__header-actions` 블록 안에 다음 미디어쿼리 추가:
+
+```scss
+@media (max-width: 1199px) {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 3;
+
+  .icon-btn {
+    width: 32px;
+    height: 32px;
+    background-color: rgba(255, 255, 255, 0.85);
+    backdrop-filter: blur(4px);
+
+    &:hover {
+      background-color: rgba(255, 255, 255, 1);
+    }
+  }
+}
+```
+
+위 블록 추가 후 기존의 `@media (min-width: 601px) and (max-width: 1199px)`, `@media (max-width: 600px)`, `@media (max-width: 320px)` action 버튼 블록은 모두 제거.
+
+- [ ] **Step 5: `&__image-section`에 `position: relative;` 보장**
+
+action 버튼이 썸네일 영역 기준 absolute여야 하므로 `&__image-section`이 relative 컨테이너인지 확인. 현재 코드 47라인 `position: relative;` 이미 있음 — 그대로 유지.
+
+단, 모바일에서는 `&__header-actions`가 `&__image-section`의 자식이 아니라 `&__info-section`의 자식이다. 두 가지 방법 중 하나:
+
+**방법 A (CSS만):** `&__header` 자체를 `position: relative;`로 두고 모바일 action 버튼은 헤더 기준 top/right 좌표를 계산 — 썸네일 폭이 100%이므로 top 12 right 12가 자연스럽게 썸네일 위로 떨어진다.
+
+방법 A를 선택. `&__header { position: relative; }` 공통부에 추가:
+
+```scss
+&__header {
+  width: 100%;
+  display: flex;
+  position: relative;  // 추가
+  // ... 미디어쿼리들
+}
+```
+
+이렇게 하면 action 버튼이 모바일에서 `top: 12; right: 12;` 일 때 헤더(=썸네일 시작점) 기준 우상단으로 정확히 떨어진다.
+
+---
+
+## Task 6: DdayTag 마운트 + 종료 오버레이
+
+**Files:**
+- Modify: `pages/event/detail/[eventId].tsx`
+- Modify: `styles/EventDetail.module.scss` (`&__image__done`, `&__image__badge` 블록 추가)
+
+- [ ] **Step 1: TSX import 추가**
+
+```tsx
+import DdayTag from 'components/common/tag/DdayTag';
+```
+
+- [ ] **Step 2: 종료 판정 헬퍼 추가 (`formatEventDate` 함수 위)**
+
+```tsx
+const isEventDone = (endDate: string): boolean => {
+  return new Date(endDate).getTime() < Date.now();
+};
+```
+
+- [ ] **Step 3: 컴포넌트 본문 상단(`const param =` 위)에서 한 번 계산**
+
+```tsx
+const eventDone = isEventDone(eventData.end_date_time);
+```
+
+- [ ] **Step 4: 썸네일 마크업 교체**
+
+기존:
+```tsx
+<div className={cx('event-detail__image')}>
+  <Image
+    src={eventData.cover_image_link || '/default/event_img.png'}
+    alt={eventData.title}
+    layout="fill"
+    objectFit="cover"
+    unoptimized
+  />
+</div>
+```
+
+신규:
+```tsx
+<div className={cx('event-detail__image')}>
+  <Image
+    src={eventData.cover_image_link || '/default/event_img.png'}
+    alt={eventData.title}
+    layout="fill"
+    objectFit="cover"
+    unoptimized
+  />
+  {eventDone && <div className={cx('event-detail__image__done')} />}
+  {!eventDone && (
+    <div className={cx('event-detail__image__badge')}>
+      <DdayTag
+        startDateTime={eventData.start_date_time}
+        endDateTime={eventData.end_date_time}
+      />
+    </div>
+  )}
+</div>
+```
+
+- [ ] **Step 5: SCSS 블록 추가** — `&__image` 블록 안에 자식 두 개 추가:
+
+```scss
+&__image {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border-radius: 12px;
+  overflow: hidden;
+
+  &__done {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    left: 0;
+    top: 0;
+    background-color: rgba(0, 0, 0, 0.4);
+    border-radius: 12px;
+    z-index: 1;
+  }
+
+  &__badge {
+    position: absolute;
+    top: 12px;
+    left: 12px;
+    z-index: 2;
+  }
+}
+```
+
+---
+
+## Task 7: 아이콘 컬러 토큰화
+
+**Files:**
+- Modify: `pages/event/detail/[eventId].tsx`
+
+- [ ] **Step 1: `ShareIcon` / `BookmarkIcon` color prop 교체**
+
+기존:
+```tsx
+<ShareIcon color="var(--gray-2)" />
+// ...
+<BookmarkIcon
+  color={isBookmarked ? '#007AFF' : 'var(--gray-2)'}
+  isFavorite={isBookmarked}
+/>
+```
+
+신규:
+```tsx
+<ShareIcon color="var(--vapor-gray-500)" />
+// ...
+<BookmarkIcon
+  color={isBookmarked ? 'var(--ktb-tech-blue)' : 'var(--vapor-gray-500)'}
+  isFavorite={isBookmarked}
+/>
+```
+
+---
+
+## Task 8: 본문(마크다운) 영역 — 컨테이너 · divider · 타이포
+
+**Files:**
+- Modify: `styles/EventDetail.module.scss` (`&__content` 블록 전체)
+
+- [ ] **Step 1: 컨테이너 패딩·divider 정리**
+
+```scss
+&__content {
+  width: 100%;
+  max-width: 1200px;
+  display: flex;
+  flex-direction: column;
+  margin: 0 auto;
+  gap: 24px;
+  padding: 24px 32px 64px;
+  border-top: 1px solid var(--vapor-gray-300);
+
+  @media (max-width: 600px) {
+    padding: 24px 16px 48px;
+  }
+
+  @media (max-width: 320px) {
+    padding: 24px 16px 40px;
+    gap: 20px;
+  }
+}
+```
+
+- [ ] **Step 2: `.content-description` 블록 — 본문 텍스트 토큰화**
+
+```scss
+.content-description {
+  color: var(--vapor-gray-900);
+  line-height: 1.6;
+  max-width: none;
+
+  p {
+    margin: 0 0 16px 0;
+    font-weight: 400;
+    font-size: 16px;
+    line-height: 1.5;
+
+    @media (max-width: 320px) {
+      font-size: 15px;
+    }
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    color: var(--vapor-gray-900);
+    margin: 32px 0 16px 0;
+    font-weight: 700;
+    letter-spacing: -0.012rem;
+    line-height: 1.3;
+
+    &:first-child {
+      margin-top: 0;
+    }
+  }
+
+  h1 { font-size: 32px; @media (max-width: 320px) { font-size: 26px; } }
+  h2 { font-size: 24px; @media (max-width: 320px) { font-size: 22px; } }
+  h3 { font-size: 20px; @media (max-width: 320px) { font-size: 18px; } }
+  h4 { font-size: 18px; @media (max-width: 320px) { font-size: 16px; } }
+  h5 { font-size: 16px; @media (max-width: 320px) { font-size: 15px; } }
+  h6 { font-size: 14px; @media (max-width: 320px) { font-size: 13px; } }
+
+  hr {
+    margin: 32px 0;
+    border: none;
+    border-top: 1px solid var(--vapor-gray-300);
+
+    @media (max-width: 320px) {
+      margin: 24px 0;
+    }
+  }
+
+  ul, ol {
+    margin: 16px 0;
+    padding-left: 24px;
+
+    li {
+      margin: 8px 0;
+      font-size: 16px;
+      line-height: 1.6;
+      color: var(--vapor-gray-900);
+
+      @media (max-width: 320px) {
+        font-size: 15px;
+      }
+    }
+  }
+
+  img {
+    max-width: 100%;
+    height: auto;
+    margin: 24px 0;
+    border-radius: 12px;
+
+    @media (max-width: 320px) {
+      margin: 16px 0;
+    }
+  }
+
+  code {
+    background-color: var(--vapor-gray-100);
+    padding: 2px 6px;
+    border-radius: 6px;
+    font-family: 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 14px;
+    color: var(--vapor-text-danger);
+
+    @media (max-width: 320px) {
+      font-size: 13px;
+    }
+  }
+
+  pre {
+    background-color: var(--vapor-gray-100);
+    padding: 16px;
+    border-radius: 12px;
+    overflow-x: auto;
+    margin: 24px 0;
+
+    @media (max-width: 320px) {
+      padding: 12px;
+      margin: 16px 0;
+    }
+
+    code {
+      background-color: transparent;
+      padding: 0;
+      color: var(--vapor-gray-900);
+    }
+  }
+
+  blockquote {
+    margin: 24px 0;
+    padding: 16px 20px;
+    border-left: 4px solid var(--ktb-tech-blue);
+    background-color: var(--vapor-gray-050);
+    color: var(--vapor-gray-900);
+    border-radius: 0 8px 8px 0;
+
+    @media (max-width: 320px) {
+      margin: 16px 0;
+      padding: 12px 16px;
+    }
+
+    p {
+      margin: 0;
+    }
+  }
+
+  a {
+    color: var(--ktb-tech-blue);
+    text-decoration: none;
+    transition: color 0.2s ease;
+
+    &:hover {
+      color: var(--ktb-tech-navy-hover);
+      text-decoration: underline;
+    }
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 24px 0;
+
+    @media (max-width: 320px) {
+      margin: 16px 0;
+      font-size: 14px;
+    }
+
+    th, td {
+      padding: 12px;
+      text-align: left;
+      border: 1px solid var(--vapor-gray-300);
+
+      @media (max-width: 320px) {
+        padding: 8px;
+      }
+    }
+
+    th {
+      background-color: var(--vapor-gray-100);
+      font-weight: 700;
+      color: var(--vapor-gray-900);
+    }
+
+    td {
+      color: var(--vapor-gray-900);
+    }
+
+    tr:hover {
+      background-color: var(--vapor-gray-050);
+    }
+  }
+
+  strong, b {
+    font-weight: 700;
+    color: var(--vapor-gray-900);
+  }
+
+  em, i {
+    font-style: italic;
+  }
+}
+```
+
+---
+
+## Task 9: 빈 상태(`.content-placeholder`) 재설계
+
+**의도:** description이 없을 때 보이는 안내 카드를 gray-050 + radius 24 패턴으로.
+
+**Files:**
+- Modify: `styles/EventDetail.module.scss` (`.content-placeholder` 블록)
+
+- [ ] **Step 1: 블록 교체**
+
+```scss
+.content-placeholder {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 120px;
+  background: var(--vapor-gray-050);
+  border-radius: 24px;
+  padding: 40px 20px;
+
+  @media (max-width: 320px) {
+    padding: 32px 16px;
+    border-radius: 16px;
+  }
+
+  .placeholder-message {
+    text-align: center;
+    max-width: 400px;
+
+    p {
+      margin: 0 0 8px 0;
+      font-weight: 500;
+      font-size: 15px;
+      line-height: 1.5;
+      color: var(--vapor-gray-600);
+
+      @media (max-width: 320px) {
+        font-size: 14px;
+      }
+
+      &:first-child {
+        font-weight: 700;
+        font-size: 16px;
+        color: var(--vapor-gray-900);
+        margin-bottom: 8px;
+      }
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+  }
+}
+```
+
+(기존 블록 안의 h1~h4 스타일은 placeholder 메시지가 H 태그를 쓰지 않으므로 모두 제거)
+
+---
+
+## Task 10: 빌드·시각 검증
+
+**Files:** 변경 없음 (검증만)
+
+- [ ] **Step 1: lint**
+
+Run: `pnpm lint`
+Expected: PASS (warning 무관)
+
+- [ ] **Step 2: build**
+
+Run: `pnpm build`
+Expected: 빌드 성공
+
+- [ ] **Step 3: 시각 검증** — `pnpm dev` (포트 5000) 실행 후 다음 URL을 브라우저로 확인:
+
+- `http://localhost:5000/event/detail/<진행중 행사 id>` — Today 배지, hero, 본문 마크다운
+- `http://localhost:5000/event/detail/<예정 행사 id>` — D-N 배지
+- `http://localhost:5000/event/detail/<종료 행사 id>` — dim 오버레이, 배지 없음
+- `http://localhost:5000/event/detail/<description 없는 행사 id>` — 빈 상태 카드
+
+각 뷰포트에서 깨짐 없음:
+- ≥1200: 2-column hero (400px + flex)
+- 1199~601: stacked, action 버튼 썸네일 우상단
+- ≤600: stacked + 작은 타이포
+- ≤320: 최소 폭
+
+- [ ] **Step 4: 토큰 누락 최종 확인**
+
+Run: `grep -n '#[0-9a-fA-F]\{3,6\}' styles/EventDetail.module.scss | grep -v 'rgba(\|rgb(' | grep -v '#ffffff' | grep -v '// '`
+Expected: 빈 결과 (rgba/rgb 함수 안 hex, `#fff`/`#ffffff` 흰색, 주석은 허용)
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** spec의 모든 섹션(Hero desktop / Hero mobile / Content / 빈 상태 / Token cleanup / 검증 기준)에 매칭되는 task 존재.
+- **No placeholders:** 모든 step에 구체 코드와 명령어 포함.
+- **Type consistency:** `&__image__done` / `&__image__badge` 클래스명, `isEventDone` 헬퍼명, `eventDone` 변수명이 task 6 안에서 일관.
+- **Commit policy:** 사용자 지시에 따라 commit step 제외. 작업 완료 후 사용자가 별도 요청 시 한 번에 commit.

--- a/docs/superpowers/plans/2026-05-11-event-filter-renewal.md
+++ b/docs/superpowers/plans/2026-05-11-event-filter-renewal.md
@@ -1,0 +1,1123 @@
+# Event Filter Renewal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `/events` ScheduledEventList 컨테이너(필터/검색/페이지네이션)를 DESIGN.md(KTB Vapor) 토큰·정형값으로 정렬.
+
+**Architecture:** SCSS module 8개 토큰 교체 + radius `2.9881px` → `8px` + border `1.5px` → `1px` + hover 매직값 정리. JSX 변경 없음.
+
+**Tech Stack:** Next.js 12 / SCSS modules / 기존 vapor·ktb CSS 변수.
+
+**User preferences:** 작업 중 git commit 없음. Plan 안 commit step 없음.
+
+---
+
+## File Structure
+
+**Modified files (SCSS only):**
+- `components/features/filters/EventFilter.module.scss`
+- `components/features/register/Register.module.scss`
+- `components/common/buttons/FillButton.module.scss`
+- `components/common/tag/JobGroupTag.module.scss`
+- `components/common/input/BasicInput.module.scss`
+- `components/common/dropdown/BasicDropdown.module.scss`
+- `components/common/date/DateBoard.module.scss`
+- `components/common/date/DateElement.module.scss`
+
+---
+
+## Task 1: EventFilter — 페이지 타이틀 + toggle hover
+
+**Files:** `components/features/filters/EventFilter.module.scss`
+
+- [ ] **Step 1: 페이지 타이틀 `.block__desc` 색상·letter-spacing**
+
+Find:
+```scss
+&__desc {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 40px;
+  line-height: 3rem;
+  color: var(--gray-1);
+}
+```
+
+Replace with:
+```scss
+&__desc {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 40px;
+  line-height: 3rem;
+  letter-spacing: -0.012rem;
+  color: var(--vapor-gray-900);
+}
+```
+
+- [ ] **Step 2: `.filter__group__toggle` hover bg — 3 군데 일괄**
+
+`replace_all` 가능. Edit 도구 `replace_all: true` 로 다음 치환:
+
+Old:
+```scss
+background-color: var(--gray-5);
+```
+New:
+```scss
+background-color: var(--vapor-gray-100);
+```
+
+(라ptop 700, tablet, mobile 블록 3 곳 모두 동일 라인 — replace_all 3건)
+
+---
+
+## Task 2: FillButton — primary/gray/white 색상
+
+**Files:** `components/common/buttons/FillButton.module.scss`
+
+- [ ] **Step 1: `.button` 기본 색상**
+
+Find:
+```scss
+.button {
+  @extend %button-base;
+  color: var(--background-1);
+  background-color: var(--gray-1);
+```
+
+Replace with:
+```scss
+.button {
+  @extend %button-base;
+  color: var(--vapor-gray-000);
+  background-color: var(--vapor-gray-900);
+```
+
+- [ ] **Step 2: `&--primary` 교체**
+
+Find:
+```scss
+&--primary {
+  background-color: var(--primary);
+  font-size: 14px;
+}
+```
+
+Replace with:
+```scss
+&--primary {
+  background-color: var(--ktb-tech-blue);
+  font-size: 14px;
+}
+```
+
+- [ ] **Step 3: `&--gray` 교체**
+
+Find:
+```scss
+&--gray {
+  background-color: var(--gray-1);
+  font-size: 14px;
+}
+```
+
+Replace with:
+```scss
+&--gray {
+  background-color: var(--vapor-gray-900);
+  font-size: 14px;
+}
+```
+
+- [ ] **Step 4: `&--white` 교체**
+
+Find:
+```scss
+&--white {
+  background-color: var(--background-1);
+  color: var(--primary);
+  font-size: 14px;
+}
+```
+
+Replace with:
+```scss
+&--white {
+  background-color: var(--vapor-gray-000);
+  color: var(--ktb-tech-blue);
+  font-size: 14px;
+}
+```
+
+---
+
+## Task 3: Register — hover shadow
+
+**Files:** `components/features/register/Register.module.scss`
+
+- [ ] **Step 1: hover shadow 교체**
+
+Find:
+```scss
+&:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(44, 76, 239, 0.2);
+}
+```
+
+Replace with:
+```scss
+&:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 67, 255, 0.18);
+}
+```
+
+---
+
+## Task 4: JobGroupTag — base + hover + active
+
+**Files:** `components/common/tag/JobGroupTag.module.scss`
+
+- [ ] **Step 1: Base `.tag` 토큰**
+
+Find:
+```scss
+.tag {
+  min-width: 40px;
+  padding-right: 16px;
+  padding-left: 16px;
+  height: 36px;
+  font-weight: 500;
+  color: var(--gray-1);
+  border: 1px solid;
+  border-color: var(--gray-4);
+  border-radius: 25px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-right: 10px;
+  margin-top: 10px;
+}
+```
+
+Replace with:
+```scss
+.tag {
+  min-width: 40px;
+  padding-right: 16px;
+  padding-left: 16px;
+  height: 36px;
+  font-weight: 500;
+  color: var(--vapor-gray-800);
+  border: 1px solid;
+  border-color: var(--vapor-gray-300);
+  border-radius: 25px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-right: 10px;
+  margin-top: 10px;
+}
+```
+
+- [ ] **Step 2: `.tag--light` hover**
+
+Find:
+```scss
+.tag--light {
+  &:hover {
+    border-color: var(--primary);
+    color: var(--primary);
+    background-color: rgba(237, 239, 255, 1);
+    cursor: pointer;
+  }
+}
+```
+
+Replace with:
+```scss
+.tag--light {
+  &:hover {
+    border-color: var(--ktb-tech-blue);
+    color: var(--ktb-tech-blue);
+    background-color: rgba(0, 67, 255, 0.08);
+    cursor: pointer;
+  }
+}
+```
+
+- [ ] **Step 3: `.tag--dark` hover**
+
+Find:
+```scss
+.tag--dark {
+  &:hover {
+    border-color: var(--primary);
+    color: var(--primary);
+    background-color: rgba(34, 35, 38, 1);
+    cursor: pointer;
+  }
+}
+```
+
+Replace with:
+```scss
+.tag--dark {
+  &:hover {
+    border-color: var(--ktb-tech-blue);
+    color: var(--ktb-tech-blue);
+    background-color: var(--vapor-gray-950);
+    cursor: pointer;
+  }
+}
+```
+
+- [ ] **Step 4: `.checked--light` active**
+
+Find:
+```scss
+.checked--light {
+  border-color: rgba(44, 76, 239, 1);
+  color: rgba(44, 76, 239, 1);
+  background-color: #edefff;
+}
+```
+
+Replace with:
+```scss
+.checked--light {
+  border-color: var(--ktb-tech-blue);
+  color: var(--ktb-tech-blue);
+  background-color: rgba(0, 67, 255, 0.08);
+}
+```
+
+- [ ] **Step 5: `.checked--dark` active**
+
+Find:
+```scss
+.checked--dark {
+  border-color: rgba(79, 108, 255, 1);
+  color: rgba(79, 108, 255, 1);
+  background-color: rgba(34, 35, 38, 1);
+}
+```
+
+Replace with:
+```scss
+.checked--dark {
+  border-color: var(--ktb-tech-blue);
+  color: var(--ktb-tech-blue);
+  background-color: var(--vapor-gray-950);
+}
+```
+
+---
+
+## Task 5: BasicInput — radius/border/color
+
+**Files:** `components/common/input/BasicInput.module.scss`
+
+- [ ] **Step 1: `.container__input` 교체**
+
+Find:
+```scss
+&__input {
+  width: 100%;
+  height: 100%;
+  outline: none;
+  background-color: var(--background-1);
+  border: 1.5px solid;
+  border-color: var(--gray-4);
+  border-radius: 2.9881px;
+  box-sizing: border-box;
+  &:hover {
+    border-color: rgba(170, 184, 255, 1);
+  }
+  &:focus {
+    border-color: var(--primary);
+  }
+}
+```
+
+Replace with:
+```scss
+&__input {
+  width: 100%;
+  height: 100%;
+  outline: none;
+  background-color: var(--vapor-gray-000);
+  border: 1px solid;
+  border-color: var(--vapor-gray-300);
+  border-radius: 8px;
+  box-sizing: border-box;
+  &:hover {
+    border-color: var(--vapor-gray-400);
+  }
+  &:focus {
+    border-color: var(--ktb-tech-blue);
+  }
+}
+```
+
+- [ ] **Step 2: input text color**
+
+Find:
+```scss
+input[type='text'] {
+  padding-left: 55px;
+  color: var(--gray-1);
+}
+```
+
+Replace with:
+```scss
+input[type='text'] {
+  padding-left: 55px;
+  color: var(--vapor-gray-900);
+}
+```
+
+- [ ] **Step 3: placeholder 교체 (중복 `font-weight` 정리)**
+
+Find:
+```scss
+input::-webkit-input-placeholder {
+  font-weight: bold;
+  color: var(--gray-3);
+  font-weight: 500;
+}
+```
+
+Replace with:
+```scss
+input::-webkit-input-placeholder {
+  color: var(--vapor-gray-500);
+  font-weight: 500;
+}
+```
+
+---
+
+## Task 6: BasicDropdown — radius/border/color/hover
+
+**Files:** `components/common/dropdown/BasicDropdown.module.scss`
+
+- [ ] **Step 1: `.dropdown__header` 교체**
+
+Find:
+```scss
+&__header {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  height: 40px;
+  padding: 0 1.125rem 0 1.125rem;
+  font-size: 1rem;
+  color: var(--gray-1);
+  font-weight: 400;
+  cursor: pointer;
+  background-color: var(--background-1);
+  border: 1.5px solid;
+  border-color: var(--gray-4);
+  box-sizing: border-box;
+  border-radius: 2.9881px;
+  &:hover {
+    border-color: rgba(170, 184, 255, 1);
+  }
+}
+```
+
+Replace with:
+```scss
+&__header {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  height: 40px;
+  padding: 0 1.125rem 0 1.125rem;
+  font-size: 1rem;
+  color: var(--vapor-gray-900);
+  font-weight: 400;
+  cursor: pointer;
+  background-color: var(--vapor-gray-000);
+  border: 1px solid;
+  border-color: var(--vapor-gray-300);
+  box-sizing: border-box;
+  border-radius: 8px;
+  &:hover {
+    border-color: var(--vapor-gray-400);
+  }
+}
+```
+
+- [ ] **Step 2: `.dropdown__list` 교체 (shadow 추가)**
+
+Find:
+```scss
+&__list {
+  width: 100%;
+  position: absolute;
+  top: 40px;
+  left: 0;
+  animation-name: appearIn;
+  animation-duration: 0.2s;
+  animation-timing-function: linear;
+  max-height: 12rem;
+  background-color: var(--background-1);
+  border-radius: 2.9881px;
+  border: 1.5px solid;
+  border-color: var(--gray-4);
+  z-index: 50;
+  overflow-y: scroll;
+```
+
+Replace with:
+```scss
+&__list {
+  width: 100%;
+  position: absolute;
+  top: 40px;
+  left: 0;
+  animation-name: appearIn;
+  animation-duration: 0.2s;
+  animation-timing-function: linear;
+  max-height: 12rem;
+  background-color: var(--vapor-gray-000);
+  border-radius: 8px;
+  border: 1px solid;
+  border-color: var(--vapor-gray-300);
+  box-shadow: 0 8px 24px rgba(0, 0, 64, 0.08);
+  z-index: 50;
+  overflow-y: scroll;
+```
+
+- [ ] **Step 3: `&__element` hover + color**
+
+Find:
+```scss
+&__element {
+  display: flex;
+  justify-content: flex-start;
+  padding-left: 1rem;
+  align-items: center;
+  width: 100%;
+  height: 2.5rem;
+  color: var(--gray-1);
+
+  &:hover {
+    cursor: pointer;
+    background-color: var(--background-2);
+  }
+}
+```
+
+Replace with:
+```scss
+&__element {
+  display: flex;
+  justify-content: flex-start;
+  padding-left: 1rem;
+  align-items: center;
+  width: 100%;
+  height: 2.5rem;
+  color: var(--vapor-gray-900);
+
+  &:hover {
+    cursor: pointer;
+    background-color: var(--vapor-gray-050);
+  }
+}
+```
+
+- [ ] **Step 4: `.selected__light` 교체**
+
+Find:
+```scss
+.selected__light {
+  font-weight: 700;
+  color: var(--primary);
+  background-color: rgba(237, 239, 255, 1);
+}
+```
+
+Replace with:
+```scss
+.selected__light {
+  font-weight: 700;
+  color: var(--ktb-tech-blue);
+  background-color: rgba(0, 67, 255, 0.08);
+}
+```
+
+- [ ] **Step 5: `.selected__dark` 교체**
+
+Find:
+```scss
+.selected__dark {
+  font-weight: 700;
+  color: var(--primary);
+  background-color: rgba(34, 35, 38, 1);
+}
+```
+
+Replace with:
+```scss
+.selected__dark {
+  font-weight: 700;
+  color: var(--ktb-tech-blue);
+  background-color: var(--vapor-gray-950);
+}
+```
+
+- [ ] **Step 6: scrollbar thumb + focus 교체**
+
+Find:
+```scss
+&::-webkit-scrollbar-thumb {
+  width: 5px;
+  border-radius: 4px;
+  background-color: #c4c4c4;
+}
+```
+
+Replace with:
+```scss
+&::-webkit-scrollbar-thumb {
+  width: 5px;
+  border-radius: 4px;
+  background-color: var(--vapor-gray-400);
+}
+```
+
+Find:
+```scss
+.dropdown__header__focus {
+  border-color: var(--primary);
+}
+```
+
+Replace with:
+```scss
+.dropdown__header__focus {
+  border-color: var(--ktb-tech-blue);
+}
+```
+
+---
+
+## Task 7: DateBoard — pagination container
+
+**Files:** `components/common/date/DateBoard.module.scss`
+
+- [ ] **Step 1: `.container` 교체**
+
+Find:
+```scss
+.container {
+  position: relative;
+  width: 100%;
+  min-width: 14rem;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background-color: var(--background-1);
+  border: 1.5px solid;
+  border-color: var(--gray-4);
+  border-radius: 2.9881px;
+
+  &:hover {
+    border-color: rgba(170, 184, 255, 1);
+  }
+```
+
+Replace with:
+```scss
+.container {
+  position: relative;
+  width: 100%;
+  min-width: 14rem;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background-color: var(--vapor-gray-000);
+  border: 1px solid;
+  border-color: var(--vapor-gray-300);
+  border-radius: 8px;
+
+  &:hover {
+    border-color: var(--vapor-gray-400);
+  }
+```
+
+- [ ] **Step 2: `.key--active` hover bg**
+
+Find:
+```scss
+.key--active {
+  min-width: 3rem;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition: all 0.1s linear;
+  &:hover {
+    cursor: pointer;
+    background-color: var(--background-2);
+  }
+}
+```
+
+Replace with:
+```scss
+.key--active {
+  min-width: 3rem;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition: all 0.1s linear;
+  &:hover {
+    cursor: pointer;
+    background-color: var(--vapor-gray-050);
+  }
+}
+```
+
+- [ ] **Step 3: `.key--left` / `.key--right` radius**
+
+Find:
+```scss
+.key--left {
+  border-radius: 2.9881px 0 0 2.9881px;
+}
+
+.key--right {
+  border-radius: 0 2.9881px 2.9881px 0;
+}
+```
+
+Replace with:
+```scss
+.key--left {
+  border-radius: 8px 0 0 8px;
+}
+
+.key--right {
+  border-radius: 0 8px 8px 0;
+}
+```
+
+- [ ] **Step 4: `.dropdown__header` color**
+
+Find:
+```scss
+&__header {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  font-size: 1rem;
+  color: var(--gray-1);
+  font-weight: 400;
+  cursor: pointer;
+}
+```
+
+Replace with:
+```scss
+&__header {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  font-size: 1rem;
+  color: var(--vapor-gray-900);
+  font-weight: 400;
+  cursor: pointer;
+}
+```
+
+- [ ] **Step 5: `.dropdown__list` 교체 (shadow 추가)**
+
+Find:
+```scss
+&__list {
+  width: 14rem;
+  height: 265px;
+  position: absolute;
+  left: 50%;
+  top: 40px;
+  transform: translateX(-50%);
+  overflow: hidden;
+  animation-name: appearIn;
+  animation-duration: 0.2s;
+  animation-timing-function: linear;
+  background-color: var(--background-1);
+  border-radius: 2.9881px;
+  border: 1.5px solid;
+  border-color: var(--gray-4);
+  z-index: 50;
+```
+
+Replace with:
+```scss
+&__list {
+  width: 14rem;
+  height: 265px;
+  position: absolute;
+  left: 50%;
+  top: 40px;
+  transform: translateX(-50%);
+  overflow: hidden;
+  animation-name: appearIn;
+  animation-duration: 0.2s;
+  animation-timing-function: linear;
+  background-color: var(--vapor-gray-000);
+  border-radius: 8px;
+  border: 1px solid;
+  border-color: var(--vapor-gray-300);
+  box-shadow: 0 8px 24px rgba(0, 0, 64, 0.08);
+  z-index: 50;
+```
+
+- [ ] **Step 6: `&__year` color**
+
+Find:
+```scss
+&__year {
+  width: 100%;
+  height: 50px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: var(--gray-1);
+```
+
+Replace with:
+```scss
+&__year {
+  width: 100%;
+  height: 50px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: var(--vapor-gray-900);
+```
+
+- [ ] **Step 7: `.container__focus`**
+
+Find:
+```scss
+.container__focus {
+  border-color: var(--primary);
+  &:hover {
+    border-color: var(--primary);
+  }
+}
+```
+
+Replace with:
+```scss
+.container__focus {
+  border-color: var(--ktb-tech-blue);
+  &:hover {
+    border-color: var(--ktb-tech-blue);
+  }
+}
+```
+
+---
+
+## Task 8: DateElement — pagination elements
+
+**Files:** `components/common/date/DateElement.module.scss`
+
+- [ ] **Step 1: `.date__element` 데스크탑 교체**
+
+Find:
+```scss
+&__element {
+  width: 52px;
+  height: 3rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 25px;
+  font-size: 14px;
+  font-weight: 500;
+  margin: 5px;
+  border: 1px solid;
+  color: var(--gray-1);
+  border-color: var(--gray-4);
+
+  &:hover {
+    cursor: pointer;
+    background-color: var(--background-2);
+  }
+}
+```
+
+Replace with:
+```scss
+&__element {
+  width: 52px;
+  height: 3rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 25px;
+  font-size: 14px;
+  font-weight: 500;
+  margin: 5px;
+  border: 1px solid;
+  color: var(--vapor-gray-900);
+  border-color: var(--vapor-gray-300);
+
+  &:hover {
+    cursor: pointer;
+    background-color: var(--vapor-gray-050);
+  }
+}
+```
+
+- [ ] **Step 2: `.date__invalid` 교체**
+
+Find:
+```scss
+&__invalid {
+  user-select: none;
+  color: var(--gray-5);
+  border-color: var(--gray-5);
+  background-color: transparent;
+  &:hover {
+    cursor: auto;
+    background-color: transparent;
+  }
+}
+```
+
+Replace with:
+```scss
+&__invalid {
+  user-select: none;
+  color: var(--vapor-gray-400);
+  border-color: var(--vapor-gray-200);
+  background-color: transparent;
+  &:hover {
+    cursor: auto;
+    background-color: transparent;
+  }
+}
+```
+
+- [ ] **Step 3: `.light--selected` 데스크탑**
+
+Find:
+```scss
+.light--selected {
+  border-color: var(--primary);
+  background-color: rgba(237, 239, 255, 1);
+  color: var(--primary);
+}
+```
+
+Replace with:
+```scss
+.light--selected {
+  border-color: var(--ktb-tech-blue);
+  background-color: rgba(0, 67, 255, 0.08);
+  color: var(--ktb-tech-blue);
+}
+```
+
+- [ ] **Step 4: `.dark--selected` 데스크탑**
+
+Find:
+```scss
+.dark--selected {
+  border-color: var(--primary);
+  background-color: rgba(34, 35, 38, 1);
+  color: var(--primary);
+}
+```
+
+Replace with:
+```scss
+.dark--selected {
+  border-color: var(--ktb-tech-blue);
+  background-color: var(--vapor-gray-950);
+  color: var(--ktb-tech-blue);
+}
+```
+
+- [ ] **Step 5: tablet `&__element` 블록 교체 (동일 매핑)**
+
+Find (tablet 미디어 내부):
+```scss
+&__element {
+  width: 68px;
+  height: 36px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 25px;
+  font-size: 14px;
+  font-weight: 500;
+  margin: 5px;
+  border: 1px solid;
+  color: var(--gray-1);
+  border-color: var(--gray-4);
+
+  &:hover {
+    cursor: pointer;
+    background-color: var(--background-2);
+  }
+}
+```
+
+Replace with:
+```scss
+&__element {
+  width: 68px;
+  height: 36px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 25px;
+  font-size: 14px;
+  font-weight: 500;
+  margin: 5px;
+  border: 1px solid;
+  color: var(--vapor-gray-900);
+  border-color: var(--vapor-gray-300);
+
+  &:hover {
+    cursor: pointer;
+    background-color: var(--vapor-gray-050);
+  }
+}
+```
+
+- [ ] **Step 6: tablet `&__invalid` 블록 교체**
+
+Find (tablet 미디어 내부):
+```scss
+&__invalid {
+  user-select: none;
+  color: var(--gray-5);
+  border-color: var(--gray-5);
+  background-color: transparent;
+  &:hover {
+    cursor: auto;
+    background-color: transparent;
+  }
+}
+```
+
+Replace with:
+```scss
+&__invalid {
+  user-select: none;
+  color: var(--vapor-gray-400);
+  border-color: var(--vapor-gray-200);
+  background-color: transparent;
+  &:hover {
+    cursor: auto;
+    background-color: transparent;
+  }
+}
+```
+
+- [ ] **Step 7: tablet `.light--selected` / `.dark--selected` 교체**
+
+Find (tablet 미디어 내부):
+```scss
+.light--selected {
+  border-color: var(--primary);
+  background-color: rgba(237, 239, 255, 1);
+  color: var(--primary);
+}
+
+.dark--selected {
+  border-color: var(--primary);
+  background-color: rgba(34, 35, 38, 1);
+  color: var(--primary);
+}
+```
+
+Replace with:
+```scss
+.light--selected {
+  border-color: var(--ktb-tech-blue);
+  background-color: rgba(0, 67, 255, 0.08);
+  color: var(--ktb-tech-blue);
+}
+
+.dark--selected {
+  border-color: var(--ktb-tech-blue);
+  background-color: var(--vapor-gray-950);
+  color: var(--ktb-tech-blue);
+}
+```
+
+---
+
+## Task 9: 빌드·토큰 검증
+
+**Files:** 변경 없음 (검증만)
+
+- [ ] **Step 1: 잔여 매직값 / legacy 토큰 검증**
+
+Run:
+```bash
+grep -nE '2\.9881px|1\.5px solid|var\(--gray-[0-9]\)|var\(--background-[0-9]\)|var\(--primary\)|var\(--text-1\)|rgba\(170,\s*184,\s*255' \
+  components/features/filters/EventFilter.module.scss \
+  components/features/register/Register.module.scss \
+  components/common/buttons/FillButton.module.scss \
+  components/common/tag/JobGroupTag.module.scss \
+  components/common/input/BasicInput.module.scss \
+  components/common/dropdown/BasicDropdown.module.scss \
+  components/common/date/DateBoard.module.scss \
+  components/common/date/DateElement.module.scss
+```
+
+Expected: 결과 비어있어야 함.
+
+- [ ] **Step 2: lint**
+
+Run: `cd /Users/user/Desktop/dev-lab/Dev-Event-Web-Brave-People && pnpm lint`
+Expected: PASS (warning 무관)
+
+- [ ] **Step 3: build**
+
+Run: `cd /Users/user/Desktop/dev-lab/Dev-Event-Web-Brave-People && pnpm build`
+Expected: 빌드 성공
+
+- [ ] **Step 4: 시각 검증** — `pnpm dev` (포트 5000) 실행 후 브라우저로 `/events` 확인:
+
+- 페이지 타이틀 "전체 행사" gray-900 + letter-spacing 적용
+- 카테고리 칩 hover/active 시 ktb-tech-blue + 8% tint 배경
+- 검색바 focus 시 ktb-tech-blue 1px border
+- 드롭다운 3종 (행사 유형, 참여 방법, 비용): 닫힘 1px gray-300, 열림 ktb-tech-blue, 항목 hover gray-050
+- 〈 전체 〉 페이지네이션: 8px radius, 1px border, gray-400 hover
+- "+ 행사 등록 요청" 버튼: ktb-tech-blue 배경, hover 부드러운 lift + 톤다운 그림자
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** spec의 모든 섹션(EventFilter / FillButton / Register / JobGroupTag / BasicInput / BasicDropdown / DateBoard / DateElement)에 매칭되는 task 존재.
+- **No placeholders:** 모든 step에 구체 SCSS 코드와 명령어 포함.
+- **Type consistency:** 토큰 이름 일관 (`--vapor-gray-*`, `--ktb-tech-blue`), 매직값 → 표준값 (`2.9881px` → `8px`, `1.5px` → `1px`) 모든 task에서 동일.
+- **Commit policy:** commit step 제외.

--- a/docs/superpowers/plans/2026-05-11-events-card-renewal.md
+++ b/docs/superpowers/plans/2026-05-11-events-card-renewal.md
@@ -1,0 +1,1166 @@
+# Events Card Renewal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reskin `Item` card on `/events` (and reuse pages) to match the KTB course-card pattern in `DESIGN.md` — responsive hybrid (horizontal row ≥1200px, vertical KTB card <1200px), unified status badge system, Vapor token alignment.
+
+**Architecture:** Surgical CSS+JSX refactor. (1) Extend SCSS theme with KTB tokens via CSS custom properties so existing `var(--*)` consumers pick them up. (2) Replace `EndBulletIcon`/`NewBulletIcon` flag JSX with a single status badge derived from `isDone` + D-Day buckets (reuse `DdayTag`'s existing classification logic). (3) Rewrite `Item.module.scss` — desktop horizontal grid with 5/3 thumb at 12px radius, mobile vertical course-card with 5/3 thumb on top. (4) Conditionally hide `DdayTag` on mobile-urgent state since the badge already encodes it. No data model / API changes.
+
+**Tech Stack:** Next 12, React 17, SCSS modules, Pretendard Variable, classnames, no automated test infra — visual verification via `pnpm dev`.
+
+**Spec:** `docs/superpowers/specs/2026-05-11-events-card-renewal-design.md`
+**Reference:** `DESIGN.md`, visual mockups at `.superpowers/brainstorm/99710-1778482665/content/card-direction-v3.html`
+
+---
+
+## File Structure
+
+| File | Role | Type |
+|---|---|---|
+| `styles/_color.scss` | Add KTB brand tokens + Vapor gray ramp as SCSS variables | Modify |
+| `styles/Theme.scss` | Expose new tokens as CSS custom properties (`--ktb-tech-blue`, `--gray-100…900`, `--text-danger`, etc.) | Modify |
+| `components/common/item/Item.tsx` | Replace flag icons with status badge; render organizer + calendar-icon meta line; conditionally hide DdayTag on mobile-urgent | Modify |
+| `components/common/item/Item.module.scss` | Full rewrite for new layout (desktop row + mobile vertical card), pulse keyframes, status badge variants | Modify |
+| `components/common/tag/FilterTag.module.scss` | Chip token alignment (gray-100 bg, gray-800 text, 8px/6px radius, 12-13px font) | Modify |
+| `components/common/tag/DdayTag.module.scss` | Token alignment (gray ramp instead of legacy `--gray-2`), pill radius | Modify |
+| `components/icons/index.ts` (or wherever) | (Reference only — no change; we use inline SVG) | — |
+
+**Files NOT touched (per spec §10):** `pages/events.tsx`, `pages/event/detail/[eventId].tsx`, Banner, Letter, EventFilter, modals, layout components, model/event, API hooks, dateUtil.
+
+---
+
+## Pre-flight: Branch + Dev Server
+
+- [ ] **Step 0.1: Confirm branch / decide branching strategy**
+
+Current branch is `release/2.3.0`. Confirm with user whether to:
+- Work directly on `release/2.3.0` (one of many in-flight features)
+- Create `feature/events-card-renewal` off `main` and PR back
+
+If branching: `git checkout main && git pull && git checkout -b feature/events-card-renewal`. **Default assumption:** stay on `release/2.3.0` unless user says otherwise.
+
+- [ ] **Step 0.2: Start dev server in background and confirm running**
+
+```bash
+pnpm install   # if node_modules out of date
+pnpm run dev
+```
+
+Expected: server on `http://localhost:5000`. Keep this running across all tasks. Open `/events` in browser.
+
+---
+
+## Task 1: Extend SCSS theme with KTB + Vapor tokens
+
+**Files:**
+- Modify: `styles/_color.scss`
+- Modify: `styles/Theme.scss`
+
+**Rationale:** The existing theme exposes only a thin token set (`--primary`, `--gray-1…5`, `--background-1/2`). DESIGN.md demands a richer ramp (gray-100…900, text-danger, ktb-tech-blue/navy). Adding these as CSS custom properties means downstream SCSS modules just consume `var(--*)`.
+
+- [ ] **Step 1.1: Add KTB + Vapor SCSS variables to `_color.scss`**
+
+Append the following block to the end of `styles/_color.scss`:
+
+```scss
+// ========================================
+// KTB / Vapor design tokens (DESIGN.md)
+// ========================================
+
+// KTB brand
+$ktb-tech-blue: #0043ff;
+$ktb-tech-navy: #000040;
+$ktb-tech-navy-hover: #0238D1;
+$ktb-tech-sky: #78CDFF;
+
+// Vapor gray ramp
+$vapor-gray-000: #ffffff;
+$vapor-gray-050: #F7F7FA;
+$vapor-gray-100: #F0F0F5;
+$vapor-gray-200: #E8E8EE;
+$vapor-gray-300: #E1E1E8;
+$vapor-gray-400: #CDCED6;
+$vapor-gray-500: #8C8F9F;
+$vapor-gray-600: #6C6E7E;
+$vapor-gray-700: #525463;
+$vapor-gray-800: #3E404C;
+$vapor-gray-900: #2B2D36;
+$vapor-gray-950: #252730;
+
+// Semantic
+$vapor-text-danger: #D91C29;
+$vapor-text-success: #08785E;
+$vapor-text-warning: #B45209;
+$vapor-text-primary: #1D6CE0;
+```
+
+- [ ] **Step 1.2: Expose tokens as CSS custom properties in `Theme.scss`**
+
+Add these custom properties inside both `html[data-theme='light']` and `html[data-theme='dark']` blocks of `styles/Theme.scss`. For dark theme, swap the gray ramp values (lighter → darker, darker → lighter) so the same `var(--*)` works in both themes.
+
+Append inside `html[data-theme='light']`:
+
+```scss
+  // KTB brand
+  --ktb-tech-blue: #{$ktb-tech-blue};
+  --ktb-tech-navy: #{$ktb-tech-navy};
+  --ktb-tech-navy-hover: #{$ktb-tech-navy-hover};
+  --ktb-tech-sky: #{$ktb-tech-sky};
+
+  // Vapor gray ramp (light theme: 000 = white → 950 = near-black)
+  --vapor-gray-000: #{$vapor-gray-000};
+  --vapor-gray-050: #{$vapor-gray-050};
+  --vapor-gray-100: #{$vapor-gray-100};
+  --vapor-gray-200: #{$vapor-gray-200};
+  --vapor-gray-300: #{$vapor-gray-300};
+  --vapor-gray-400: #{$vapor-gray-400};
+  --vapor-gray-500: #{$vapor-gray-500};
+  --vapor-gray-600: #{$vapor-gray-600};
+  --vapor-gray-700: #{$vapor-gray-700};
+  --vapor-gray-800: #{$vapor-gray-800};
+  --vapor-gray-900: #{$vapor-gray-900};
+  --vapor-gray-950: #{$vapor-gray-950};
+
+  // Semantic
+  --vapor-text-danger: #{$vapor-text-danger};
+  --vapor-text-success: #{$vapor-text-success};
+  --vapor-text-warning: #{$vapor-text-warning};
+  --vapor-text-primary: #{$vapor-text-primary};
+```
+
+Append inside `html[data-theme='dark']` (inverted gray ramp for dark mode — body text becomes light):
+
+```scss
+  // KTB brand (same hex in dark — saturated blue still reads on dark)
+  --ktb-tech-blue: #{$ktb-tech-blue};
+  --ktb-tech-navy: #{$ktb-tech-navy};
+  --ktb-tech-navy-hover: #{$ktb-tech-navy-hover};
+  --ktb-tech-sky: #{$ktb-tech-sky};
+
+  // Vapor gray ramp (dark theme: 000 = near-black bg → 950 = white text)
+  --vapor-gray-000: #{$vapor-gray-950};
+  --vapor-gray-050: #{$vapor-gray-900};
+  --vapor-gray-100: #{$vapor-gray-800};
+  --vapor-gray-200: #{$vapor-gray-700};
+  --vapor-gray-300: #{$vapor-gray-700};
+  --vapor-gray-400: #{$vapor-gray-500};
+  --vapor-gray-500: #{$vapor-gray-400};
+  --vapor-gray-600: #{$vapor-gray-300};
+  --vapor-gray-700: #{$vapor-gray-200};
+  --vapor-gray-800: #{$vapor-gray-100};
+  --vapor-gray-900: #{$vapor-gray-050};
+  --vapor-gray-950: #{$vapor-gray-000};
+
+  // Semantic
+  --vapor-text-danger: #{$vapor-text-danger};
+  --vapor-text-success: #{$vapor-text-success};
+  --vapor-text-warning: #{$vapor-text-warning};
+  --vapor-text-primary: #{$vapor-text-primary};
+```
+
+- [ ] **Step 1.3: Verify SCSS compiles and dev server has no errors**
+
+Check terminal where `pnpm dev` is running. Expected: no SCSS compile errors. Hot-reload should re-render `/events` with no visible change yet (tokens declared but not consumed).
+
+If error: read the SCSS error message and fix the offending line. Common pitfall: missing `;` or wrong variable interpolation `#{$var}`.
+
+- [ ] **Step 1.4: Commit**
+
+```bash
+git add styles/_color.scss styles/Theme.scss
+git commit -m "feat(design): add KTB + Vapor design tokens to theme
+
+Expose KTB brand colors (tech-blue, tech-navy, tech-navy-hover, tech-sky) and
+the full Vapor gray ramp (000-950) + semantic colors (danger/success/warning/
+primary) as CSS custom properties on both light and dark theme roots. Prepares
+for Item card renewal per DESIGN.md."
+```
+
+---
+
+## Task 2: Add Item status helper + integrate badge state
+
+**Files:**
+- Modify: `components/common/item/Item.tsx`
+
+**Rationale:** Status badge has 4 variants (`live`, `urgent`, `upcoming`, `ended`). We derive the variant from existing `isDone` + D-Day classification (`DdayTag` already buckets D-Day; we inline the same logic here to avoid passing computed state). Steps 2-3 do the JSX side; Step 4-5 the CSS side.
+
+- [ ] **Step 2.1: Add `EventStatus` type + `getEventStatus` helper inside Item.tsx**
+
+In `components/common/item/Item.tsx`, after the `DateType` const (around line 31) and before the `Props` type, add:
+
+```tsx
+type EventStatus = 'live' | 'urgent' | 'upcoming' | 'ended';
+
+function getEventStatus(
+  startDateTime: string,
+  endDateTime: string,
+  isDone: boolean
+): EventStatus {
+  if (isDone) return 'ended';
+  const today = DateUtil.setDateTimeToDate();
+  const start = startDateTime
+    ? DateUtil.setDateTimeToDate(startDateTime)
+    : null;
+  const end = endDateTime ? DateUtil.setDateTimeToDate(endDateTime) : null;
+  const dStart = start ? start.diff(today, 'day') : null;
+  const dEnd = end ? end.diff(today, 'day') : null;
+
+  // currently ongoing: started but not ended
+  if (dStart !== null && dEnd !== null && dStart <= 0 && dEnd >= 0) {
+    return 'live';
+  }
+  // urgent: starts within 3 days
+  if (dStart !== null && dStart > 0 && dStart <= 3) {
+    return 'urgent';
+  }
+  // upcoming: future, beyond 3 days
+  if (dStart !== null && dStart > 3) {
+    return 'upcoming';
+  }
+  // fallback (no start_date, or already past with no end) — treat as ended
+  return 'ended';
+}
+
+const STATUS_LABEL: Record<EventStatus, string> = {
+  live: '모집중',
+  urgent: '마감임박',
+  upcoming: '예정',
+  ended: '종료',
+};
+```
+
+- [ ] **Step 2.2: Add status state computation inside the Item component**
+
+In the `Item` component body, after the existing `useState` hooks (around line 56-57), add:
+
+```tsx
+const status: EventStatus = getEventStatus(
+  data.start_date_time,
+  data.end_date_time,
+  isDone
+);
+```
+
+- [ ] **Step 2.3: Verify TypeScript compiles**
+
+`pnpm dev` should hot-reload. Check the terminal where the dev server is running. Expected: no TS errors. If TS errors about `setDateTimeToDate` signature, confirm by reading `lib/utils/dateUtil.ts` and adjust calls.
+
+- [ ] **Step 2.4: Commit**
+
+```bash
+git add components/common/item/Item.tsx
+git commit -m "feat(item): add EventStatus derivation
+
+Derive a single status variant ('live' | 'urgent' | 'upcoming' | 'ended')
+from existing isDone + D-Day buckets. Used by the upcoming status badge
+that replaces the EndBulletIcon/NewBulletIcon flags."
+```
+
+---
+
+## Task 3: Replace flag icons with status badge in Item.tsx JSX
+
+**Files:**
+- Modify: `components/common/item/Item.tsx`
+
+**Rationale:** Remove the existing `EndBulletIcon` / `NewBulletIcon` flag block (around lines 159-174) and emit a single `.status-badge` span instead. Also add calendar SVG inline for the meta line. Conditionally hide `DdayTag` on mobile-urgent (badge already encodes D-Day).
+
+- [ ] **Step 3.1: Remove old icon imports**
+
+In `components/common/item/Item.tsx`, edit the icons import (lines 5-12). Remove `EndBulletIcon` and `NewBulletIcon` (no longer used). Keep `BookmarkIcon`, `BookmarkIconMobile`, `ShareIcon`, `ShareIconMobile`.
+
+Before:
+```tsx
+import {
+  BookmarkIcon,
+  BookmarkIconMobile,
+  EndBulletIcon,
+  NewBulletIcon,
+  ShareIcon,
+  ShareIconMobile,
+} from 'components/icons';
+```
+
+After:
+```tsx
+import {
+  BookmarkIcon,
+  BookmarkIconMobile,
+  ShareIcon,
+  ShareIconMobile,
+} from 'components/icons';
+```
+
+- [ ] **Step 3.2: Replace the flag JSX block with the status badge**
+
+Locate the block inside `item__content__img` (currently lines 158-174):
+
+```tsx
+{isDone && <div className={cn('item__content__img__done')} />}
+{isDone ? (
+  <div className={cn('item__content__flag')}>
+    <EndBulletIcon
+      color={'rgba(203, 203, 206, 1)'}
+      backgroundColor={'rgba(49, 50, 52, 1)'}
+    />
+  </div>
+) : null}
+{isNew ? (
+  <div className={cn('item__content__flag')}>
+    <NewBulletIcon
+      color={'rgba(203, 203, 206, 1)'}
+      backgroundColor={'rgba(44, 76, 239, 1)'}
+    />
+  </div>
+) : null}
+```
+
+Replace with:
+
+```tsx
+{isDone && <div className={cn('item__content__img__done')} />}
+<span className={cn('status-badge', `status-badge--${status}`)}>
+  {STATUS_LABEL[status]}
+</span>
+```
+
+Note: `isNew` state remains computed (used elsewhere if needed) but no longer drives a visual flag here — the status badge subsumes the "NEW" signal via the `upcoming` variant. Leave the `isNew` `useState` line and `isEventNew` prop as-is for now (out-of-scope cleanup).
+
+- [ ] **Step 3.3: Conditionally hide DdayTag on mobile (where badge encodes urgency)**
+
+In the `item__content_title__container` block (around lines 227-245), the current code unconditionally renders `<DdayTag>`. Wrap it so it only renders on desktop or when status isn't `urgent`/`ended`:
+
+Before:
+```tsx
+{isDone ? null : (
+  <DdayTag
+    startDateTime={data.start_date_time}
+    endDateTime={data.end_date_time}
+  />
+)}
+```
+
+After:
+```tsx
+{!isDone && status !== 'urgent' && (
+  <DdayTag
+    startDateTime={data.start_date_time}
+    endDateTime={data.end_date_time}
+  />
+)}
+```
+
+(Mobile-specific hiding is also handled in CSS for cases where we want the DdayTag visible on desktop but not mobile. CSS in Task 5 covers `.item__content_title__container .tag { display: none; }` under the mobile media query for urgent state. The JSX gate above is the primary mechanism — simpler.)
+
+- [ ] **Step 3.4: Replace existing meta date area with calendar-icon prefixed format**
+
+Locate the `.item__content__desc` block (around lines 247-291). The current structure shows "일시" / "접수" prefix + dates inline. Replace the prefix span with a calendar SVG icon for visual consistency with KTB course-card.
+
+Before (around lines 251-275):
+```tsx
+<span
+  className={cn(
+    isDone ? 'date__type__done' : 'date__type'
+  )}
+>
+  {data.event_time_type === 'DATE' ? '일시 ' : '접수 '}
+</span>
+```
+
+After:
+```tsx
+<svg
+  className={cn('date__icon')}
+  width="16"
+  height="16"
+  viewBox="0 0 16 16"
+  fill="currentColor"
+  xmlns="http://www.w3.org/2000/svg"
+  aria-hidden="true"
+>
+  <path d="M3.33333 14.6666C2.96667 14.6666 2.65278 14.536 2.39167 14.2749C2.13056 14.0138 2 13.6999 2 13.3333V3.99992C2 3.63325 2.13056 3.31936 2.39167 3.05825C2.65278 2.79714 2.96667 2.66659 3.33333 2.66659H4V1.99992C4 1.81103 4.06389 1.6527 4.19167 1.52492C4.31944 1.39714 4.47778 1.33325 4.66667 1.33325C4.85556 1.33325 5.01389 1.39714 5.14167 1.52492C5.26944 1.6527 5.33333 1.81103 5.33333 1.99992V2.66659H10.6667V1.99992C10.6667 1.81103 10.7306 1.6527 10.8583 1.52492C10.9861 1.39714 11.1444 1.33325 11.3333 1.33325C11.5222 1.33325 11.6806 1.39714 11.8083 1.52492C11.9361 1.6527 12 1.81103 12 1.99992V2.66659H12.6667C13.0333 2.66659 13.3472 2.79714 13.6083 3.05825C13.8694 3.31936 14 3.63325 14 3.99992V13.3333C14 13.6999 13.8694 14.0138 13.6083 14.2749C13.3472 14.536 13.0333 14.6666 12.6667 14.6666H3.33333ZM3.33333 13.3333H12.6667V6.66658H3.33333V13.3333Z" />
+</svg>
+```
+
+(The visual icon now carries the meaning "이건 일정 정보" — the `일시` / `접수` Korean prefix is replaced by an SVG glyph. If product wants the Korean word as well for accessibility, leave the span and add the icon before it. **Default decision: replace the prefix span entirely** — cleaner per DESIGN.md course-period pattern.)
+
+- [ ] **Step 3.5: Verify in browser**
+
+Refresh `http://localhost:5000/events`. Expected: cards now render with raw status badge text (e.g. "모집중", "예정") and a calendar SVG — but with **broken visual layout** until Task 4-5 CSS lands. This is expected. The goal of Step 3.5 is to confirm:
+- No React errors in console
+- No TypeScript errors in terminal
+- Status badge text actually appears in DOM (inspect element)
+- Calendar SVG renders
+- `isDone` cards have no NEW flag and no End flag (both removed)
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+git add components/common/item/Item.tsx
+git commit -m "refactor(item): replace flag icons with status badge
+
+Replaces EndBulletIcon/NewBulletIcon flags with a single .status-badge span
+driven by EventStatus. Wraps date prefix in a calendar SVG glyph to match
+KTB course-period pattern. DdayTag is conditionally hidden when status is
+'urgent' since the badge already encodes that information."
+```
+
+---
+
+## Task 4: Rewrite Item.module.scss — desktop horizontal row
+
+**Files:**
+- Modify: `components/common/item/Item.module.scss`
+
+**Rationale:** Apply DESIGN.md tokens to the existing desktop horizontal layout. Thumb sizing 280×168 (5/3 at 280px width), 12px radius, organizer 14px hint tone, title 20px/700 with 2-line clamp, calendar-prefixed meta line, chip row, status badge variants.
+
+- [ ] **Step 4.1: Replace `Item.module.scss` entirely with the desktop+pulse keyframe scaffold**
+
+Replace the **entire contents** of `components/common/item/Item.module.scss` with the following. Mobile rewrite comes in Task 5.
+
+```scss
+@import '~styles/_mixin.scss';
+@import '~styles/_variables.scss';
+@import '~styles/_common.scss';
+
+// ===== Pulse keyframes (DESIGN.md §7) — live/urgent badges only =====
+@keyframes pulse-blue {
+  0%   { box-shadow: 0 0 0 0 rgba(0, 67, 255, 0.55); }
+  70%  { box-shadow: 0 0 0 8px rgba(0, 67, 255, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(0, 67, 255, 0); }
+}
+@keyframes pulse-danger {
+  0%   { box-shadow: 0 0 0 0 rgba(217, 28, 41, 0.55); }
+  70%  { box-shadow: 0 0 0 8px rgba(217, 28, 41, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(217, 28, 41, 0); }
+}
+
+.item__container {
+  width: 100%;
+  padding: 24px 0;
+  background-color: transparent;
+  border-bottom: 1px solid var(--vapor-gray-300);
+
+  .item {
+    width: 100%;
+
+    &:hover {
+      cursor: pointer;
+    }
+
+    &__content {
+      width: 100%;
+      display: grid;
+      grid-template-columns: 280px 1fr auto;
+      gap: 32px;
+      align-items: center;
+      position: relative;
+
+      &__img {
+        width: 280px;
+        aspect-ratio: 5 / 3;
+        position: relative;
+        border-radius: 12px;
+        overflow: hidden;
+
+        &__mask {
+          border-radius: 12px;
+          overflow: hidden;
+          transition: transform $transition-duration $transition-timing;
+        }
+
+        &__done {
+          width: 100%;
+          height: 100%;
+          position: absolute;
+          left: 0;
+          top: 0;
+          background-color: rgba(0, 0, 0, 0.4);
+          overflow: hidden;
+          border-radius: 12px;
+          z-index: 1;
+        }
+      }
+
+      &__body {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        min-width: 0;
+
+        .wrap {
+          .host {
+            font-size: 14px;
+            font-weight: 500;
+            color: var(--vapor-gray-600);
+            margin-bottom: 6px;
+          }
+
+          .host__done {
+            font-size: 14px;
+            font-weight: 500;
+            color: var(--vapor-gray-500);
+            margin-bottom: 6px;
+          }
+        }
+      }
+
+      &_title__container {
+        width: 100%;
+        margin: 0 0 10px 0;
+        display: flex;
+        align-items: flex-start;
+        gap: 8px;
+      }
+
+      &__title {
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        font-weight: 700;
+        font-size: 20px;
+        line-height: 1.4;
+        letter-spacing: -0.012rem;
+        color: var(--vapor-gray-900);
+        text-align: left;
+        flex: 1;
+        word-break: keep-all;
+      }
+
+      &__title__done {
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        font-weight: 700;
+        font-size: 20px;
+        line-height: 1.4;
+        letter-spacing: -0.012rem;
+        color: var(--vapor-gray-600);
+        text-align: left;
+        flex: 1;
+        word-break: keep-all;
+      }
+
+      &__desc {
+        width: 100%;
+        font-weight: 400;
+        font-size: 15px;
+        color: var(--vapor-gray-700);
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+
+        &__tags {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 6px;
+          width: 100%;
+        }
+      }
+
+      .wrap {
+        color: var(--vapor-gray-900);
+
+        .date {
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          font-size: 15px;
+          font-weight: 500;
+          color: var(--vapor-gray-700);
+
+          &__icon {
+            flex-shrink: 0;
+            color: var(--vapor-gray-600);
+          }
+
+          &__date {
+            white-space: nowrap;
+            color: var(--vapor-gray-700);
+            font-weight: 500;
+          }
+
+          &__date__done {
+            white-space: nowrap;
+            color: var(--vapor-gray-500);
+            font-weight: 500;
+          }
+
+          &__date__mobile {
+            display: none;
+          }
+
+          &__date__done__mobile {
+            display: none;
+          }
+        }
+      }
+    }
+
+    &__buttons {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      align-self: flex-start;
+
+      .button {
+        width: 36px;
+        height: 36px;
+        border: none;
+        background-color: transparent;
+        border-radius: 8px;
+        @include flex-center;
+        color: var(--vapor-gray-500);
+
+        &:hover {
+          cursor: pointer;
+          background-color: var(--vapor-gray-100);
+        }
+      }
+
+      .laptop {
+        display: flex;
+
+        &:first-child {
+          margin-right: 2px;
+        }
+      }
+
+      .mobile {
+        display: none;
+      }
+    }
+  }
+}
+
+// ===== Status badge =====
+.status-badge {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  z-index: 2;
+  padding: 4px 10px;
+  border-radius: 9999px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #ffffff;
+  letter-spacing: 0;
+  white-space: nowrap;
+
+  &--live {
+    background-color: var(--ktb-tech-blue);
+    animation: pulse-blue 2s infinite;
+  }
+  &--urgent {
+    background-color: var(--vapor-text-danger);
+    animation: pulse-danger 2s infinite;
+  }
+  &--upcoming {
+    background-color: var(--ktb-tech-navy);
+  }
+  &--ended {
+    background-color: var(--vapor-gray-600);
+  }
+}
+
+// Mobile rewrite — Task 5 will append the @media (max-width: 1200px) block below.
+```
+
+- [ ] **Step 4.2: Visual check at desktop width (>1200px)**
+
+Open `/events` at viewport ≥1200px. Expected:
+- Thumb is 280px wide, 5/3 aspect (height 168px), rounded 12px
+- Status badge visible top-left at (12px, 12px) with correct color per variant
+- Pulse glow visible on `live` / `urgent`, plain on `upcoming` / `ended`
+- Organizer in hint tone above title
+- Title 20px/700, 2-line clamp
+- Calendar icon + date in single row (15px), tag chips below
+- Share/bookmark buttons on the right, hover bg gray-100
+- Hover on card: image scales 1.05 (existing transition)
+- Border-bottom 1px gray-300 between cards
+
+- [ ] **Step 4.3: Commit**
+
+```bash
+git add components/common/item/Item.module.scss
+git commit -m "feat(item): rewrite desktop SCSS to KTB token system
+
+- 280px × 5/3 thumb with 12px radius
+- 20px/700 2-line clamp title with -0.012rem letter-spacing
+- Calendar-icon prefixed meta line, gap 6px
+- Status badge with 4 variants (live/urgent/upcoming/ended) +
+  pulse-blue / pulse-danger keyframes for live/urgent only
+- Action buttons gray-500 with gray-100 hover bg
+- Mobile @media block to be added in next task"
+```
+
+---
+
+## Task 5: Append mobile vertical card to Item.module.scss
+
+**Files:**
+- Modify: `components/common/item/Item.module.scss`
+
+**Rationale:** Replace the current mobile `@media (max-width: 1200px)` block with a vertical KTB course-card layout — thumb on top (5/3 full-width), info below.
+
+- [ ] **Step 5.1: Append the mobile media query block**
+
+Append the following block to the end of `components/common/item/Item.module.scss` (after the `.status-badge` rules from Task 4):
+
+```scss
+// ===== Tablet / Mobile — vertical KTB course-card =====
+@media (max-width: 1200px) {
+  .item__container {
+    display: block;
+    border-bottom: none;
+    padding: 0;
+    overflow: visible;
+
+    .item__content {
+      display: block;
+      grid-template-columns: none;
+      gap: 0;
+    }
+
+    .item__content__img {
+      width: 100%;
+      aspect-ratio: 5 / 3;
+      max-height: none;
+      border-radius: 12px;
+    }
+
+    .item__content__img__mask,
+    .item__content__img__done {
+      border-radius: 12px;
+    }
+
+    .item__content__body {
+      margin-top: 12px;
+      padding: 0;
+      justify-content: inherit;
+
+      .wrap {
+        .host {
+          font-size: 13px;
+          margin-bottom: 4px;
+        }
+
+        .host__done {
+          font-size: 13px;
+          margin-bottom: 4px;
+        }
+      }
+    }
+
+    .item__content_title__container {
+      margin-bottom: 4px;
+    }
+
+    .item__content__title {
+      display: block;
+      -webkit-line-clamp: unset;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      font-size: 16px;
+      font-weight: 700;
+      line-height: 1.4;
+      letter-spacing: -0.012rem;
+      margin-right: 0;
+    }
+
+    .item__content__title__done {
+      display: block;
+      -webkit-line-clamp: unset;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      font-size: 16px;
+      font-weight: 700;
+      line-height: 1.4;
+      letter-spacing: -0.012rem;
+      margin-right: 0;
+    }
+
+    .item__content__desc {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      font-size: 14px;
+      color: var(--vapor-gray-600);
+    }
+
+    .item__content__desc__tags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px;
+      padding-top: 0;
+    }
+
+    .wrap {
+      .date {
+        font-size: 14px;
+        gap: 4px;
+        white-space: normal;
+
+        &__icon {
+          width: 16px;
+          height: 16px;
+        }
+
+        .date__date,
+        .date__date__done {
+          white-space: nowrap;
+        }
+      }
+    }
+
+    .item__buttons {
+      position: absolute;
+      top: 12px;
+      right: 12px;
+
+      .button {
+        width: 32px;
+        height: 32px;
+        background-color: rgba(255, 255, 255, 0.85);
+        backdrop-filter: blur(4px);
+
+        &:hover {
+          background-color: rgba(255, 255, 255, 1);
+        }
+      }
+
+      .laptop {
+        display: none;
+      }
+
+      .mobile {
+        display: flex;
+      }
+    }
+  }
+
+  // DdayTag inside the title container — visually de-emphasize on mobile
+  // (the status badge already encodes urgency)
+  .item__content_title__container > div:last-child:not(.item__content__title):not(.item__content__title__done) {
+    display: none;
+  }
+
+  // Status badge slightly smaller on mobile
+  .status-badge {
+    font-size: 10px;
+    padding: 3px 8px;
+  }
+}
+
+@media (max-width: 550px) {
+  .item__container {
+    max-width: inherit;
+  }
+}
+```
+
+- [ ] **Step 5.2: Visual check at multiple viewports**
+
+Use DevTools responsive mode. Verify:
+- **1199px** (just below threshold): cards flip to vertical, thumb full-width, info below
+- **768px** (tablet): same vertical layout
+- **375px** (mobile): single column, action buttons inside the thumb area with translucent white bg
+- Status badge slightly smaller (10px font, 3×8 padding)
+- Title stays single-line ellipsis, organizer above
+- Calendar-icon meta line gap 4px, font 14px
+- Tag chips wrap
+
+If grid container needs spacing between cards (the `border-bottom` was removed for mobile), confirm `List.module.scss` or parent already provides gap. If not, document as follow-up — but **don't fix in this task** (out of scope per spec §10).
+
+- [ ] **Step 5.3: Commit**
+
+```bash
+git add components/common/item/Item.module.scss
+git commit -m "feat(item): mobile vertical KTB course-card layout
+
+- Thumb full-width at 5/3 aspect, 12px radius
+- Info stack below: organizer (13px) / title (16px ellipsis) / calendar+date (14px) / chips
+- Action buttons absolutely positioned over the thumb on mobile with
+  translucent white bg + backdrop-filter
+- DdayTag hidden visually inside title container (badge encodes urgency)
+- Status badge scales down to 10px / 3px 8px padding"
+```
+
+---
+
+## Task 6: Align FilterTag chip styling with DESIGN.md
+
+**Files:**
+- Modify: `components/common/tag/FilterTag.module.scss`
+
+**Rationale:** The chip used inside `item__content__desc__tags` needs to match the DESIGN.md spec — `gray-100` bg, `gray-800` text, 8px radius (desktop) / 6px (mobile), 13/12px font, 500 weight. Current chip is `--gray-5` bg and `--gray-1` text — close, but ramp and radius are off.
+
+- [ ] **Step 6.1: Update `FilterTag.module.scss` chip rules**
+
+Replace the **entire contents** of `components/common/tag/FilterTag.module.scss` with:
+
+```scss
+@import '~styles/_mixin.scss';
+@import '~styles/_color.scss';
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  border: none;
+  color: var(--vapor-gray-800);
+  background-color: var(--vapor-gray-100);
+  cursor: pointer;
+  font-weight: 500;
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  border-radius: 8px;
+  padding: 4px 10px;
+  font-size: 13px;
+  line-height: 1.4;
+  letter-spacing: -0.012rem;
+  margin: 0;
+
+  &.size--large {
+    font-size: 13px;
+    padding: 4px 10px;
+  }
+
+  &.size--regular {
+    font-size: 13px;
+    padding: 4px 10px;
+  }
+}
+
+@include tablet {
+  .tag {
+    border-radius: 6px;
+    padding: 3px 8px;
+    font-size: 12px;
+
+    &.size--large {
+      font-size: 12px;
+      padding: 3px 8px;
+    }
+    &.size--regular {
+      font-size: 12px;
+      padding: 3px 8px;
+    }
+  }
+}
+
+@include mobile {
+  .tag {
+    border-radius: 6px;
+    padding: 2px 8px;
+    font-size: 12px;
+
+    &.size--large {
+      font-size: 12px;
+      padding: 2px 8px;
+    }
+    &.size--regular {
+      font-size: 12px;
+      padding: 2px 8px;
+    }
+  }
+}
+```
+
+(`type--location` selector existed but was unused for styling — dropped. If future variants need it, re-add.)
+
+- [ ] **Step 6.2: Visual check**
+
+Refresh `/events`. Expected:
+- Chips inside cards use light gray bg (`#F0F0F5`) and dark gray text (`#3E404C`)
+- 8px radius desktop, 6px mobile
+- 13/12px font, 500 weight
+- Compact padding (4×10 / 3×8 / 2×8)
+- Spacing between chips comes from `.item__content__desc__tags { gap: 6px / 4px }` already set in Item.module.scss — confirm no double-margin
+
+- [ ] **Step 6.3: Commit**
+
+```bash
+git add components/common/tag/FilterTag.module.scss
+git commit -m "feat(tag): align FilterTag chip with KTB Vapor tokens
+
+- bg vapor-gray-100, text vapor-gray-800
+- 8px radius desktop / 6px tablet+mobile
+- 13/12px font, 500 weight, -0.012rem letter-spacing
+- Drop unused .type--location styling"
+```
+
+---
+
+## Task 7: Align DdayTag styling with new token system
+
+**Files:**
+- Modify: `components/common/tag/DdayTag.module.scss`
+
+**Rationale:** DdayTag still uses legacy `--gray-2` / `--background-2` / `--primary`. Bring it into the new ramp and make it visually quieter so the status badge remains the urgency signal (D-Day shows only on desktop now).
+
+- [ ] **Step 7.1: Replace `DdayTag.module.scss` contents**
+
+Replace with:
+
+```scss
+@import '~styles/_mixin.scss';
+
+.tag {
+  border: none;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--vapor-gray-700);
+  background-color: var(--vapor-gray-100);
+  border-radius: 9999px;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2px 10px;
+  white-space: nowrap;
+  flex-shrink: 0;
+
+  &--bold {
+    font-weight: 600;
+    color: var(--ktb-tech-blue);
+  }
+
+  @media (max-width: 1199px) {
+    display: none; // mobile uses the status badge instead
+  }
+}
+```
+
+- [ ] **Step 7.2: Visual check**
+
+Refresh `/events`. Expected:
+- DdayTag visible on desktop only, next to title, pill-shaped gray
+- "Today" tag uses tech-blue color (`--bold` variant)
+- Hidden entirely on mobile (the JSX gate in Task 3 also hides on urgent; CSS belt-and-suspenders for non-urgent + scheduled buckets)
+
+- [ ] **Step 7.3: Commit**
+
+```bash
+git add components/common/tag/DdayTag.module.scss
+git commit -m "feat(tag): DdayTag token alignment + mobile hide
+
+- Pill shape (9999px radius), 13px / 500
+- bg vapor-gray-100, text vapor-gray-700
+- 'Today' variant uses ktb-tech-blue
+- Hidden under 1200px (status badge takes over the urgency signal)"
+```
+
+---
+
+## Task 8: Visual regression check + reused-page review
+
+**Files:**
+- No edits expected, but be ready to add narrow follow-ups if regressions surface
+
+**Rationale:** `Item.tsx` is consumed by both `/events` (ScheduledEventList / MonthlyEventList / FilteredEventList) and `/myevent` (MyEventScheduledList / MyEventDoneList). The same card design now applies to both. Confirm both pages look correct and existing functionality is intact.
+
+- [ ] **Step 8.1: Walk through `/events`**
+
+At each viewport (1400px / 1199px / 768px / 375px), confirm:
+- Cards render in all 4 status variants when seeded (manually filter by date if needed, or wait for real data with mix of states)
+- `Banner`, `Letter`, `EventFilter`, modals visually unchanged
+- Filter / search interactions still work — chip clicks, date filter, search bar
+- Bookmark / share buttons functional
+- Click on card navigates to `/event/detail/{id}`
+- Scroll loading / infinite list behavior unchanged
+
+- [ ] **Step 8.2: Walk through `/myevent` (requires login)**
+
+If logged in, navigate to `/myevent` and confirm:
+- Scheduled list shows the new vertical card on mobile / horizontal on desktop
+- Done list shows the ended-state badge + dimmed thumb overlay
+- Bookmark removal still works (it's not the card chrome — same handlers)
+
+If no login session is available locally, document as a manual smoke test in the PR description.
+
+- [ ] **Step 8.3: Walk through `/calender` and `/search`**
+
+These pages also render `List` → `Item`. Quick visual smoke:
+- `/calender`: cards in a date-grouped view
+- `/search`: cards in a filtered list
+
+Note any visual oddity. **Don't fix in this task** — file a follow-up ticket if issues arise. Scope was `/events`.
+
+- [ ] **Step 8.4: Lint check**
+
+```bash
+pnpm run lint
+```
+
+Expected: pass. If `unused-imports` or similar complains about `EndBulletIcon` / `NewBulletIcon` removal, confirm they were imported only in `Item.tsx` and the removal in Task 3.1 cleared them.
+
+- [ ] **Step 8.5: Build check**
+
+```bash
+pnpm run build
+```
+
+Expected: build succeeds. Watch for SCSS compile errors or TS type errors. If build fails, read the error and fix.
+
+- [ ] **Step 8.6: Final commit + summary**
+
+If any tiny adjustments were needed during the walk-through:
+
+```bash
+git add -A
+git commit -m "fix(item): adjustments from visual regression pass
+
+[describe specific fixes — e.g., chip gap on mobile, badge contrast]"
+```
+
+If clean (no adjustments needed), no extra commit. Just confirm:
+
+```bash
+git log --oneline -10
+```
+
+Expected: 7-8 commits from Tasks 1-7 (each task = 1 commit).
+
+---
+
+## Self-Review
+
+Coverage map vs spec sections:
+
+| Spec § | Task |
+|---|---|
+| §2 Scope (Item card only) | Tasks 1-7 only touch Item + tags + theme |
+| §4.1 Responsive (≥1200px row, <1200px vertical) | Task 4 (desktop) + Task 5 (mobile) |
+| §4.2 Horizontal row layout | Task 4 SCSS |
+| §4.3 Vertical card layout | Task 5 SCSS |
+| §4.4 Status badge (4 variants + pulse) | Task 2 (helper) + Task 3 (JSX) + Task 4 (CSS) |
+| §4.5 Ended state styling | Task 4 (`__title__done`, `__done` overlay) |
+| §4.6 D-Day handling (desktop inline, mobile via badge) | Task 3 (JSX gate) + Task 5 (CSS hide) + Task 7 (token align) |
+| §5 Component contract / `EventStatus` | Task 2 |
+| §6 Files Touched | All 7 tasks |
+| §7 Edge cases (organizer null, no tags, long title, no date) | Existing JSX already handles; documented in Task 2 helper (null guards on dStart/dEnd) |
+| §8 Testing plan (manual) | Task 8 |
+| §9 Open Questions | Resolved during exploration: Item reused in /myevent/calender/search (Task 8.2-8.3); dateUtil at lib/utils/dateUtil (used in Task 2); organizer is `string` non-null per model/event.ts |
+| §10 Non-Goals | Not touched — banner/filter/modal/layout unchanged |
+
+Placeholder scan: no "TBD" / "TODO" / "implement later" / "add appropriate error handling" / vague references. Each step has exact code, exact paths, exact commands.
+
+Type consistency: `EventStatus` ('live'|'urgent'|'upcoming'|'ended') defined in Task 2.1, consumed in 2.2 (state) and 3.2 (badge class) and 3.3 (DdayTag gate). `STATUS_LABEL` Record consistent. `status-badge--{variant}` class names match Task 4 CSS.
+
+---
+
+## Execution Handoff
+
+Plan saved to `docs/superpowers/plans/2026-05-11-events-card-renewal.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration. Good for visual UI changes where checkpoint review catches drift early.
+
+**2. Inline Execution** — Execute tasks sequentially in this session using `executing-plans`, batched with checkpoints at task boundaries.
+
+Which approach?

--- a/docs/superpowers/plans/2026-05-11-header-footer-banner-renewal.md
+++ b/docs/superpowers/plans/2026-05-11-header-footer-banner-renewal.md
@@ -1,0 +1,846 @@
+# Header / Footer / Banner Renewal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 전역 chrome(Header / Footer)과 `/events` Banner를 DESIGN.md(KTB Vapor) 토큰·타이포로 리뉴얼.
+
+**Architecture:** SCSS module 4개 토큰·값 교체 + Banner 사이즈 다이어트 + Profile dropdown 미니 리디자인. JSX 변경 없음.
+
+**Tech Stack:** Next.js 12 / React 17 / SCSS modules / 기존 vapor·ktb CSS 변수.
+
+**User preferences:** 작업 중 git commit 없음. Plan 안 commit step 없음.
+
+---
+
+## File Structure
+
+**Modified files (SCSS only):**
+- `components/layout/header/Header.module.scss`
+- `components/layout/header/HeaderTab.module.scss`
+- `components/common/banner/banner.module.scss`
+- `components/layout/footer/Footer.module.scss`
+
+**Reused (변경 없음):** `styles/_color.scss`, `styles/Theme.scss`, 모든 TSX.
+
+---
+
+## Task 1: Header outer 토큰 cleanup
+
+**Files:** `components/layout/header/Header.module.scss`
+
+- [ ] **Step 1: border 토큰**
+
+Find:
+```scss
+border-bottom: 1px solid $light-gray-4;
+```
+Replace with:
+```scss
+border-bottom: 1px solid var(--vapor-gray-300);
+```
+
+- [ ] **Step 2: toggle hover 토큰**
+
+Find:
+```scss
+&:hover {
+  background-color: var(--gray-5);
+}
+```
+(inside `.toggle__container`)
+
+Replace with:
+```scss
+&:hover {
+  background-color: var(--vapor-gray-100);
+}
+```
+
+- [ ] **Step 3: profile button svg 토큰**
+
+Find:
+```scss
+svg path {
+  fill: var(--gray-2);
+}
+```
+(inside `.profile .profile-button`)
+
+Replace with:
+```scss
+svg path {
+  fill: var(--vapor-gray-500);
+}
+```
+
+---
+
+## Task 2: Profile dropdown 미니 리디자인
+
+**Files:** `components/layout/header/Header.module.scss`
+
+- [ ] **Step 1: `.profile-menu` 외곽 교체**
+
+Find:
+```scss
+.profile-menu {
+  animation-name: appearIn;
+  animation-duration: 0.2s;
+  animation-timing-function: linear;
+
+  border-radius: 10px;
+  width: 136px;
+  height: 135px;
+  padding: 0;
+  left: 50%;
+  top: 42px;
+  margin-left: -102px;
+  text-align: center;
+  position: absolute;
+  z-index: 1;
+  background-color: #fff;
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
+```
+
+Replace with:
+```scss
+.profile-menu {
+  animation: fadeIn 0.15s ease-out;
+
+  border-radius: 12px;
+  width: 160px;
+  padding: 4px;
+  left: 50%;
+  top: 44px;
+  margin-left: -128px;
+  text-align: center;
+  position: absolute;
+  z-index: 1;
+  background-color: var(--vapor-gray-000);
+  box-shadow: 0 8px 24px rgba(0, 0, 64, 0.08), 0 0 0 1px var(--vapor-gray-300);
+```
+
+(height·고정값 제거, padding 4px로 inner 여백, animation 단순화)
+
+- [ ] **Step 2: `&__item` 블록 교체**
+
+Find:
+```scss
+&__item {
+  padding: 0.5rem 1.813rem 0.5rem 1.813rem;
+  background-color: #fff;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  font-size: 0.875rem;
+  color: #757575;
+  font-weight: 400;
+  cursor: pointer;
+  height: 45px;
+
+  &:hover {
+    background: #ebebeb;
+  }
+  &:focus {
+    background-color: #ebebeb;
+  }
+}
+```
+
+Replace with:
+```scss
+&__item {
+  padding: 10px 16px;
+  background-color: transparent;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  color: var(--vapor-gray-800);
+  font-weight: 500;
+  cursor: pointer;
+  border-radius: 8px;
+  transition: background-color 0.15s ease;
+
+  &:hover {
+    background-color: var(--vapor-gray-100);
+  }
+  &:focus-visible {
+    background-color: var(--vapor-gray-100);
+    outline: none;
+  }
+}
+```
+
+(고정 height 제거, padding 정규화, 아이템 자체에 radius 추가 — 외곽 padding 4px와 어울림)
+
+- [ ] **Step 3: first-child/last-child 모서리 처리 + caret 제거**
+
+Find:
+```scss
+&__item:first-child {
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
+}
+&__item:last-child {
+  border-bottom-left-radius: 10px;
+  border-bottom-right-radius: 10px;
+}
+```
+
+및
+
+```scss
+.profile-menu::after {
+  content: ' ';
+  position: absolute;
+  bottom: 100%;
+  left: 102px;
+  margin-left: -10px;
+  border-width: 10px;
+  border-style: solid;
+  border-color: transparent transparent #ffffff transparent;
+}
+```
+
+두 블록 전체 삭제. (아이템마다 8px radius가 있으므로 외곽 first/last 처리 불필요. caret도 제거.)
+
+- [ ] **Step 4: keyframes 교체**
+
+Find:
+```scss
+@keyframes appearIn {
+  0% {
+    height: 0px;
+    opacity: 0%;
+  }
+
+  100% {
+    height: 135px;
+    opacity: 100%;
+  }
+}
+```
+
+Replace with:
+```scss
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+```
+
+---
+
+## Task 3: HeaderTab 토큰 cleanup
+
+**Files:** `components/layout/header/HeaderTab.module.scss`
+
+- [ ] **Step 1: tab-text 색상 교체**
+
+Find:
+```scss
+.tab-text {
+  font-size: 14px;
+  line-height: 14px;
+  color: var(--gray-2);
+  font-weight: 500;
+
+  &.active {
+    color: #313234;
+  }
+}
+```
+
+Replace with:
+```scss
+.tab-text {
+  font-size: 14px;
+  line-height: 14px;
+  color: var(--vapor-gray-600);
+  font-weight: 500;
+
+  &.active {
+    color: var(--vapor-gray-900);
+  }
+}
+```
+
+- [ ] **Step 2: new-badge 색상 교체**
+
+Find:
+```scss
+background-color: #3182f6;
+```
+(in `.new-badge`)
+
+Replace with:
+```scss
+background-color: var(--ktb-tech-blue);
+```
+
+---
+
+## Task 4: Banner 사이즈 다이어트 + 토큰
+
+**Files:** `components/common/banner/banner.module.scss`
+
+- [ ] **Step 1: `.banner` 외곽 — desktop 기본 height 축소**
+
+Find:
+```scss
+.banner {
+  position: relative;
+  height: 30rem;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  align-self: flex-start;
+  padding: 0 20px;
+  margin-top: $header_height;
+  z-index: 0;
+  overflow: hidden;
+```
+
+Replace `height: 30rem;` with:
+```scss
+  height: 28rem;
+```
+
+(나머지 라인 그대로)
+
+- [ ] **Step 2: `.banner__title` 교체**
+
+Find:
+```scss
+&__title {
+  font-size: 3.8rem;
+  font-weight: 700;
+  line-height: 5.1rem;
+  letter-spacing: 0em;
+  text-align: center;
+  color: #ffffff;
+  padding: 0px;
+  margin: 0px;
+  z-index: 1;
+}
+```
+
+Replace with:
+```scss
+&__title {
+  font-size: 3rem;
+  font-weight: 800;
+  line-height: 1.2;
+  letter-spacing: -0.012rem;
+  text-align: center;
+  color: #ffffff;
+  padding: 0px;
+  margin: 0px;
+  z-index: 1;
+}
+```
+
+- [ ] **Step 3: `.banner__desc` 교체**
+
+Find:
+```scss
+&__desc {
+  font-weight: 400;
+  font-size: 1.23rem;
+  line-height: 1.813rem;
+  text-align: center;
+  color: #ffffff;
+  padding-top: 1.938rem;
+  padding-bottom: 0px;
+  margin: 0px;
+  z-index: 1;
+  &--bold {
+    font-weight: bold;
+  }
+}
+```
+
+Replace with:
+```scss
+&__desc {
+  font-weight: 500;
+  font-size: 1.125rem;
+  line-height: 1.5;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.85);
+  padding-top: 1.5rem;
+  padding-bottom: 0px;
+  margin: 0px;
+  z-index: 1;
+  &--bold {
+    font-weight: 700;
+  }
+}
+```
+
+- [ ] **Step 4: `@include laptop` 미디어 교체**
+
+Find:
+```scss
+@include laptop {
+  @media (max-width: 1075px) {
+    .banner {
+      width: 100%;
+      height: 28rem;
+    }
+  }
+  @media (max-width: 800px) {
+    .banner {
+      width: 100%;
+      height: 26rem;
+      &__title {
+        font-size: 3.4rem;
+        line-height: 4.5rem;
+      }
+      &__desc {
+        font-size: 1rem;
+      }
+    }
+  }
+}
+```
+
+Replace with:
+```scss
+@include laptop {
+  @media (max-width: 1075px) {
+    .banner {
+      width: 100%;
+      height: 24rem;
+      &__title {
+        font-size: 2.75rem;
+      }
+    }
+  }
+  @media (max-width: 800px) {
+    .banner {
+      width: 100%;
+      height: 22rem;
+      &__title {
+        font-size: 2.5rem;
+        line-height: 1.2;
+      }
+      &__desc {
+        font-size: 1rem;
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 5: `@include tablet` 미디어 교체**
+
+Find:
+```scss
+@include tablet {
+  .banner {
+    width: 100%;
+    height: 24rem;
+    &__title {
+      font-size: 3rem;
+      line-height: 4rem;
+    }
+    &__desc {
+      font-size: 1rem;
+    }
+  }
+  @media (max-width: 500px) {
+    .banner {
+      width: 100%;
+      height: 22rem;
+      &__title {
+        font-size: 2.3rem;
+        line-height: 3rem;
+      }
+      &__desc {
+        font-size: 1rem;
+      }
+    }
+  }
+  @media (max-width: 400px) {
+    .banner {
+      &__title {
+        font-size: 2.1rem;
+        line-height: 3rem;
+      }
+      &__desc {
+        font-size: 0.9rem;
+      }
+    }
+  }
+}
+```
+
+Replace with:
+```scss
+@include tablet {
+  .banner {
+    width: 100%;
+    height: 22rem;
+    &__title {
+      font-size: 2.125rem;
+      line-height: 1.2;
+    }
+    &__desc {
+      font-size: 1rem;
+    }
+  }
+  @media (max-width: 500px) {
+    .banner {
+      width: 100%;
+      height: 20rem;
+      &__title {
+        font-size: 1.875rem;
+        line-height: 1.2;
+      }
+      &__desc {
+        font-size: 1rem;
+      }
+    }
+  }
+  @media (max-width: 400px) {
+    .banner {
+      &__title {
+        font-size: 1.75rem;
+        line-height: 1.2;
+      }
+      &__desc {
+        font-size: 0.9rem;
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 6: `@include mobile` 미디어 교체**
+
+Find:
+```scss
+@include mobile {
+  .banner {
+    width: 100%;
+    height: 18rem;
+    &__title {
+      font-size: 2rem;
+      line-height: 2.5rem;
+    }
+    &__desc {
+      font-size: 0.9rem;
+    }
+  }
+}
+```
+
+Replace with:
+```scss
+@include mobile {
+  .banner {
+    width: 100%;
+    height: 18rem;
+    &__title {
+      font-size: 1.75rem;
+      line-height: 1.2;
+    }
+    &__desc {
+      font-size: 0.9rem;
+    }
+  }
+}
+```
+
+(높이는 18rem 유지, title만 절제)
+
+---
+
+## Task 5: Footer 토큰 + max-width + 아이콘 row gap
+
+**Files:** `components/layout/footer/Footer.module.scss`
+
+- [ ] **Step 1: 컨테이너 교체**
+
+Find:
+```scss
+.footer {
+  width: 100%;
+  max-width: 1104px;
+  height: 200px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  position: relative;
+  background-color: var(--background-1);
+```
+
+Replace with:
+```scss
+.footer {
+  width: 100%;
+  max-width: 1200px;
+  min-height: 200px;
+  margin: 0 auto;
+  padding: 0 32px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  position: relative;
+  background-color: var(--vapor-gray-000);
+```
+
+(height fixed → min-height, max-width 1200, padding 추가, background 토큰)
+
+- [ ] **Step 2: `&__column` 텍스트 토큰 교체**
+
+Find:
+```scss
+&__column {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  height: 100%;
+
+  .footer__desc {
+    color: var(--gray-2);
+    font-size: 16px;
+    margin-top: 1rem;
+  }
+  .footer__copyright {
+    color: var(--gray-3);
+    font-size: 16px;
+    margin-top: 3rem;
+  }
+}
+```
+
+Replace with:
+```scss
+&__column {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  height: 100%;
+
+  .footer__desc {
+    color: var(--vapor-gray-700);
+    font-size: 14px;
+    font-weight: 500;
+    margin-top: 1rem;
+  }
+  .footer__copyright {
+    color: var(--vapor-gray-500);
+    font-size: 14px;
+    font-weight: 500;
+    margin-top: 3rem;
+
+    a {
+      color: var(--ktb-tech-blue);
+      text-decoration: none;
+      transition: color 0.2s ease;
+
+      &:hover {
+        color: var(--ktb-tech-navy-hover);
+        text-decoration: underline;
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 3: `&__row` 아이콘 영역에 gap 추가**
+
+Find:
+```scss
+&__row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  position: absolute;
+  bottom: 32px;
+  right: 0;
+}
+```
+
+Replace with:
+```scss
+&__row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 12px;
+  position: absolute;
+  bottom: 32px;
+  right: 32px;
+}
+```
+
+(right 0 → 32 — 컨테이너 padding과 정렬)
+
+- [ ] **Step 4: `@include tablet` 교체**
+
+Find:
+```scss
+@include tablet {
+  .footer {
+    padding: 32px $tablet_padding;
+    //padding: 32px 0;
+    display: block;
+    max-width: 1271px;
+
+    &__column {
+      .footer__desc,
+      .footer__copyright {
+        display: inline-block;
+        font-size: 14px;
+        font-weight: 500;
+      }
+    }
+
+    // 바로가기 Github & Whale 아이콘
+    &__row {
+      padding-right: $tablet_padding;
+      bottom: 32px;
+    }
+  }
+}
+```
+
+Replace with:
+```scss
+@include tablet {
+  .footer {
+    padding: 32px;
+    display: block;
+
+    &__column {
+      .footer__desc,
+      .footer__copyright {
+        display: inline-block;
+        font-size: 13px;
+        font-weight: 500;
+      }
+    }
+
+    // 바로가기 Github & Whale 아이콘
+    &__row {
+      right: 32px;
+      bottom: 32px;
+    }
+  }
+}
+```
+
+- [ ] **Step 5: `@include mobile` 교체**
+
+Find:
+```scss
+@include mobile {
+  .footer {
+    display: block;
+    padding: 32px 20px;
+    width: 100%;
+
+    &__column {
+      .footer__desc,
+      .footer__copyright {
+        display: inline-block;
+        font-size: 14px;
+        font-weight: 500;
+      }
+    }
+
+    // 바로가기 Github & Whale 아이콘
+    &__row {
+      right: 18px;
+      bottom: 0;
+    }
+  }
+}
+```
+
+Replace with:
+```scss
+@include mobile {
+  .footer {
+    display: block;
+    padding: 32px 16px;
+    width: 100%;
+
+    &__column {
+      .footer__desc,
+      .footer__copyright {
+        display: inline-block;
+        font-size: 13px;
+        font-weight: 500;
+      }
+    }
+
+    // 바로가기 Github & Whale 아이콘
+    &__row {
+      right: 16px;
+      bottom: 0;
+    }
+  }
+}
+```
+
+---
+
+## Task 6: 빌드·시각·토큰 검증
+
+**Files:** 변경 없음 (검증만)
+
+- [ ] **Step 1: 잔여 하드코딩 검증**
+
+Run:
+```bash
+grep -nE '#[0-9a-fA-F]{3,6}|\$light-gray|var\(--gray-[0-9]\)|var\(--background-1\)|var\(--text-1\)' \
+  /Users/user/Desktop/dev-lab/Dev-Event-Web-Brave-People/components/layout/header/Header.module.scss \
+  /Users/user/Desktop/dev-lab/Dev-Event-Web-Brave-People/components/layout/header/HeaderTab.module.scss \
+  /Users/user/Desktop/dev-lab/Dev-Event-Web-Brave-People/components/common/banner/banner.module.scss \
+  /Users/user/Desktop/dev-lab/Dev-Event-Web-Brave-People/components/layout/footer/Footer.module.scss
+```
+
+Expected: 결과에서 `#ffffff` 외 하드코딩 hex가 없어야 하고, `$light-gray`·`var(--gray-N)`·`var(--background-1)`·`var(--text-1)` 모두 0건. `hsla()` / `rgba()` 안의 hex/rgb 값은 무시.
+
+- [ ] **Step 2: lint**
+
+Run: `cd /Users/user/Desktop/dev-lab/Dev-Event-Web-Brave-People && pnpm lint`
+Expected: PASS (warning 무관)
+
+- [ ] **Step 3: build**
+
+Run: `cd /Users/user/Desktop/dev-lab/Dev-Event-Web-Brave-People && pnpm build`
+Expected: 빌드 성공
+
+- [ ] **Step 4: 시각 검증** — `pnpm dev` 실행 후 브라우저로 확인:
+
+- `http://localhost:5000/events` — Header frosted, Banner 작아진 타이틀, Footer 정렬
+- Profile 클릭 → dropdown이 caret 없이 fade-in
+- Footer 링크가 ktb-tech-blue
+- 다크 테마 토글 (있으면): 모든 영역 자연 반전
+
+뷰포트별 깨짐 없음: 1200+, 1075, 800, 500, 400, ≤480.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** spec의 모든 섹션(Header / Profile dropdown / HeaderTab / Banner sizing / Footer / 검증)에 매칭되는 task 존재.
+- **No placeholders:** 모든 step에 구체 코드와 명령어 포함.
+- **Type consistency:** 색상 토큰명 일관 (`--vapor-gray-*`, `--ktb-tech-blue`, `--ktb-tech-navy-hover`), `fadeIn` keyframe 이름 Task 2 Step 1/4에서 동일.
+- **Commit policy:** 사용자 지시에 따라 commit step 제외.

--- a/docs/superpowers/plans/2026-05-12-events-calendar-view.md
+++ b/docs/superpowers/plans/2026-05-12-events-calendar-view.md
@@ -1,0 +1,1802 @@
+# `/events` 캘린더 보기 추가 — 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `/events` 페이지에 리스트 ↔ 캘린더 뷰 토글을 추가하고, 한 달치 이벤트를 시각적 격자(데스크탑) 또는 점 캘린더(모바일)로 보여준다.
+
+**Architecture:** 새 컴포넌트들은 `components/events/calendar/` 아래에 모은다. 순수 계산 로직(`buildCalendarMatrix`, `layoutMultiDayEvents`, `tagColor`)은 `utils/`로 분리해 단위 테스트한다. URL 쿼리(`?view=calendar&year=&month=`)가 상태의 진실 근원이며 `pages/events.tsx`의 SSR이 모드별로 API를 분기 호출한다. 기존 `useMonthlyEvent` 훅과 `WindowContext`를 재사용한다.
+
+**Tech Stack:** Next.js 12 (page router) · React 17 · TypeScript · SWR · dayjs · SCSS modules · react-modal · Jest + ts-jest (이번에 셋업)
+
+**관련 스펙:** `docs/superpowers/specs/2026-05-12-events-calendar-view-design.md`
+
+---
+
+## 파일 구조 매핑
+
+**신규 생성**
+- `components/events/calendar/CalendarView.tsx` — 뷰 진입, viewport 분기, 선택일 상태
+- `components/events/calendar/CalendarHeader.tsx` — 월 네비 + "오늘"
+- `components/events/calendar/CalendarGrid.tsx` — 데스크탑 7×6 그리드
+- `components/events/calendar/CalendarDotGrid.tsx` — 모바일 점 캘린더
+- `components/events/calendar/DayDetailSheet.tsx` — 선택일 이벤트 모달/시트
+- `components/events/calendar/ViewToggle.tsx` — 리스트/캘린더 세그먼트
+- `components/events/calendar/CalendarView.module.scss`
+- `components/events/calendar/utils/buildCalendarMatrix.ts`
+- `components/events/calendar/utils/layoutMultiDayEvents.ts`
+- `components/events/calendar/utils/tagColor.ts`
+- `components/events/calendar/utils/__tests__/buildCalendarMatrix.test.ts`
+- `components/events/calendar/utils/__tests__/layoutMultiDayEvents.test.ts`
+- `components/events/calendar/utils/__tests__/tagColor.test.ts`
+- `jest.config.js`, `jest.setup.ts` (루트)
+
+**변경**
+- `pages/events.tsx` — SSR 분기, 뷰 분기 렌더, `ViewToggle` 마운트
+- `pages/calender.tsx` — 컴포넌트 본체 제거, 307 redirect만
+- `package.json` — Jest 의존성 + `test` 스크립트
+
+**삭제 없음** (`MonthlyEventList` 등 기존 컴포넌트는 유지 — 다른 곳 영향 회피)
+
+---
+
+## Task 0: Jest 테스트 셋업
+
+**Files:**
+- Modify: `package.json`
+- Create: `jest.config.js`, `jest.setup.ts`
+
+- [ ] **Step 1: Jest + ts-jest 설치**
+
+```bash
+pnpm add -D jest@29 ts-jest@29 @types/jest@29 jest-environment-jsdom@29
+```
+
+- [ ] **Step 2: `jest.config.js` 작성**
+
+루트에 새 파일:
+```js
+// jest.config.js
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEach: ['<rootDir>/jest.setup.ts'],
+  moduleDirectories: ['node_modules', '<rootDir>'],
+  moduleNameMapper: {
+    '\\.(scss|css)$': '<rootDir>/__mocks__/styleMock.js',
+  },
+  testMatch: ['**/__tests__/**/*.test.ts', '**/__tests__/**/*.test.tsx'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.json' }],
+  },
+};
+```
+
+- [ ] **Step 3: `jest.setup.ts` + 스타일 목업 생성**
+
+```ts
+// jest.setup.ts
+import '@testing-library/jest-dom';
+```
+
+```js
+// __mocks__/styleMock.js
+module.exports = {};
+```
+
+> 참고: 유틸 함수만 테스트할 거라면 `@testing-library/jest-dom`은 생략 가능. 일단 셋업만 두고 사용 안 함.
+
+- [ ] **Step 4: `package.json`에 test 스크립트 추가**
+
+`scripts` 블록에 추가:
+```json
+"test": "jest",
+"test:watch": "jest --watch"
+```
+
+- [ ] **Step 5: 빈 sanity 테스트로 확인**
+
+```ts
+// components/events/calendar/utils/__tests__/sanity.test.ts
+describe('jest setup', () => {
+  it('runs', () => { expect(1 + 1).toBe(2); });
+});
+```
+
+Run: `pnpm test`
+Expected: PASS, 1 test passed
+
+- [ ] **Step 6: sanity 테스트 삭제 후 커밋**
+
+```bash
+rm components/events/calendar/utils/__tests__/sanity.test.ts
+git add package.json pnpm-lock.yaml jest.config.js jest.setup.ts __mocks__/styleMock.js
+git commit -m "chore: add jest + ts-jest test setup"
+```
+
+---
+
+## Task 1: `buildCalendarMatrix` 유틸 (TDD)
+
+캘린더 그리드의 6주×7일 행렬을 만드는 순수 함수.
+
+**Files:**
+- Create: `components/events/calendar/utils/buildCalendarMatrix.ts`
+- Test: `components/events/calendar/utils/__tests__/buildCalendarMatrix.test.ts`
+
+- [ ] **Step 1: 테스트 작성 (failing)**
+
+```ts
+// components/events/calendar/utils/__tests__/buildCalendarMatrix.test.ts
+import { buildCalendarMatrix, CalendarCell } from '../buildCalendarMatrix';
+
+describe('buildCalendarMatrix', () => {
+  it('returns 6 weeks × 7 days = 42 cells', () => {
+    const matrix = buildCalendarMatrix(2026, 5);
+    expect(matrix).toHaveLength(6);
+    matrix.forEach((week) => expect(week).toHaveLength(7));
+  });
+
+  it('marks outside-month cells with isOutside=true (2026-05)', () => {
+    const matrix = buildCalendarMatrix(2026, 5);
+    // 2026/5/1 is Friday — first row has 5 outside cells (4/26~4/30)
+    expect(matrix[0][0]).toEqual<CalendarCell>({
+      date: '2026-04-26', year: 2026, month: 4, day: 26, dow: 0, isOutside: true,
+    });
+    expect(matrix[0][5]).toEqual<CalendarCell>({
+      date: '2026-05-01', year: 2026, month: 5, day: 1, dow: 5, isOutside: false,
+    });
+  });
+
+  it('handles year boundary (2025-12 → 2026-01 outside cells)', () => {
+    const matrix = buildCalendarMatrix(2025, 12);
+    const last = matrix[matrix.length - 1];
+    const outsideAfter = last.filter((c) => c.isOutside && c.year === 2026);
+    expect(outsideAfter.length).toBeGreaterThan(0);
+    expect(outsideAfter[0].month).toBe(1);
+  });
+
+  it('handles leap year February 2024 correctly', () => {
+    const matrix = buildCalendarMatrix(2024, 2);
+    const inMonth = matrix.flat().filter((c) => !c.isOutside);
+    expect(inMonth).toHaveLength(29);
+    expect(inMonth[inMonth.length - 1].day).toBe(29);
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → FAIL 확인**
+
+Run: `pnpm test -- buildCalendarMatrix`
+Expected: FAIL (`Cannot find module '../buildCalendarMatrix'`)
+
+- [ ] **Step 3: 최소 구현**
+
+```ts
+// components/events/calendar/utils/buildCalendarMatrix.ts
+import dayjs from 'dayjs';
+
+export interface CalendarCell {
+  date: string;     // 'YYYY-MM-DD'
+  year: number;
+  month: number;    // 1~12
+  day: number;
+  dow: number;      // 0=Sun ... 6=Sat
+  isOutside: boolean;
+}
+
+export function buildCalendarMatrix(year: number, month: number): CalendarCell[][] {
+  const firstOfMonth = dayjs(`${year}-${String(month).padStart(2, '0')}-01`);
+  const startDow = firstOfMonth.day(); // 0~6
+  const gridStart = firstOfMonth.subtract(startDow, 'day');
+
+  const matrix: CalendarCell[][] = [];
+  for (let w = 0; w < 6; w++) {
+    const week: CalendarCell[] = [];
+    for (let d = 0; d < 7; d++) {
+      const cur = gridStart.add(w * 7 + d, 'day');
+      week.push({
+        date: cur.format('YYYY-MM-DD'),
+        year: cur.year(),
+        month: cur.month() + 1,
+        day: cur.date(),
+        dow: cur.day(),
+        isOutside: cur.month() + 1 !== month || cur.year() !== year,
+      });
+    }
+    matrix.push(week);
+  }
+  return matrix;
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `pnpm test -- buildCalendarMatrix`
+Expected: PASS, 4 tests passed
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add components/events/calendar/utils/buildCalendarMatrix.ts \
+        components/events/calendar/utils/__tests__/buildCalendarMatrix.test.ts
+git commit -m "feat(calendar): add buildCalendarMatrix util with tests"
+```
+
+---
+
+## Task 2: `tagColor` 유틸 (TDD)
+
+태그 이름 → KTB 색 매핑.
+
+**Files:**
+- Create: `components/events/calendar/utils/tagColor.ts`
+- Test: `components/events/calendar/utils/__tests__/tagColor.test.ts`
+
+- [ ] **Step 1: 테스트 작성**
+
+```ts
+// components/events/calendar/utils/__tests__/tagColor.test.ts
+import { tagColor, DEFAULT_TAG_COLOR } from '../tagColor';
+
+describe('tagColor', () => {
+  it('maps 컨퍼런스 to KTB Blue', () => {
+    expect(tagColor(['컨퍼런스'])).toBe('#0043FF');
+  });
+  it('maps 웨비나 to Success green', () => {
+    expect(tagColor(['웨비나'])).toBe('#08785E');
+  });
+  it('maps 해커톤 to Warning orange', () => {
+    expect(tagColor(['해커톤'])).toBe('#B45209');
+  });
+  it('maps 네트워킹 to Violet', () => {
+    expect(tagColor(['네트워킹'])).toBe('#7A0CFF');
+  });
+  it('returns default color when no tag matches', () => {
+    expect(tagColor(['알수없는태그'])).toBe(DEFAULT_TAG_COLOR);
+  });
+  it('returns default color for empty tags', () => {
+    expect(tagColor([])).toBe(DEFAULT_TAG_COLOR);
+  });
+  it('uses first matching tag when multiple tags', () => {
+    expect(tagColor(['알수없음', '컨퍼런스', '웨비나'])).toBe('#0043FF');
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → FAIL 확인**
+
+Run: `pnpm test -- tagColor`
+Expected: FAIL
+
+- [ ] **Step 3: 최소 구현**
+
+```ts
+// components/events/calendar/utils/tagColor.ts
+export const DEFAULT_TAG_COLOR = '#525463';
+
+const COLOR_MAP: Array<{ keywords: string[]; color: string }> = [
+  { keywords: ['컨퍼런스', 'conference', 'conf'],         color: '#0043FF' },
+  { keywords: ['웨비나', '세미나', 'webinar', 'seminar'], color: '#08785E' },
+  { keywords: ['해커톤', '공모전', 'hackathon'],           color: '#B45209' },
+  { keywords: ['네트워킹', '밋업', 'meetup'],              color: '#7A0CFF' },
+];
+
+export function tagColor(tagNames: string[]): string {
+  for (const tagName of tagNames) {
+    const lower = tagName.toLowerCase();
+    const match = COLOR_MAP.find(({ keywords }) =>
+      keywords.some((k) => lower.includes(k.toLowerCase()))
+    );
+    if (match) return match.color;
+  }
+  return DEFAULT_TAG_COLOR;
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `pnpm test -- tagColor`
+Expected: PASS, 7 tests passed
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add components/events/calendar/utils/tagColor.ts \
+        components/events/calendar/utils/__tests__/tagColor.test.ts
+git commit -m "feat(calendar): add tagColor util with tests"
+```
+
+---
+
+## Task 3: `layoutMultiDayEvents` 유틸 (TDD)
+
+이벤트들을 받아서 주차별 segment로 배치하는 핵심 로직.
+
+**Files:**
+- Create: `components/events/calendar/utils/layoutMultiDayEvents.ts`
+- Test: `components/events/calendar/utils/__tests__/layoutMultiDayEvents.test.ts`
+
+- [ ] **Step 1: 테스트 작성**
+
+```ts
+// components/events/calendar/utils/__tests__/layoutMultiDayEvents.test.ts
+import { layoutMultiDayEvents, EventSegment } from '../layoutMultiDayEvents';
+import { buildCalendarMatrix } from '../buildCalendarMatrix';
+import { Event } from 'model/event';
+
+const baseEvent = (overrides: Partial<Event>): Event => ({
+  id: '1', title: 'Test', description: '', organizer: 'Org',
+  event_link: '', cover_image_link: '', display_sequence: 0,
+  event_time_type: 'DATE', start_day_week: '월', end_day_week: '월',
+  start_date_time: '', end_date_time: '',
+  tags: [], create_date_time: '',
+  use_end_date_time_yn: 'Y', use_start_date_time_yn: 'Y',
+  ...overrides,
+});
+
+describe('layoutMultiDayEvents', () => {
+  const matrix2026May = buildCalendarMatrix(2026, 5);
+
+  it('produces single segment for single-day event', () => {
+    const events = [baseEvent({ id: '1', start_date_time: '2026-05-12T10:00:00', end_date_time: '2026-05-12T18:00:00' })];
+    const result = layoutMultiDayEvents(events, matrix2026May);
+    const allSegments = result.flat();
+    expect(allSegments).toHaveLength(1);
+    expect(allSegments[0]).toMatchObject({ isStart: true, isEnd: true, eventId: '1' });
+  });
+
+  it('produces single segment for multi-day event within one week', () => {
+    // 5/5 (화) ~ 5/7 (목) — all in week starting 5/3 (일)
+    const events = [baseEvent({ id: '1', start_date_time: '2026-05-05T00:00:00', end_date_time: '2026-05-07T23:59:59' })];
+    const result = layoutMultiDayEvents(events, matrix2026May);
+    const segments = result.flat();
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toMatchObject({ isStart: true, isEnd: true, startCol: 2, endCol: 4, weekIndex: 1 });
+  });
+
+  it('splits multi-day event crossing week boundary into two segments', () => {
+    // 5/14 (목) ~ 5/16 (토) — single week
+    // 5/15 (금) ~ 5/18 (월) — crosses sat→sun boundary
+    const events = [baseEvent({ id: 'cross', start_date_time: '2026-05-15T00:00:00', end_date_time: '2026-05-18T23:59:59' })];
+    const result = layoutMultiDayEvents(events, matrix2026May);
+    const segments = result.flat();
+    expect(segments).toHaveLength(2);
+    expect(segments[0]).toMatchObject({ isStart: true, isEnd: false });
+    expect(segments[1]).toMatchObject({ isStart: false, isEnd: true });
+  });
+
+  it('includes outside cells when event spans month boundary', () => {
+    // 5/30 (토) ~ 6/1 (월) — last segment is in outside cells of week 5
+    const events = [baseEvent({ id: 'border', start_date_time: '2026-05-30T00:00:00', end_date_time: '2026-06-01T23:59:59' })];
+    const result = layoutMultiDayEvents(events, matrix2026May);
+    const segments = result.flat();
+    expect(segments.length).toBeGreaterThanOrEqual(1);
+    const hasOutside = segments.some((s) => s.isOutside);
+    expect(hasOutside).toBe(true);
+  });
+
+  it('skips events with event_time_type=RECRUIT', () => {
+    const events = [baseEvent({ id: 'r', event_time_type: 'RECRUIT', start_date_time: '2026-05-12T00:00:00', end_date_time: '2026-05-12T23:59:59' })];
+    const result = layoutMultiDayEvents(events, matrix2026May);
+    expect(result.flat()).toHaveLength(0);
+  });
+
+  it('skips events with use_start_date_time_yn=N', () => {
+    const events = [baseEvent({ id: 'n', start_date_time: '2026-05-12T00:00:00', end_date_time: '2026-05-12T23:59:59', use_start_date_time_yn: 'N' })];
+    const result = layoutMultiDayEvents(events, matrix2026May);
+    expect(result.flat()).toHaveLength(0);
+  });
+
+  it('sorts overlapping events by display_sequence then start_date_time', () => {
+    const events = [
+      baseEvent({ id: 'B', display_sequence: 2, start_date_time: '2026-05-12T10:00:00', end_date_time: '2026-05-12T12:00:00' }),
+      baseEvent({ id: 'A', display_sequence: 1, start_date_time: '2026-05-12T11:00:00', end_date_time: '2026-05-12T13:00:00' }),
+    ];
+    const result = layoutMultiDayEvents(events, matrix2026May);
+    const segs = result.flat();
+    expect(segs[0].eventId).toBe('A');
+    expect(segs[1].eventId).toBe('B');
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → FAIL 확인**
+
+Run: `pnpm test -- layoutMultiDayEvents`
+Expected: FAIL (module not found)
+
+- [ ] **Step 3: 구현**
+
+```ts
+// components/events/calendar/utils/layoutMultiDayEvents.ts
+import dayjs from 'dayjs';
+import { Event } from 'model/event';
+import { CalendarCell } from './buildCalendarMatrix';
+
+export interface EventSegment {
+  eventId: string;
+  event: Event;
+  weekIndex: number;   // 0~5
+  startCol: number;    // 0~6 (inclusive)
+  endCol: number;      // 0~6 (inclusive)
+  isStart: boolean;    // true if this is the original start day
+  isEnd: boolean;      // true if this is the original end day
+  isOutside: boolean;  // segment falls in outside cells of the matrix
+}
+
+function isRenderable(e: Event): boolean {
+  if (e.event_time_type !== 'DATE') return false;
+  if (e.use_start_date_time_yn === 'N') return false;
+  if (!e.start_date_time) return false;
+  return true;
+}
+
+export function layoutMultiDayEvents(
+  events: Event[],
+  matrix: CalendarCell[][],
+): EventSegment[][] {
+  const segmentsByWeek: EventSegment[][] = matrix.map(() => []);
+
+  const sorted = [...events]
+    .filter(isRenderable)
+    .sort((a, b) => {
+      const ds = a.display_sequence - b.display_sequence;
+      if (ds !== 0) return ds;
+      return a.start_date_time.localeCompare(b.start_date_time);
+    });
+
+  const gridStart = dayjs(matrix[0][0].date);
+  const gridEnd   = dayjs(matrix[5][6].date);
+
+  for (const event of sorted) {
+    const start = dayjs(event.start_date_time);
+    const end   = event.end_date_time ? dayjs(event.end_date_time) : start;
+
+    // clip to grid
+    const clipStart = start.isBefore(gridStart) ? gridStart : start;
+    const clipEnd   = end.isAfter(gridEnd)      ? gridEnd   : end;
+    if (clipEnd.isBefore(clipStart)) continue;
+
+    // walk weeks: find which (week, col) clipStart and clipEnd fall in
+    for (let w = 0; w < matrix.length; w++) {
+      const weekStart = dayjs(matrix[w][0].date);
+      const weekEnd   = dayjs(matrix[w][6].date);
+
+      if (clipEnd.isBefore(weekStart) || clipStart.isAfter(weekEnd)) continue;
+
+      const segStart = clipStart.isBefore(weekStart) ? weekStart : clipStart;
+      const segEnd   = clipEnd.isAfter(weekEnd)      ? weekEnd   : clipEnd;
+      const startCol = segStart.diff(weekStart, 'day');
+      const endCol   = segEnd.diff(weekStart, 'day');
+
+      const segmentIsOutside =
+        matrix[w][startCol].isOutside && matrix[w][endCol].isOutside;
+
+      segmentsByWeek[w].push({
+        eventId: event.id,
+        event,
+        weekIndex: w,
+        startCol,
+        endCol,
+        isStart: segStart.isSame(start, 'day'),
+        isEnd:   segEnd.isSame(end, 'day'),
+        isOutside: segmentIsOutside,
+      });
+    }
+  }
+
+  return segmentsByWeek;
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `pnpm test -- layoutMultiDayEvents`
+Expected: PASS, 7 tests passed
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add components/events/calendar/utils/layoutMultiDayEvents.ts \
+        components/events/calendar/utils/__tests__/layoutMultiDayEvents.test.ts
+git commit -m "feat(calendar): add layoutMultiDayEvents util with tests"
+```
+
+---
+
+## Task 4: `ViewToggle` 컴포넌트
+
+리스트 ↔ 캘린더 세그먼트 컨트롤.
+
+**Files:**
+- Create: `components/events/calendar/ViewToggle.tsx`
+- Create: `components/events/calendar/CalendarView.module.scss` (이 task에서 초기 생성, 다음 task들이 추가)
+
+- [ ] **Step 1: SCSS 모듈 초기화**
+
+```scss
+// components/events/calendar/CalendarView.module.scss
+@import 'styles/variables';
+
+.viewToggle {
+  display: inline-flex;
+  background: #F0F0F5;
+  padding: 4px;
+  border-radius: 10px;
+}
+
+.viewToggle__btn {
+  border: 0;
+  background: transparent;
+  padding: 6px 14px;
+  border-radius: 7px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #6C6E7E;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+
+  &.on {
+    background: #fff;
+    color: #2B2D36;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+  }
+}
+```
+
+- [ ] **Step 2: `ViewToggle.tsx` 구현**
+
+```tsx
+// components/events/calendar/ViewToggle.tsx
+import { useRouter } from 'next/router';
+import dayjs from 'dayjs';
+import classNames from 'classnames/bind';
+import style from './CalendarView.module.scss';
+
+const cn = classNames.bind(style);
+
+export type ViewMode = 'list' | 'calendar';
+
+type Props = { current: ViewMode };
+
+const ViewToggle = ({ current }: Props) => {
+  const router = useRouter();
+
+  const switchTo = (mode: ViewMode) => {
+    if (mode === current) return;
+    if (mode === 'list') {
+      const { view, year, month, ...rest } = router.query;
+      router.push({ pathname: '/events', query: rest }, undefined, { shallow: true });
+    } else {
+      const now = dayjs();
+      router.push(
+        {
+          pathname: '/events',
+          query: {
+            ...router.query,
+            view: 'calendar',
+            year: router.query.year ?? now.year(),
+            month: router.query.month ?? now.month() + 1,
+          },
+        },
+        undefined,
+        { shallow: true }
+      );
+    }
+  };
+
+  return (
+    <div className={cn('viewToggle')} role="tablist" aria-label="보기 전환">
+      <button
+        type="button"
+        role="tab"
+        aria-selected={current === 'list'}
+        className={cn('viewToggle__btn', { on: current === 'list' })}
+        onClick={() => switchTo('list')}
+      >
+        📋 리스트
+      </button>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={current === 'calendar'}
+        className={cn('viewToggle__btn', { on: current === 'calendar' })}
+        onClick={() => switchTo('calendar')}
+      >
+        📅 캘린더
+      </button>
+    </div>
+  );
+};
+
+export default ViewToggle;
+```
+
+- [ ] **Step 3: 빌드 확인**
+
+Run: `pnpm build`
+Expected: 빌드 성공 (이 컴포넌트는 아직 어디서도 import되지 않음)
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add components/events/calendar/CalendarView.module.scss \
+        components/events/calendar/ViewToggle.tsx
+git commit -m "feat(calendar): add ViewToggle component"
+```
+
+---
+
+## Task 5: `CalendarHeader` 컴포넌트
+
+월 네비 + "오늘" 버튼.
+
+**Files:**
+- Create: `components/events/calendar/CalendarHeader.tsx`
+- Modify: `components/events/calendar/CalendarView.module.scss` (append)
+
+- [ ] **Step 1: SCSS 추가**
+
+`CalendarView.module.scss` 끝에 추가:
+
+```scss
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.header__nav {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.header__monthLabel {
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: -0.012em;
+}
+
+.header__navBtn {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  border: 1px solid #E1E1E8;
+  background: #fff;
+  cursor: pointer;
+  font-size: 16px;
+  color: #6C6E7E;
+  &:hover { border-color: #CDCED6; }
+}
+
+.header__todayBtn {
+  margin-left: 8px;
+  padding: 6px 12px;
+  border-radius: 8px;
+  border: 1px solid #E1E1E8;
+  background: #fff;
+  color: #2B2D36;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+}
+```
+
+- [ ] **Step 2: `CalendarHeader.tsx` 구현**
+
+```tsx
+// components/events/calendar/CalendarHeader.tsx
+import { useRouter } from 'next/router';
+import dayjs from 'dayjs';
+import classNames from 'classnames/bind';
+import style from './CalendarView.module.scss';
+
+const cn = classNames.bind(style);
+
+type Props = { year: number; month: number };
+
+const CalendarHeader = ({ year, month }: Props) => {
+  const router = useRouter();
+
+  const navigate = (deltaMonths: number | 'today') => {
+    let nextYear = year;
+    let nextMonth = month;
+    if (deltaMonths === 'today') {
+      const now = dayjs();
+      nextYear = now.year();
+      nextMonth = now.month() + 1;
+    } else {
+      const next = dayjs(`${year}-${String(month).padStart(2, '0')}-01`).add(deltaMonths, 'month');
+      nextYear = next.year();
+      nextMonth = next.month() + 1;
+    }
+    router.push(
+      { pathname: '/events', query: { ...router.query, view: 'calendar', year: nextYear, month: nextMonth } },
+      undefined,
+      { shallow: true }
+    );
+  };
+
+  return (
+    <div className={cn('header__nav')}>
+      <button type="button" className={cn('header__navBtn')} aria-label="이전 달" onClick={() => navigate(-1)}>‹</button>
+      <span className={cn('header__monthLabel')}>{year}년 {month}월</span>
+      <button type="button" className={cn('header__navBtn')} aria-label="다음 달" onClick={() => navigate(1)}>›</button>
+      <button type="button" className={cn('header__todayBtn')} onClick={() => navigate('today')}>오늘</button>
+    </div>
+  );
+};
+
+export default CalendarHeader;
+```
+
+- [ ] **Step 3: 빌드 확인 & 커밋**
+
+```bash
+pnpm build
+git add components/events/calendar/CalendarHeader.tsx \
+        components/events/calendar/CalendarView.module.scss
+git commit -m "feat(calendar): add CalendarHeader with month navigation"
+```
+
+---
+
+## Task 6: `CalendarGrid` (데스크탑)
+
+7×6 셀 그리드 + 다중일 이벤트 segment 렌더.
+
+**Files:**
+- Create: `components/events/calendar/CalendarGrid.tsx`
+- Modify: `components/events/calendar/CalendarView.module.scss`
+
+- [ ] **Step 1: SCSS 추가**
+
+`CalendarView.module.scss` 끝에 추가:
+
+```scss
+.grid__weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  margin-bottom: 8px;
+
+  div {
+    font-size: 12px;
+    font-weight: 600;
+    color: #6C6E7E;
+    text-align: center;
+    padding: 8px 0;
+  }
+  div:first-child { color: #D91C29; }
+  div:last-child  { color: #1D6CE0; }
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 1px;
+  background: #E8E8EE;
+  border: 1px solid #E8E8EE;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.grid__cell {
+  background: #fff;
+  min-height: 110px;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  cursor: pointer;
+  position: relative;
+  &:hover { background: #F7F7FA; }
+
+  &.outside { background: #F7F7FA; color: #8C8F9F; }
+}
+
+.grid__num {
+  font-size: 13px;
+  font-weight: 600;
+  padding: 2px 4px;
+
+  &.sun { color: #D91C29; }
+  &.sat { color: #1D6CE0; }
+  &.outside { color: #8C8F9F; }
+}
+
+.grid__numToday {
+  background: #0043FF;
+  color: #fff !important;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+}
+
+.grid__chip {
+  font-size: 11px;
+  padding: 3px 6px;
+  border-radius: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 500;
+  line-height: 1.3;
+}
+.grid__chip--start { border-radius: 4px 0 0 4px; margin-right: -9px; padding-right: 12px; }
+.grid__chip--mid   { border-radius: 0; margin-left: -9px; margin-right: -9px; padding-left: 12px; padding-right: 12px; }
+.grid__chip--end   { border-radius: 0 4px 4px 0; margin-left: -9px; padding-left: 12px; }
+
+.grid__more {
+  font-size: 11px;
+  color: #6C6E7E;
+  padding: 2px 6px;
+}
+```
+
+- [ ] **Step 2: `CalendarGrid.tsx` 구현**
+
+```tsx
+// components/events/calendar/CalendarGrid.tsx
+import dayjs from 'dayjs';
+import classNames from 'classnames/bind';
+import { Event } from 'model/event';
+import { TagResponse } from 'model/tag';
+import { buildCalendarMatrix } from './utils/buildCalendarMatrix';
+import { layoutMultiDayEvents, EventSegment } from './utils/layoutMultiDayEvents';
+import { tagColor } from './utils/tagColor';
+import style from './CalendarView.module.scss';
+import { useMemo } from 'react';
+
+const cn = classNames.bind(style);
+
+const MAX_CHIPS_PER_CELL = 2;
+const WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토'];
+
+type Props = {
+  year: number;
+  month: number;
+  events: Event[];
+  onSelectDate: (dateISO: string) => void;
+};
+
+const CalendarGrid = ({ year, month, events, onSelectDate }: Props) => {
+  const matrix = useMemo(() => buildCalendarMatrix(year, month), [year, month]);
+  const segmentsByWeek = useMemo(
+    () => layoutMultiDayEvents(events, matrix),
+    [events, matrix]
+  );
+  const todayISO = dayjs().format('YYYY-MM-DD');
+
+  // For each cell, decide which segments to display and overflow count
+  const renderWeek = (weekIdx: number) => {
+    const week = matrix[weekIdx];
+    const weekSegments = segmentsByWeek[weekIdx];
+
+    // For each cell column, count segments occupying it
+    const segmentsByCol: EventSegment[][] = Array.from({ length: 7 }, () => []);
+    weekSegments.forEach((seg) => {
+      for (let c = seg.startCol; c <= seg.endCol; c++) {
+        segmentsByCol[c].push(seg);
+      }
+    });
+
+    return week.map((cell, col) => {
+      const isToday = cell.date === todayISO && !cell.isOutside;
+      const segsHere = segmentsByCol[col];
+      const visibleSegs = segsHere.slice(0, MAX_CHIPS_PER_CELL);
+      const overflow = segsHere.length - visibleSegs.length;
+
+      return (
+        <div
+          key={cell.date}
+          className={cn('grid__cell', { outside: cell.isOutside })}
+          role="button"
+          tabIndex={0}
+          aria-label={`${cell.month}월 ${cell.day}일 행사 ${segsHere.length}건`}
+          onClick={() => onSelectDate(cell.date)}
+          onKeyDown={(e) => { if (e.key === 'Enter') onSelectDate(cell.date); }}
+        >
+          <span
+            className={cn('grid__num', {
+              sun: cell.dow === 0 && !cell.isOutside,
+              sat: cell.dow === 6 && !cell.isOutside,
+              outside: cell.isOutside,
+            })}
+          >
+            <span className={cn({ grid__numToday: isToday })}>{cell.day}</span>
+          </span>
+          {visibleSegs.map((seg) => {
+            // Only render chip in startCol of this segment (one chip per segment)
+            if (seg.startCol !== col) return null;
+            const color = tagColor(seg.event.tags.map((t: TagResponse) => t.tag_name));
+            const isStartChip = seg.isStart;
+            const isEndChip   = seg.isEnd;
+            const isPureSpanMid = !isStartChip && !isEndChip;
+            return (
+              <div
+                key={`${seg.eventId}-${seg.weekIndex}-${seg.startCol}`}
+                className={cn(
+                  'grid__chip',
+                  {
+                    'grid__chip--start': !isStartChip || (seg.endCol > seg.startCol && isStartChip && !isEndChip),
+                    'grid__chip--mid':   isPureSpanMid,
+                    'grid__chip--end':   !isEndChip && seg.endCol > seg.startCol,
+                  }
+                )}
+                style={{
+                  background: hexToBg(color, 0.08),
+                  color,
+                  borderLeft: `2px solid ${color}`,
+                  gridColumn: `span ${seg.endCol - seg.startCol + 1}`,
+                }}
+                title={seg.event.title}
+              >
+                {seg.event.title}
+              </div>
+            );
+          })}
+          {overflow > 0 && (
+            <span className={cn('grid__more')}>+{overflow} 더보기</span>
+          )}
+        </div>
+      );
+    });
+  };
+
+  return (
+    <>
+      <div className={cn('grid__weekdays')}>
+        {WEEKDAYS.map((d) => <div key={d}>{d}</div>)}
+      </div>
+      <div className={cn('grid')}>
+        {matrix.map((_, w) => renderWeek(w))}
+      </div>
+    </>
+  );
+};
+
+function hexToBg(hex: string, alpha: number): string {
+  const h = hex.replace('#', '');
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+export default CalendarGrid;
+```
+
+> 참고: segment를 셀별로 펼치는 방식은 CSS Grid의 `grid-column: span N` 을 사용해서 한 칩이 여러 셀에 걸치게 한다. 위 코드의 chip은 시작 셀에서만 렌더하고, span으로 너비를 늘린다. (`MonthlyEventList`의 기존 색감/스타일과는 독립이며 KTB DESIGN.md 토큰을 따른다.)
+
+- [ ] **Step 3: 빌드 확인 & 시각 확인용 스토리 페이지 (선택)**
+
+Run: `pnpm build`
+Expected: 빌드 성공 (아직 마운트 안 됨)
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add components/events/calendar/CalendarGrid.tsx \
+        components/events/calendar/CalendarView.module.scss
+git commit -m "feat(calendar): add CalendarGrid (desktop) with multi-day segments"
+```
+
+---
+
+## Task 7: `CalendarDotGrid` (모바일)
+
+점 캘린더 + 선택일 표시.
+
+**Files:**
+- Create: `components/events/calendar/CalendarDotGrid.tsx`
+- Modify: `components/events/calendar/CalendarView.module.scss`
+
+- [ ] **Step 1: SCSS 추가**
+
+`CalendarView.module.scss` 끝에 추가:
+
+```scss
+.dot__grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 2px;
+}
+
+.dot__cell {
+  aspect-ratio: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 600;
+  border-radius: 8px;
+  gap: 2px;
+  cursor: pointer;
+  position: relative;
+
+  &.outside { color: #8C8F9F; }
+  &.today   { background: #0043FF; color: #fff; }
+  &.selected { outline: 2px solid #0043FF; outline-offset: -2px; }
+  &.sun:not(.today):not(.outside) { color: #D91C29; }
+  &.sat:not(.today):not(.outside) { color: #1D6CE0; }
+}
+
+.dot__dots {
+  display: flex;
+  gap: 1.5px;
+
+  i {
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    display: inline-block;
+  }
+  i.plus { background: #8C8F9F; }
+}
+```
+
+- [ ] **Step 2: `CalendarDotGrid.tsx` 구현**
+
+```tsx
+// components/events/calendar/CalendarDotGrid.tsx
+import { useMemo } from 'react';
+import dayjs from 'dayjs';
+import classNames from 'classnames/bind';
+import { Event } from 'model/event';
+import { TagResponse } from 'model/tag';
+import { buildCalendarMatrix } from './utils/buildCalendarMatrix';
+import { tagColor } from './utils/tagColor';
+import style from './CalendarView.module.scss';
+
+const cn = classNames.bind(style);
+const MAX_DOTS = 3;
+
+type Props = {
+  year: number;
+  month: number;
+  events: Event[];
+  selectedDate: string | null;
+  onSelectDate: (dateISO: string) => void;
+};
+
+const CalendarDotGrid = ({ year, month, events, selectedDate, onSelectDate }: Props) => {
+  const matrix = useMemo(() => buildCalendarMatrix(year, month), [year, month]);
+  const todayISO = dayjs().format('YYYY-MM-DD');
+
+  // events-by-date map (DATE-typed, with start date)
+  const eventsByDate = useMemo(() => {
+    const map = new Map<string, Event[]>();
+    events
+      .filter((e) =>
+        e.event_time_type === 'DATE' &&
+        e.use_start_date_time_yn !== 'N' &&
+        e.start_date_time
+      )
+      .forEach((e) => {
+        const start = dayjs(e.start_date_time);
+        const end   = e.end_date_time ? dayjs(e.end_date_time) : start;
+        let cursor = start;
+        while (cursor.isBefore(end) || cursor.isSame(end, 'day')) {
+          const iso = cursor.format('YYYY-MM-DD');
+          if (!map.has(iso)) map.set(iso, []);
+          map.get(iso)!.push(e);
+          cursor = cursor.add(1, 'day');
+        }
+      });
+    return map;
+  }, [events]);
+
+  return (
+    <div className={cn('dot__grid')}>
+      {matrix.flat().map((cell) => {
+        const isToday = cell.date === todayISO && !cell.isOutside;
+        const isSelected = cell.date === selectedDate;
+        const dayEvents = eventsByDate.get(cell.date) ?? [];
+        const visible = dayEvents.slice(0, MAX_DOTS);
+        const overflow = dayEvents.length - visible.length;
+
+        return (
+          <div
+            key={cell.date}
+            className={cn('dot__cell', {
+              outside: cell.isOutside,
+              today: isToday,
+              selected: isSelected,
+              sun: cell.dow === 0,
+              sat: cell.dow === 6,
+            })}
+            role="button"
+            tabIndex={0}
+            aria-label={`${cell.month}월 ${cell.day}일 행사 ${dayEvents.length}건`}
+            onClick={() => onSelectDate(cell.date)}
+            onKeyDown={(e) => { if (e.key === 'Enter') onSelectDate(cell.date); }}
+          >
+            <span>{cell.day}</span>
+            {(visible.length > 0 || overflow > 0) && (
+              <div className={cn('dot__dots')}>
+                {visible.map((e, i) => (
+                  <i
+                    key={`${e.id}-${i}`}
+                    style={{ background: tagColor(e.tags.map((t: TagResponse) => t.tag_name)) }}
+                  />
+                ))}
+                {overflow > 0 && <i className={cn('plus')} />}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default CalendarDotGrid;
+```
+
+- [ ] **Step 3: 빌드 & 커밋**
+
+```bash
+pnpm build
+git add components/events/calendar/CalendarDotGrid.tsx \
+        components/events/calendar/CalendarView.module.scss
+git commit -m "feat(calendar): add CalendarDotGrid (mobile)"
+```
+
+---
+
+## Task 8: `DayDetailSheet` 컴포넌트
+
+선택일의 이벤트 목록 (데스크탑: react-modal, 모바일: 하단 시트).
+
+**Files:**
+- Create: `components/events/calendar/DayDetailSheet.tsx`
+- Modify: `components/events/calendar/CalendarView.module.scss`
+
+- [ ] **Step 1: SCSS 추가**
+
+`CalendarView.module.scss` 끝에 추가:
+
+```scss
+.sheet__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 9000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.sheet {
+  background: #fff;
+  border-radius: 12px;
+  padding: 20px;
+  max-width: 480px;
+  width: 90vw;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.sheet__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.sheet__title {
+  font-size: 16px;
+  font-weight: 800;
+  letter-spacing: -0.012em;
+}
+
+.sheet__close {
+  background: none;
+  border: 0;
+  font-size: 18px;
+  cursor: pointer;
+  color: #6C6E7E;
+}
+
+.sheet__empty {
+  text-align: center;
+  color: #6C6E7E;
+  padding: 32px 0;
+  font-size: 13px;
+}
+
+.sheet__item {
+  display: flex;
+  gap: 12px;
+  padding: 12px 0;
+  border-bottom: 1px solid #F0F0F5;
+  cursor: pointer;
+
+  &:last-child { border-bottom: 0; }
+
+  .sheet__bar { width: 3px; flex-shrink: 0; border-radius: 2px; }
+  .sheet__body {
+    .sheet__itemTitle { font-size: 14px; font-weight: 700; margin-bottom: 4px; }
+    .sheet__itemMeta  { font-size: 12px; color: #6C6E7E; }
+  }
+}
+
+// mobile bottom-sheet variant
+@media (max-width: 720px) {
+  .sheet {
+    align-self: flex-end;
+    max-width: 100vw;
+    width: 100vw;
+    border-radius: 16px 16px 0 0;
+    max-height: 70vh;
+  }
+  .sheet__overlay { align-items: flex-end; }
+}
+```
+
+- [ ] **Step 2: `DayDetailSheet.tsx` 구현**
+
+```tsx
+// components/events/calendar/DayDetailSheet.tsx
+import Modal from 'react-modal';
+import dayjs from 'dayjs';
+import Link from 'next/link';
+import classNames from 'classnames/bind';
+import { Event } from 'model/event';
+import { TagResponse } from 'model/tag';
+import { tagColor } from './utils/tagColor';
+import style from './CalendarView.module.scss';
+
+const cn = classNames.bind(style);
+const DOW = ['일', '월', '화', '수', '목', '금', '토'];
+
+type Props = {
+  isOpen: boolean;
+  selectedDate: string | null;
+  events: Event[];
+  onClose: () => void;
+};
+
+const DayDetailSheet = ({ isOpen, selectedDate, events, onClose }: Props) => {
+  if (!selectedDate) return null;
+  const d = dayjs(selectedDate);
+  const dayEvents = events.filter((e) => {
+    if (e.event_time_type !== 'DATE') return false;
+    if (e.use_start_date_time_yn === 'N') return false;
+    if (!e.start_date_time) return false;
+    const start = dayjs(e.start_date_time);
+    const end = e.end_date_time ? dayjs(e.end_date_time) : start;
+    return (d.isSame(start, 'day') || d.isAfter(start, 'day')) &&
+           (d.isSame(end, 'day')   || d.isBefore(end, 'day'));
+  });
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onRequestClose={onClose}
+      className={cn('sheet')}
+      overlayClassName={cn('sheet__overlay')}
+      ariaHideApp={false}
+    >
+      <div className={cn('sheet__header')}>
+        <span className={cn('sheet__title')}>
+          {d.month() + 1}월 {d.date()}일 ({DOW[d.day()]}) · 행사 {dayEvents.length}건
+        </span>
+        <button type="button" className={cn('sheet__close')} aria-label="닫기" onClick={onClose}>✕</button>
+      </div>
+
+      {dayEvents.length === 0 ? (
+        <div className={cn('sheet__empty')}>이 날은 등록된 행사가 없어요</div>
+      ) : (
+        <div>
+          {dayEvents.map((e) => {
+            const color = tagColor(e.tags.map((t: TagResponse) => t.tag_name));
+            const start = dayjs(e.start_date_time);
+            const end   = e.end_date_time ? dayjs(e.end_date_time) : start;
+            const isMulti = !start.isSame(end, 'day');
+            const meta = isMulti
+              ? `${start.format('M/D')} ~ ${end.format('M/D')} · ${e.organizer}`
+              : `${start.format('M월 D일 HH:mm')} · ${e.organizer}`;
+            return (
+              <Link href={`/event/detail/${e.id}`} key={e.id}>
+                <a className={cn('sheet__item')}>
+                  <div className={cn('sheet__bar')} style={{ background: color }} />
+                  <div className={cn('sheet__body')}>
+                    <div className={cn('sheet__itemTitle')}>{e.title}</div>
+                    <div className={cn('sheet__itemMeta')}>{meta}</div>
+                  </div>
+                </a>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </Modal>
+  );
+};
+
+export default DayDetailSheet;
+```
+
+- [ ] **Step 3: 빌드 & 커밋**
+
+```bash
+pnpm build
+git add components/events/calendar/DayDetailSheet.tsx \
+        components/events/calendar/CalendarView.module.scss
+git commit -m "feat(calendar): add DayDetailSheet for selected-day events"
+```
+
+---
+
+## Task 9: `CalendarView` 진입점
+
+뷰포트 분기 + 선택일 상태 + 헤더/그리드/시트 조립.
+
+**Files:**
+- Create: `components/events/calendar/CalendarView.tsx`
+- Modify: `components/events/calendar/CalendarView.module.scss`
+
+- [ ] **Step 1: SCSS 추가 (컨테이너)**
+
+`CalendarView.module.scss` 끝에 추가:
+
+```scss
+.container {
+  background: #fff;
+  border: 1px solid #E1E1E8;
+  border-radius: 12px;
+  padding: 24px;
+  margin: 16px 0;
+}
+
+@media (max-width: 720px) {
+  .container {
+    padding: 12px;
+    margin: 8px 0;
+  }
+}
+```
+
+- [ ] **Step 2: `CalendarView.tsx` 구현**
+
+```tsx
+// components/events/calendar/CalendarView.tsx
+import { useState, useContext } from 'react';
+import classNames from 'classnames/bind';
+import { Event } from 'model/event';
+import { WindowContext } from 'context/window';
+import CalendarHeader from './CalendarHeader';
+import CalendarGrid from './CalendarGrid';
+import CalendarDotGrid from './CalendarDotGrid';
+import DayDetailSheet from './DayDetailSheet';
+import style from './CalendarView.module.scss';
+
+const cn = classNames.bind(style);
+const MOBILE_BREAKPOINT = 720;
+
+type Props = {
+  year: number;
+  month: number;
+  events: Event[];
+};
+
+const CalendarView = ({ year, month, events }: Props) => {
+  const { windowX } = useContext(WindowContext);
+  const isMobile = windowX > 0 && windowX <= MOBILE_BREAKPOINT;
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+
+  return (
+    <div className={cn('container')}>
+      <CalendarHeader year={year} month={month} />
+      {isMobile ? (
+        <CalendarDotGrid
+          year={year}
+          month={month}
+          events={events}
+          selectedDate={selectedDate}
+          onSelectDate={(d) => setSelectedDate(d)}
+        />
+      ) : (
+        <CalendarGrid
+          year={year}
+          month={month}
+          events={events}
+          onSelectDate={(d) => setSelectedDate(d)}
+        />
+      )}
+      <DayDetailSheet
+        isOpen={!!selectedDate}
+        selectedDate={selectedDate}
+        events={events}
+        onClose={() => setSelectedDate(null)}
+      />
+    </div>
+  );
+};
+
+export default CalendarView;
+```
+
+- [ ] **Step 3: 빌드 & 커밋**
+
+```bash
+pnpm build
+git add components/events/calendar/CalendarView.tsx \
+        components/events/calendar/CalendarView.module.scss
+git commit -m "feat(calendar): add CalendarView entry component with viewport split"
+```
+
+---
+
+## Task 10: `pages/events.tsx` SSR 분기 & 토글 마운트
+
+캘린더 컴포넌트들을 실제 페이지에 wiring.
+
+**Files:**
+- Modify: `pages/events.tsx`
+
+- [ ] **Step 1: 현재 `pages/events.tsx` 백업하고 새 버전 작성**
+
+```tsx
+// pages/events.tsx (full replacement)
+import Banner from 'components/common/banner/banner';
+import FilterDateModal from 'components/common/modal/FilterDateModal';
+import FilterSearchModal from 'components/common/modal/FilterSearchModal';
+import FilterTagModal from 'components/common/modal/FilterTagModal';
+import LoginModal from 'components/common/modal/LoginModal';
+import ScheduledEventList from 'components/events/ScheduledEventList';
+import CalendarView from 'components/events/calendar/CalendarView';
+import CalendarHeader from 'components/events/calendar/CalendarHeader';
+import ViewToggle, { ViewMode } from 'components/events/calendar/ViewToggle';
+import Letter from 'components/features/letter/Letter';
+import Layout from 'components/layout';
+import { AuthContext } from 'context/auth';
+import { EventContext } from 'context/event';
+import { WindowContext } from 'context/window';
+import cookie from 'cookie';
+import dayjs from 'dayjs';
+import { useScheduledEvents, useMonthlyEvent } from 'lib/hooks/useSWR';
+import { blockMouseScroll, isModalOpen } from 'lib/utils/windowUtil';
+import { Event, EventResponse } from 'model/event';
+import style from 'styles/Home.module.scss';
+import React, { useEffect, useContext, useState, useRef } from 'react';
+import type { ReactElement } from 'react';
+import classNames from 'classnames/bind';
+import { GetServerSideProps } from 'next';
+import Head from 'next/head';
+
+const cn = classNames.bind(style);
+
+type ListProps = {
+  view: 'list';
+  isLoggedIn: boolean;
+  fallbackData: EventResponse[];
+};
+
+type CalendarProps = {
+  view: 'calendar';
+  year: number;
+  month: number;
+  isLoggedIn: boolean;
+  fallbackData: Event[];
+};
+
+type Props = ListProps | CalendarProps;
+
+const Events = (props: Props) => {
+  const authContext = React.useContext(AuthContext);
+  const [loginModalIsOpen, setLoginModalIsOpen] = useState(false);
+  const { modalState } = useContext(WindowContext);
+  const { date } = useContext(EventContext);
+  const bodyRef = useRef<HTMLDivElement>(null);
+
+  // list mode SWR
+  const listSWR = useScheduledEvents(
+    props.view === 'list' ? props.fallbackData : undefined
+  );
+  // calendar mode SWR
+  const calendarSWR = useMonthlyEvent({
+    param: props.view === 'calendar'
+      ? { year: props.year, month: props.month }
+      : { year: 1970, month: 1 }, // unused, but hook needs stable param
+    fallbackData: props.view === 'calendar' ? props.fallbackData : [],
+  });
+
+  useEffect(() => {
+    if (props.isLoggedIn) {
+      authContext.login();
+    } else {
+      authContext.logout();
+    }
+    if (modalState.currentModal !== 0) {
+      document.body.style.position = 'fixed';
+      document.body.style.overflow = 'hidden';
+    }
+
+    return () => {
+      document.body.style.position = 'relative';
+      document.body.style.overflow = 'unset';
+      bodyRef.current?.removeEventListener('wheel', blockMouseScroll);
+      setLoginModalIsOpen(false);
+    };
+  }, [props.isLoggedIn, modalState, date]);
+
+  return (
+    <main ref={bodyRef} className={cn('main')}>
+      <Head>
+        <title>Dev Event - 개발자 행사는 모두 데브이벤트 웹에서!</title>
+        <meta name="description" content="데브이벤트 웹에서 개발자 행사를 놓치지 마세요! 개발자를 위한 {웨비나, 컨퍼런스, 해커톤, 네트워킹} 소식을 알려드립니다." />
+        <meta name="keywords" content="데브이벤트 웹, Dev Event, 데브이벤트, 개발자 행사, 용감한 친구들, 개발자, 이벤트, 행사, 웨비나, 컨퍼런스, 해커톤, 네트워킹, IT" />
+        <meta property="og:image" content="/default/og_image.png" />
+        <meta property="og:title" content="Dev Event - 개발자 행사는 모두 데브이벤트 웹에서!" />
+        <meta property="og:description" content="개발자를 위한 {웨비나, 컨퍼런스, 해커톤, 네트워킹} 소식을 알려드립니다." />
+      </Head>
+      {modalState.currentModal === 0 && (
+        <>
+          <Banner />
+          <section className={cn('section')}>
+            <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '8px 0' }}>
+              <ViewToggle current={props.view} />
+            </div>
+            {props.view === 'list' ? (
+              <ScheduledEventList events={listSWR.scheduledEvents} isError={listSWR.isError} />
+            ) : (
+              <CalendarView
+                year={props.year}
+                month={props.month}
+                events={calendarSWR.monthlyEvent ?? []}
+              />
+            )}
+          </section>
+          <Letter />
+        </>
+      )}
+      {isModalOpen(modalState.currentModal, 1) && props.view === 'list' && (
+        <FilterSearchModal events={listSWR.scheduledEvents} isError={listSWR.isError} />
+      )}
+      {isModalOpen(modalState.currentModal, 2) && <FilterTagModal />}
+      {isModalOpen(modalState.currentModal, 3) && <FilterDateModal />}
+      <LoginModal
+        isOpen={loginModalIsOpen}
+        onClose={() => setLoginModalIsOpen(false)}
+      />
+    </main>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const cookies = context.req.headers.cookie || '';
+  const view = context.query.view === 'calendar' ? 'calendar' : 'list';
+
+  const parsedCookies = cookies ? cookie.parse(cookies) : {};
+  const isLoggedIn = Boolean(parsedCookies.access_token && parsedCookies.refresh_token);
+
+  if (view === 'calendar') {
+    const now = dayjs();
+    const yearParam = Number(context.query.year);
+    const monthParam = Number(context.query.month);
+    const year = Number.isFinite(yearParam) && yearParam > 0 ? yearParam : now.year();
+    const month = Number.isFinite(monthParam) && monthParam >= 1 && monthParam <= 12
+      ? monthParam
+      : now.month() + 1;
+    const res = await fetch(`${process.env.BASE_SERVER_URL}/front/v2/events/${year}/${month}`);
+    const events = await res.json();
+    return {
+      props: {
+        view: 'calendar' as const,
+        year,
+        month,
+        isLoggedIn,
+        fallbackData: events,
+      },
+    };
+  }
+
+  const res = await fetch(`${process.env.BASE_SERVER_URL}/front/v2/events/current`);
+  const events = await res.json();
+  return {
+    props: {
+      view: 'list' as const,
+      isLoggedIn,
+      fallbackData: events,
+    },
+  };
+};
+
+Events.getLayout = function getLayout(page: ReactElement) {
+  return <Layout>{page}</Layout>;
+};
+export default Events;
+```
+
+- [ ] **Step 2: 빌드 + 타입 체크**
+
+Run: `pnpm build`
+Expected: 빌드 성공
+
+- [ ] **Step 3: 수동 확인**
+
+Run: `pnpm dev`
+- `http://localhost:5000/events` → 기존 리스트 그대로
+- 우측에 "📋 리스트 / 📅 캘린더" 토글 보임
+- 캘린더 클릭 → URL이 `?view=calendar&year=&month=` 로 바뀌고 캘린더 그리드 표시
+- 리스트 클릭 → 다시 리스트로 복귀
+- 모바일 (Chrome DevTools 360px) → 점 캘린더 노출
+- 셀 클릭 → DayDetailSheet 열림, 카드 클릭 시 상세 페이지 이동
+- 월 네비 ‹ › → URL 변경 + 데이터 페치
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add pages/events.tsx
+git commit -m "feat(events): wire calendar view toggle into /events page"
+```
+
+---
+
+## Task 11: `pages/calender.tsx` 리디렉트
+
+기존 `/calender?year=&month=` 북마크 보호.
+
+**Files:**
+- Modify: `pages/calender.tsx`
+
+- [ ] **Step 1: 파일 전체 교체**
+
+```tsx
+// pages/calender.tsx (full replacement)
+import { GetServerSideProps } from 'next';
+import dayjs from 'dayjs';
+
+// This page only exists for backward compatibility.
+// It permanently redirects /calender?year=&month= → /events?view=calendar&year=&month=
+const Calender = () => null;
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const now = dayjs();
+  const yearParam = Number(context.query.year);
+  const monthParam = Number(context.query.month);
+  const year = Number.isFinite(yearParam) && yearParam > 0 ? yearParam : now.year();
+  const month = Number.isFinite(monthParam) && monthParam >= 1 && monthParam <= 12
+    ? monthParam
+    : now.month() + 1;
+
+  return {
+    redirect: {
+      destination: `/events?view=calendar&year=${year}&month=${month}`,
+      permanent: false, // 307 — keep until SEO confirms safe to use 308
+    },
+  };
+};
+
+export default Calender;
+```
+
+- [ ] **Step 2: 빌드 & 수동 확인**
+
+Run: `pnpm dev`
+- `http://localhost:5000/calender?year=2026&month=5` 접속 → `/events?view=calendar&year=2026&month=5`로 리디렉트 확인
+- `http://localhost:5000/calender` (쿼리 없음) → 현재 년/월로 리디렉트 확인
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add pages/calender.tsx
+git commit -m "feat(calender): redirect legacy /calender to /events?view=calendar"
+```
+
+---
+
+## Task 12: 수동 QA 체크리스트 통과
+
+전체 동작 확인 후 PR 작성 준비.
+
+- [ ] **Step 1: dev 서버 실행**
+
+Run: `pnpm dev`
+
+- [ ] **Step 2: 데스크탑 (1280px) 체크리스트**
+
+- [ ] `/events` 진입 시 기존 리스트 카드 정상
+- [ ] 우측 "📅 캘린더" 클릭 → URL `?view=calendar&...` 변화, 그리드 표시
+- [ ] 캘린더 그리드: 일요일 빨강, 토요일 파랑, 오늘 파란 원
+- [ ] outside 셀이 회색 배경
+- [ ] 다중일 이벤트(테스트 데이터에 5/14~5/16 또는 비슷한 게 있다면) 연속 막대로 표시
+- [ ] 같은 날 이벤트 3개 이상 → `+N 더보기` 표시
+- [ ] 셀 클릭 → `DayDetailSheet` 모달 열림
+- [ ] 모달에서 이벤트 카드 클릭 → `/event/detail/{id}` 정상 이동
+- [ ] ‹ › 월 네비 → URL 변경 + 데이터 갱신
+- [ ] "오늘" 버튼 → 현재 월로 복귀
+- [ ] "📋 리스트" 클릭 → 기존 리스트 복귀, 월 네비 사라짐
+
+- [ ] **Step 3: 모바일 (DevTools 375px) 체크리스트**
+
+- [ ] 점 캘린더 노출
+- [ ] 셀당 점 최대 3개 + "+" 회색 점 확인
+- [ ] 오늘 셀 파란 배경
+- [ ] 셀 탭 → 시트가 하단에서 슬라이드 인
+- [ ] 선택 셀 outline 표시
+- [ ] 시트 닫기 → 그리드로 복귀
+
+- [ ] **Step 4: 리디렉트 / 엣지 케이스**
+
+- [ ] `/calender?year=2026&month=5` → `/events?view=calendar&year=2026&month=5`
+- [ ] `/calender` (쿼리 없음) → 현재 년/월로 리디렉트
+- [ ] `/events?view=calendar&year=abc&month=99` → 현재 년/월로 폴백
+- [ ] 뒤로가기/앞으로가기 정상
+
+- [ ] **Step 5: 단위 테스트 전체 재실행**
+
+Run: `pnpm test`
+Expected: 모든 utils 테스트 PASS
+
+- [ ] **Step 6: 린트**
+
+Run: `pnpm lint`
+Expected: 에러 없음 (경고는 기존 코드 수준)
+
+- [ ] **Step 7: 최종 PR 본문 작성용 스크린샷 캡쳐**
+- 데스크탑 리스트 모드, 데스크탑 캘린더 모드, 모바일 점 캘린더, DayDetailSheet 4종
+
+---
+
+## 자체 점검 (writing-plans self-review)
+
+**1. Spec 커버리지**
+
+| Spec 결정 | 구현 위치 |
+|---|---|
+| D1 옵션 A 토글 | Task 4 ViewToggle, Task 10 events.tsx wiring |
+| D2 모바일 점 캘린더 | Task 7 CalendarDotGrid, Task 9 CalendarView 분기 |
+| D3 셀 클릭 → 시트 | Task 8 DayDetailSheet, Task 6/7 onSelectDate |
+| D4 기본 리스트 | Task 10 SSR 분기 (`view !== 'calendar'` → list) |
+| D5 URL 상태 | Task 4 ViewToggle, Task 5 CalendarHeader, Task 10 getServerSideProps |
+| D6 필터 칩 모드 간 유지 | EventFilter 그대로 사용 (Task 10에서 ScheduledEventList 내부에 마운트 유지) |
+| D7 `/calender` 리디렉트 | Task 11 |
+| D8 RECRUIT 제외 | Task 3 layoutMultiDayEvents `isRenderable`, Task 7 dot grid 필터 |
+| D9 다중일 연속 막대 | Task 3 segment 알고리즘, Task 6 chip span CSS |
+| D10 `+N 더보기` | Task 6 overflow 처리 (데스크탑), Task 7 plus dot (모바일) |
+| D11 기존 API 재사용 | Task 10 `useMonthlyEvent` 활용 |
+| 단위 테스트 (buildCalendarMatrix / layoutMultiDayEvents / tagColor) | Task 1, 2, 3 |
+| 6주(42칸) 고정 | Task 1 구현 명시 |
+| 월 경계 이벤트 segment | Task 3 테스트 케이스 |
+| dayjs `Asia/Seoul` | Task 0~3 모두 dayjs 사용 (TZ 명시는 추후 timezone 플러그인 도입 시 적용 — 현 시점은 호스트 TZ가 KST임을 전제, 별도 후속 작업 가능) |
+
+**2. Placeholder 스캔** — "TBD", "TODO" 없음. 모든 단계에 코드/명령어/예상 결과 포함.
+
+**3. 타입/메서드 일관성**
+- `CalendarCell`: Task 1에서 정의 → Task 3, 6, 7에서 그대로 사용 ✓
+- `EventSegment`: Task 3에서 정의 → Task 6에서 사용 ✓
+- `useMonthlyEvent`: `lib/hooks/useSWR.tsx`의 실제 export 이름 사용 ✓
+- `WindowContext.windowX`: 실제 컨텍스트 필드 일치 ✓
+- `Event` 모델 필드명(`event_time_type`, `start_date_time`, `use_start_date_time_yn`) — `model/event.ts` 정의와 일치 ✓
+- `tagColor` 인자: 태그명 배열로 통일 (Task 2 정의, Task 6/7/8에서 `e.tags.map(t => t.tag_name)` 으로 호출) ✓
+
+**4. 위험/주의 사항**
+- `react-modal`은 `ariaHideApp={false}`로 일단 둠 (다른 모달들도 동일 패턴). 운영 시 `Modal.setAppElement('#__next')` 처리는 별도 작업.
+- `next/router`의 `shallow: true`는 같은 경로일 때만 동작 — `/events` 안의 토글이므로 OK. 다만 SSR 데이터가 SWR fallbackData로만 전달되므로 첫 토글 시 클라이언트에서 한 번 fetch 발생.
+- `useMonthlyEvent` 훅이 fallbackData 인자를 매번 받지만 SWR 키가 `[year, month]`로 다르면 새로 페치하므로 동작 OK.
+- Jest 셋업이 기존에 없어 Task 0이 다소 무겁다 — 팀이 향후 테스트 작성 의지가 없다면 Task 0과 utils 테스트는 건너뛰고 수동 QA로만 갈 수도 있음 (스펙 권장 사항이며 강제 아님).
+
+---
+
+**Plan complete and saved to `docs/superpowers/plans/2026-05-12-events-calendar-view.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — 각 Task마다 새 서브에이전트 dispatch + 사이 리뷰. 빠른 반복.
+
+**2. Inline Execution** — 현재 세션에서 executing-plans로 배치 실행 + 체크포인트.
+
+어떤 방식으로 진행하시겠어요?

--- a/docs/superpowers/specs/2026-05-11-event-detail-renewal-design.md
+++ b/docs/superpowers/specs/2026-05-11-event-detail-renewal-design.md
@@ -1,0 +1,195 @@
+# Event Detail Page Renewal — Design Spec
+
+**Date:** 2026-05-11
+**Scope:** `/event/detail/[eventId]` 페이지 비주얼 리뉴얼
+**Source of truth:** 프로젝트 루트의 `DESIGN.md` (KTB 비주얼 시스템)
+
+## Goal
+
+`/event/detail/[eventId]` 페이지를 `DESIGN.md` (KTB / Vapor 토큰 시스템) 기준으로 리뉴얼한다. 행사 목록(`/events`) 카드에서 적용한 토큰·타이포·인터랙션과 시각적으로 연속된 상세 페이지를 만든다. React 구조는 유지하고 SCSS와 일부 JSX 마이크로 변경만 한다.
+
+## Out of Scope
+
+- `Letter` (뉴스레터 신청) 컴포넌트 리스타일링
+- 마크다운 파서/렌더링 로직 변경
+- API/데이터 모델 변경
+- 다크 테마 별도 정의 (기존 `Theme.scss`의 `[data-theme]` 매핑 그대로 사용)
+
+## Architecture
+
+영향 받는 파일:
+
+- `pages/event/detail/[eventId].tsx` — JSX 마이크로 변경 (DdayTag 추가, 아이콘 컬러 토큰화, 메타라벨 prefix 정리)
+- `styles/EventDetail.module.scss` — 전면 리라이트
+- `components/common/tag/DdayTag.tsx` / `DdayTag.module.scss` — 재사용 (이미 DESIGN.md 적용 완료)
+- 토큰: `styles/_color.scss` + `styles/Theme.scss` (이전 작업으로 이미 정비됨, 추가 작업 불필요)
+
+## Decisions (사용자 확정)
+
+1. **Hero 레이아웃**: 하이브리드 — 5:3 비율 썸네일 유지하면서 DESIGN.md 토큰 적용
+2. **본문(마크다운) 영역**: Flat (흰 캔버스 + 얇은 divider) — `common-card` 표면 미사용
+3. **CTA 버튼**: 모든 viewport에서 in-flow (모바일 sticky bar 없음)
+
+## Hero — Desktop (≥1200px)
+
+```
+┌─────────────────┬──────────────────────────────────────────┐
+│                 │  [share][bookmark]      ← absolute top-R │
+│   THUMB         │  organizer text                          │
+│   400px × 5:3   │  Title (32px / 700 / -0.012rem)          │
+│   radius 12     │  일시  26. 6. 14(토) 10:00~18:00          │
+│   [D-3 badge]   │  [tag] [tag] [tag]                       │
+│                 │  [참여하기 ─ btn-ktb]                     │
+└─────────────────┴──────────────────────────────────────────┘
+container: max-width 1200, mx auto, padding 64px 32px
+columns: 400px 1fr, gap 32px
+```
+
+**Thumb:**
+- `width: 400px; aspect-ratio: 5 / 3; flex-shrink: 0;`
+- `border-radius: 12px;` (`--border-radius-400` 등가)
+- `overflow: hidden; position: relative;`
+- 이미지: `Image` `layout="fill"` `objectFit="cover"`
+- 종료된 행사: `position: absolute inset 0; background: rgba(0,0,0,0.4);` 오버레이
+- 종료 안 된 행사: `DdayTag` (`startDateTime` / `endDateTime`) 좌상단 absolute (top 12, left 12, z-index 2)
+
+**Info column:**
+- `flex: 1; display: flex; flex-direction: column; gap: 16px;`
+- `position: relative; padding-right: 88px;` (action 버튼 자리)
+
+**Action buttons (share / bookmark):**
+- `position: absolute; top: 0; right: 0; display: flex; gap: 4px;`
+- 각 버튼 36×36, radius 8, background transparent
+- hover: `background: var(--vapor-gray-100);`
+- 아이콘 컬러: `var(--vapor-gray-500)` (기본), bookmark 활성 시 `var(--ktb-tech-blue)`
+
+**Organizer text:**
+- `font-size: 14px; font-weight: 500; color: var(--vapor-gray-600);`
+
+**Title (h1):**
+- `font-size: 32px; font-weight: 700; line-height: 1.3; letter-spacing: -0.012rem; color: var(--vapor-gray-900); margin: 0; word-break: keep-all;`
+
+**Meta (일시):**
+- 부모 `display: flex; align-items: baseline; gap: 8px; font-size: 14px;`
+- `.meta-label`: `color: var(--vapor-gray-500); font-weight: 500; flex-shrink: 0;`
+- `.meta-value`: `color: var(--vapor-gray-700); font-weight: 500;`
+
+**Tags:**
+- `display: flex; flex-wrap: wrap; gap: 6px;`
+- `event-tag` 클래스를 `FilterTag` 컴포넌트 사용으로 변경 (이미 DESIGN.md 적용된 chip — gray-100 bg, gray-800 text, radius 8, 13px)
+
+**CTA (`.apply-btn`):**
+- `background: var(--ktb-tech-blue); color: #fff;`
+- `padding: 12px 24px; border-radius: 12px;`
+- `font-size: 16px; font-weight: 700; letter-spacing: -0.012rem;`
+- `align-self: flex-start;` (콘텐츠 너비)
+- `min-height: 48px; display: inline-flex; align-items: center;`
+- hover: `background: var(--ktb-tech-navy-hover);` (`#0238D1`)
+- active: `transform: translateY(0)` (현재의 1px 점프 제거)
+
+## Hero — Tablet/Mobile (≤1199px)
+
+- 컨테이너: `flex-direction: column; padding: 32px 32px;` → ≤600 `padding: 24px 16px;`
+- Thumb: `width: 100%; aspect-ratio: 5 / 3;`
+- Info: 썸네일 아래, `padding-right: 0;` (action 버튼이 썸네일 위로 이동)
+- Action 버튼: 썸네일 영역에 absolute top 12 right 12, `background: rgba(255,255,255,0.85); backdrop-filter: blur(4px);` 32×32
+- Title: 24px (≤1199) → 20px (≤600)
+- CTA: `width: 100%;` full-width 48px
+
+## Content 영역 (마크다운)
+
+**Container:**
+- `max-width: 1200px; margin: 0 auto; padding: 0 32px 40px;` (desktop)
+- ≤600: `padding: 0 16px 40px;`
+- ≤320: `padding: 0 16px 32px; gap: 24px;`
+
+**Top divider:**
+- Hero와 content 사이 `border-top: 1px solid var(--vapor-gray-300);` 단일선
+- divider 자체에는 외부 margin/padding 없음, container의 padding-top 24px
+
+**Typography (DESIGN.md §3 매핑):**
+
+| Element | Size | Weight | Color | Notes |
+|---------|------|--------|-------|-------|
+| h1 | 32px | 700 | gray-900 | margin 32 0 16, letter-spacing -0.012rem |
+| h2 | 24px | 700 | gray-900 | 동일 |
+| h3 | 20px | 700 | gray-900 | 동일 |
+| h4 | 18px | 700 | gray-900 | 동일 |
+| h5 | 16px | 700 | gray-900 | 동일 |
+| h6 | 14px | 700 | gray-900 | 동일 |
+| p | 16px | 400 | gray-900 | line-height 1.5, margin 0 0 16 |
+| li | 16px | 400 | gray-900 | line-height 1.6, margin 8 0 |
+| strong | inherit | 700 | gray-900 | — |
+| em | inherit | inherit | inherit | font-style italic |
+
+≤320: 각 H 단계 -2~-4px, p/li 15px.
+
+**Code / Pre:**
+- 인라인 `code`: `background: var(--vapor-gray-100); padding: 2px 6px; border-radius: 6px;` mono `font-size: 14px; color: var(--vapor-text-danger);`
+- `pre`: `background: var(--vapor-gray-100); padding: 16px; border-radius: 12px; overflow-x: auto;` 내부 code는 색상 reset
+
+**Blockquote:**
+- `border-left: 4px solid var(--ktb-tech-blue); background: var(--vapor-gray-050); padding: 16px 20px; margin: 24px 0; color: var(--vapor-gray-900);`
+
+**Hr:**
+- `border-top: 1px solid var(--vapor-gray-300); margin: 32px 0;`
+
+**Link:**
+- `color: var(--ktb-tech-blue);` hover `color: var(--ktb-tech-navy-hover); text-decoration: underline;`
+
+**Image:**
+- `max-width: 100%; height: auto; border-radius: 12px; margin: 24px 0;` (border 제거)
+
+**Table:**
+- `border-collapse: collapse; width: 100%;`
+- th/td: `padding: 12px; border: 1px solid var(--vapor-gray-300);`
+- th: `background: var(--vapor-gray-100); font-weight: 700; color: var(--vapor-gray-900);`
+- `tr:hover`: `background: var(--vapor-gray-050);`
+
+## 빈 상태 (description 없음)
+
+- 외부: `display: flex; justify-content: center; padding: 24px 0;`
+- 내부 카드: `background: var(--vapor-gray-050); border-radius: 24px; padding: 40px 20px; max-width: 480px;`
+- 메시지 1번째 줄: weight 700 16px gray-900
+- 메시지 2번째 줄: weight 500 15px gray-600 (`margin-top: 8px`)
+
+## JSX 변경 (최소)
+
+`pages/event/detail/[eventId].tsx`:
+1. 썸네일 컨테이너 안에 `DdayTag` 마운트 (행사 종료 안 됐을 때)
+2. 종료 상태 오버레이 (`event-detail__image__done`) 마운트 (행사 종료됐을 때)
+3. `ShareIcon` / `BookmarkIcon` 컬러 prop: `var(--gray-2)` → `var(--vapor-gray-500)`, 활성 bookmark `#007AFF` → `var(--ktb-tech-blue)`
+4. 태그 렌더링: `<span className={cx('event-tag')}>` → `<FilterTag label={tag.tag_name} size="regular" type="location" />`
+5. 종료 판정 헬퍼 추가: `isEventDone()` — 기존 Item.tsx 패턴 참조
+6. 메타라벨 prefix (`일시`) 유지 — 마크업 변경 없음
+
+## Token Cleanup
+
+`EventDetail.module.scss`에서 다음 하드코딩 제거:
+
+| Before | After |
+|--------|-------|
+| `var(--text-1)` | `var(--vapor-gray-900)` |
+| `var(--gray-2)` | `var(--vapor-gray-700)` (meta), `var(--vapor-gray-500)` (icon), `var(--vapor-gray-600)` (placeholder) — 맥락별 |
+| `var(--background-1)` | `var(--vapor-gray-000)` |
+| `#2c4cef` / `#1e3bcf` | `var(--ktb-tech-blue)` / `var(--ktb-tech-navy-hover)` |
+| `#ebebeb` | `var(--vapor-gray-300)` (border) |
+| `#e1e2e6` | `var(--vapor-gray-300)` |
+| `#f5f5f5` | `var(--vapor-gray-100)` |
+| `#f5f7ff` | `var(--vapor-gray-050)` |
+| `#d3d4d8` | `var(--vapor-gray-300)` |
+| `#f9f9f9` | `var(--vapor-gray-050)` |
+| `#e53e3e` | `var(--vapor-text-danger)` |
+
+## 검증 기준
+
+- [ ] Hero가 ≥1200, 1199~601, ≤600, ≤320 각 브레이크포인트에서 깨지지 않음
+- [ ] 종료된 행사: 썸네일 dim 오버레이, DdayTag 미표시
+- [ ] 진행 중 / D-day 행사: DdayTag pulse 애니메이션 정상
+- [ ] 마크다운 본문이 흰 캔버스 위에 자연스럽게 렌더링됨
+- [ ] 빈 상태 메시지가 회색 카드로 표시됨
+- [ ] CTA hover: 색상 변화만 (transform translateY 제거)
+- [ ] Share / bookmark 버튼: 모바일에서 썸네일 위 backdrop-blur, 데스크탑에서 info 우상단
+- [ ] 모든 색상값이 토큰 (`--vapor-*`, `--ktb-*`) 경유
+- [ ] `pnpm lint` 통과
+- [ ] `pnpm build` 성공

--- a/docs/superpowers/specs/2026-05-11-event-filter-renewal-design.md
+++ b/docs/superpowers/specs/2026-05-11-event-filter-renewal-design.md
@@ -1,0 +1,257 @@
+# Event Filter (ScheduledEventList 컨테이너) Renewal — Design Spec
+
+**Date:** 2026-05-11
+**Scope:** `/events` 페이지 ScheduledEventList 컨테이너 — 페이지 타이틀, 카테고리 칩, 검색바, 드롭다운 필터, 월별 페이지네이션, 등록 요청 버튼
+**Source of truth:** 프로젝트 루트의 `DESIGN.md` (KTB 비주얼 시스템)
+
+## Goal
+
+`/events` 페이지의 필터/네비게이션 영역(EventFilter + 하위 컴포넌트)을 DESIGN.md 토큰 체계로 리뉴얼한다. legacy 토큰(`--gray-N`, `--primary`, `--background-N`)을 `--vapor-gray-*` / `--ktb-tech-*` 로 교체하고, 매직값(`2.9881px` radius, `1.5px` border, `rgba(170,184,255,1)` hover) 을 DESIGN.md 표준값으로 정규화한다.
+
+## Out of Scope
+
+- 필터 모달 3종 (`FilterSearchModal`, `FilterTagModal`, `FilterDateModal`) — 모달 묶음에서 별도 처리
+- React 동작 로직 (state, context, URL 파싱) — 변경 없음
+- `JobGroupTag.tsx` / `BasicDropdown.tsx` / `BasicInput.tsx` 등 컴포넌트 prop API — 변경 없음
+- ItemList / 카드: 이전 작업으로 완료
+- Dark theme 별도 정의 — 기존 `[data-theme]` 매핑 활용
+
+## Architecture
+
+영향 받는 SCSS 파일 (JSX 변경 없음):
+
+- `components/features/filters/EventFilter.module.scss` — 외곽 + 페이지 타이틀
+- `components/features/register/Register.module.scss` — 등록 버튼 hover shadow
+- `components/common/buttons/FillButton.module.scss` — primary/gray/white 색상 토큰
+- `components/features/filters/ByJobGroup/FilterByJobGroup.module.scss` — 변경 없음 (margin only)
+- `components/common/tag/JobGroupTag.module.scss` — 카테고리 칩 토큰 + active state
+- `components/features/filters/searchEvent/SearchEvent.module.scss` — 변경 없음
+- `components/common/input/BasicInput.module.scss` — 검색 input radius/border/color
+- `components/common/dropdown/BasicDropdown.module.scss` — 드롭다운 radius/border/color/hover
+- `components/common/date/DateBoard.module.scss` — 페이지네이션 컨테이너 토큰
+- `components/common/date/DateElement.module.scss` — 페이지네이션 요소 토큰
+
+## Decisions (사용자 확정)
+
+1. **변경 범위**: 토큰 cleanup + 형태 정리 (radius 2.9881 → 8, border 1.5 → 1, hover 매직값 제거)
+2. **페이지 타이틀**: 현재 40px 크기 유지 (디자인 강조). 토큰만 정리 + letter-spacing
+3. **Active 칩 / Selected 드롭다운 배경**: `rgba(0, 67, 255, 0.08)` — ktb-tech-blue 의 8% tint
+
+---
+
+## EventFilter (`EventFilter.module.scss`)
+
+### `.block__desc` (페이지 타이틀 "전체 행사")
+
+- `font-size: 40px;` — 유지
+- `font-weight: 700;` — 유지
+- `line-height: 3rem;` — 유지
+- `color: var(--gray-1);` → `color: var(--vapor-gray-900);`
+- 추가: `letter-spacing: -0.012rem;`
+
+### 반응형 페이지 타이틀
+
+- 1075/950/800/700/tablet/mobile 각 단계 폰트 사이즈 유지 (2.1/2.0/1.8/1.6/1.6/1.6rem)
+
+### Toggle 버튼 (`.filter__group__toggle`) hover bg
+
+- `background-color: var(--gray-5);` (3 군데 — laptop 700, tablet, mobile) → `background-color: var(--vapor-gray-100);`
+
+---
+
+## FillButton (`components/common/buttons/FillButton.module.scss`)
+
+### `&.color`
+
+- `&--primary { background-color: var(--primary); }` → `background-color: var(--ktb-tech-blue);`
+- `&--gray { background-color: var(--gray-1); }` → `background-color: var(--vapor-gray-900);`
+- `&--white { background-color: var(--background-1); color: var(--primary); }` → `background-color: var(--vapor-gray-000); color: var(--ktb-tech-blue);`
+
+### `.button` 기본
+
+- `color: var(--background-1);` → `color: var(--vapor-gray-000);`
+- `background-color: var(--gray-1);` → `background-color: var(--vapor-gray-900);`
+
+---
+
+## Register (`components/features/register/Register.module.scss`)
+
+### `.register`
+
+- hover `box-shadow: 0 4px 12px rgba(44, 76, 239, 0.2);` → `0 4px 12px rgba(0, 67, 255, 0.18);`
+- `translateY(-2px)` 호버 유지 (CTA 강조)
+- 기존 mobile/tablet `display: none;` 유지
+
+---
+
+## JobGroupTag (`components/common/tag/JobGroupTag.module.scss`)
+
+### Base `.tag`
+
+- `color: var(--gray-1);` → `color: var(--vapor-gray-800);`
+- `border-color: var(--gray-4);` → `border-color: var(--vapor-gray-300);`
+- 그 외 (border 1px, radius 25/24/22/14, padding 16, height 36/34/32) — 유지
+
+### `.tag--light` hover
+
+- `border-color: var(--primary);` → `border-color: var(--ktb-tech-blue);`
+- `color: var(--primary);` → `color: var(--ktb-tech-blue);`
+- `background-color: rgba(237, 239, 255, 1);` → `background-color: rgba(0, 67, 255, 0.08);`
+
+### `.tag--dark` hover
+
+- `border-color: var(--primary);` → `border-color: var(--ktb-tech-blue);`
+- `color: var(--primary);` → `color: var(--ktb-tech-blue);`
+- `background-color: rgba(34, 35, 38, 1);` → `background-color: var(--vapor-gray-950);`
+
+### `.checked--light` (active)
+
+- `border-color: rgba(44, 76, 239, 1);` → `border-color: var(--ktb-tech-blue);`
+- `color: rgba(44, 76, 239, 1);` → `color: var(--ktb-tech-blue);`
+- `background-color: #edefff;` → `background-color: rgba(0, 67, 255, 0.08);`
+
+### `.checked--dark` (active dark)
+
+- `border-color: rgba(79, 108, 255, 1);` → `border-color: var(--ktb-tech-blue);`
+- `color: rgba(79, 108, 255, 1);` → `color: var(--ktb-tech-blue);`
+- `background-color: rgba(34, 35, 38, 1);` → `background-color: var(--vapor-gray-950);`
+
+---
+
+## BasicInput (`components/common/input/BasicInput.module.scss`)
+
+### `.container__input`
+
+- `background-color: var(--background-1);` → `var(--vapor-gray-000);`
+- `border: 1.5px solid;` → `border: 1px solid;`
+- `border-color: var(--gray-4);` → `border-color: var(--vapor-gray-300);`
+- `border-radius: 2.9881px;` → `border-radius: 8px;`
+- hover `border-color: rgba(170, 184, 255, 1);` → `border-color: var(--vapor-gray-400);`
+- focus `border-color: var(--primary);` → `border-color: var(--ktb-tech-blue);`
+- focus shadow 추가 (선택적): focus 시 `box-shadow: 0 0 0 3px rgba(0, 67, 255, 0.12);` (DESIGN.md 인풋 focus ring 패턴) — 단, 기존에 없었으면 추가하지 않음. 본 spec에서는 **추가하지 않는다** (시각 변화 최소).
+
+### `input[type='text']`
+
+- `color: var(--gray-1);` → `color: var(--vapor-gray-900);`
+
+### `input::-webkit-input-placeholder`
+
+- `color: var(--gray-3);` → `color: var(--vapor-gray-500);`
+- `font-weight: bold;` + `font-weight: 500;` 중복 → `font-weight: 500;` 한 줄로 정리
+
+---
+
+## BasicDropdown (`components/common/dropdown/BasicDropdown.module.scss`)
+
+### `.dropdown__header`
+
+- `color: var(--gray-1);` → `color: var(--vapor-gray-900);`
+- `background-color: var(--background-1);` → `var(--vapor-gray-000);`
+- `border: 1.5px solid;` → `border: 1px solid;`
+- `border-color: var(--gray-4);` → `border-color: var(--vapor-gray-300);`
+- `border-radius: 2.9881px;` → `border-radius: 8px;`
+- hover `border-color: rgba(170, 184, 255, 1);` → `border-color: var(--vapor-gray-400);`
+
+### `.dropdown__list`
+
+- `background-color: var(--background-1);` → `var(--vapor-gray-000);`
+- `border-radius: 2.9881px;` → `border-radius: 8px;`
+- `border: 1.5px solid;` → `border: 1px solid;`
+- `border-color: var(--gray-4);` → `border-color: var(--vapor-gray-300);`
+- 추가: `box-shadow: 0 8px 24px rgba(0, 0, 64, 0.08);` (드롭다운 깊이감)
+
+### `&__element`
+
+- `color: var(--gray-1);` → `color: var(--vapor-gray-900);`
+- hover `background-color: var(--background-2);` → `background-color: var(--vapor-gray-050);`
+
+### `.selected__light`
+
+- `color: var(--primary);` → `color: var(--ktb-tech-blue);`
+- `background-color: rgba(237, 239, 255, 1);` → `background-color: rgba(0, 67, 255, 0.08);`
+
+### `.selected__dark`
+
+- `color: var(--primary);` → `color: var(--ktb-tech-blue);`
+- `background-color: rgba(34, 35, 38, 1);` → `background-color: var(--vapor-gray-950);`
+
+### `.dropdown__header__focus`
+
+- `border-color: var(--primary);` → `border-color: var(--ktb-tech-blue);`
+
+### Scrollbar
+
+- `&::-webkit-scrollbar-thumb { background-color: #c4c4c4; }` → `background-color: var(--vapor-gray-400);`
+
+---
+
+## DateBoard (`components/common/date/DateBoard.module.scss`)
+
+### `.container`
+
+- `background-color: var(--background-1);` → `var(--vapor-gray-000);`
+- `border: 1.5px solid;` → `border: 1px solid;`
+- `border-color: var(--gray-4);` → `border-color: var(--vapor-gray-300);`
+- `border-radius: 2.9881px;` → `border-radius: 8px;`
+- hover `border-color: rgba(170, 184, 255, 1);` → `border-color: var(--vapor-gray-400);`
+
+### `.key--active`
+
+- `&:hover { background-color: var(--background-2); }` → `var(--vapor-gray-050);`
+
+### `.key--left` / `.key--right` border-radius
+
+- 각각 `2.9881px 0 0 2.9881px` / `0 2.9881px 2.9881px 0` → `8px 0 0 8px` / `0 8px 8px 0`
+
+### `.dropdown__header` (내부)
+
+- `color: var(--gray-1);` → `color: var(--vapor-gray-900);`
+
+### `.dropdown__list`
+
+- `background-color: var(--background-1);` → `var(--vapor-gray-000);`
+- `border-radius: 2.9881px;` → `8px;`
+- `border: 1.5px solid;` → `1px solid;`
+- `border-color: var(--gray-4);` → `var(--vapor-gray-300);`
+- 추가: `box-shadow: 0 8px 24px rgba(0, 0, 64, 0.08);`
+
+### `&__year`
+
+- `color: var(--gray-1);` → `color: var(--vapor-gray-900);`
+
+### `.container__focus`
+
+- `border-color: var(--primary);` → `var(--ktb-tech-blue);`
+
+---
+
+## DateElement (`components/common/date/DateElement.module.scss`)
+
+(파일 확인 필요. 동일 패턴으로 토큰 매핑)
+
+- `var(--gray-1)` → `var(--vapor-gray-900)`
+- `var(--gray-3)` → `var(--vapor-gray-500)`
+- `var(--gray-4)` → `var(--vapor-gray-300)`
+- `var(--primary)` → `var(--ktb-tech-blue)`
+- `var(--background-1)` → `var(--vapor-gray-000)`
+- `var(--background-2)` → `var(--vapor-gray-050)`
+- `2.9881px` → `8px`
+- `1.5px solid` → `1px solid`
+- `rgba(170, 184, 255, 1)` → `var(--vapor-gray-400)`
+
+(상세 매핑은 구현 단계에서 파일 읽고 확인)
+
+---
+
+## 검증 기준
+
+- [ ] "전체 행사" 타이틀이 vapor-gray-900으로 렌더링
+- [ ] 카테고리 칩 hover/active 시 ktb-tech-blue 텍스트 + 8% tint 배경
+- [ ] 검색바 focus 시 ktb-tech-blue 1px border (1.5 → 1px 확인)
+- [ ] 드롭다운 3종: 닫힘 상태 1px gray-300, 열림 상태 ktb-tech-blue focus border, 항목 hover gray-050
+- [ ] 월별 페이지네이션: 8px radius, 1px border, ktb-tech-blue focus
+- [ ] 등록 요청 버튼: ktb-tech-blue 배경, hover translateY + 톤다운된 그림자
+- [ ] 모든 `2.9881px` 제거됨 (grep 검증)
+- [ ] 모든 `1.5px solid` 제거됨 (1px로 변환)
+- [ ] `--primary` / `--gray-1~5` / `--background-1~2` 잔여 없음 (단 컴포넌트가 변경 범위 밖이면 예외)
+- [ ] `pnpm lint` / `pnpm build` 통과

--- a/docs/superpowers/specs/2026-05-11-events-card-renewal-design.md
+++ b/docs/superpowers/specs/2026-05-11-events-card-renewal-design.md
@@ -1,0 +1,213 @@
+# Events 페이지 카드 리뉴얼 — Design Spec
+
+- **Date**: 2026-05-11
+- **Author**: 고언약 + Claude Code (Opus 4.7)
+- **Status**: Draft — pending user review
+- **Reference**: [DESIGN.md](../../../DESIGN.md), kakaotechbootcamp.com course-card pattern
+- **Visual mockups**: `.superpowers/brainstorm/99710-1778482665/content/card-direction-v3.html`
+
+## 1. Goal
+
+`/events` 페이지에 렌더링되는 행사 카드를 DESIGN.md의 KTB course-card 스펙으로 리뉴얼한다. 반응형 하이브리드 — 데스크탑(≥1200px)은 horizontal row 유지, 그 이하는 vertical KTB 카드. 색·타이포·radius·간격은 모두 Vapor 토큰으로 정렬.
+
+## 2. Scope
+
+### In scope
+- `components/common/item/Item.tsx` — 카드 컴포넌트의 JSX 구조 일부 조정 (status badge 추가, organizer 위치 정렬)
+- `components/common/item/Item.module.scss` — 색·타이포·radius·간격·hover를 DESIGN.md 토큰으로 교체
+- `components/common/tag/DdayTag` — D-Day 표시 위치 조정 필요 시 함께 손봄 (status badge가 D-Day 자리를 일부 흡수할 수 있음)
+- 새 SCSS 변수 / mixin 필요 시 `styles/_variables.scss` 또는 `styles/_color.scss`에 추가
+
+### Out of scope
+- `pages/events.tsx` 레이아웃, `Banner`, `Letter`, `EventFilter`, 모달, 헤더/푸터 — 모두 그대로 둠
+- 데이터 모델 (`model/event.ts`), API, SWR hook 변경 없음
+- 기존 SCSS 변수(`$light-primary`, `$dark-primary` 등) 제거 — 별도 정리는 차후 작업
+- 다크 모드 — 현재 시스템 유지 (별도 ticket)
+
+## 3. Current State (요약)
+
+`components/common/item/Item.tsx`:
+- `<Link>` 안에 `item__content` 그리드 — 좌측 썸네일 252×144 (4px radius) + 우측 body
+- Body: organizer host (16px) + 공유/북마크 버튼 (절대 위치, top-right) + title (22px/600) + date + tags
+- `@media (max-width: 1200px)`에서 vertical로 전환 — 썸네일 16:9 max-height 190px, title 18px
+- 만료 상태(`isDone`) — 썸네일 어두운 오버레이 + 텍스트 톤 다운
+- `EndBulletIcon`, `NewBulletIcon` flag — 썸네일 좌상단 절대 위치
+
+기존 상태 시그널:
+- `EndBulletIcon` (만료, gray)
+- `NewBulletIcon` (NEW, primary blue)
+- `DdayTag` (남은 일수, 별도 컴포넌트)
+
+## 4. Target Design
+
+### 4.1 Responsive Behavior
+
+| Breakpoint | Layout | Variant |
+|---|---|---|
+| `≥1200px` (laptop+) | Horizontal row | B variant |
+| `<1200px` (tablet/mobile) | Vertical KTB course-card | A variant |
+
+`@media (max-width: 1200px)` 경계 유지 — 기존 코드와 동일.
+
+### 4.2 Horizontal Row (Desktop, ≥1200px)
+
+```
+┌──────────────┬────────────────────────────────────────┬─────┐
+│   thumb      │  host (14px hint)                       │ ⋯ ⋯ │
+│   280×168    │  title (20px/700, 2-line clamp)         │ ico │
+│   r=12px     │  calendar-icon · date (15px secondary)  │ ns  │
+│              │  [chip] [chip] [chip]                   │     │
+└──────────────┴────────────────────────────────────────┴─────┘
+```
+
+- Container: `grid-template-columns: 280px 1fr auto`, `gap: 32px`, `padding: 24px 0`, `border-bottom: 1px solid var(--gray-300, #E1E1E8)`
+- Thumb: width 280px, aspect-ratio 5/3 (height 168px), `border-radius: 12px`, `overflow: hidden`. Status badge absolute top-left at `(12px, 12px)`.
+- Host: 14px / 500 / `--gray-600` (#6C6E7E), margin-bottom 6px
+- Title: 20px / 700 / `--gray-900` (#2B2D36), `letter-spacing: -0.012rem`, `line-height: 1.4`, 2-line clamp (replace current single-line `text-ellipsis`)
+- Meta line: calendar SVG 18×18 + 15px / `--gray-700` (#525463), margin-bottom 10px
+- Tag chips: bg `--gray-100` (#F0F0F5), text `--gray-800` (#3E404C), padding 4px 10px, radius 8px, 13px / 500
+- Action buttons (share, bookmark): right column, top-aligned, 36×36 icon buttons, gray (`--gray-500`), hover bg `--gray-100`
+- Hover: 카드 전체 background-color 변화 없음. 썸네일 image scale 1.05 (`.item__content__img__mask:hover`) — DESIGN.md의 hover signature 유지
+
+### 4.3 Vertical KTB Card (Tablet/Mobile, <1200px)
+
+```
+┌─────────────────────────┐
+│   thumb                 │
+│   100% × aspect 5/3     │
+│   r=12px                │
+│   [badge]               │
+└─────────────────────────┘
+  host (13px hint)
+  title (16px/700, ellipsis)
+  📅 date (14px hint)
+  [chip] [chip] [chip]
+```
+
+- Card container: width 100%, no border, no shadow, padding 0 (gap만 사용)
+- Thumb: width 100%, aspect-ratio 5/3, radius 12px, overflow hidden. Badge absolute (12px, 12px).
+- Info block: padding-top 12px
+- Host: 13px / 500 / `--gray-600`, margin-bottom 4px
+- Title: 16px / 700 / `--gray-900`, `letter-spacing: -0.012rem`, single-line ellipsis, margin-bottom 4px
+- Period: 14px / `--gray-600` w/ calendar SVG 16×16, gap 4px, margin-bottom 10px
+- Tag chips: bg `--gray-100`, text `--gray-800`, padding 2px 8px, radius 6px, 12px / 500
+
+### 4.4 Status Badge System (NEW)
+
+기존 `EndBulletIcon` / `NewBulletIcon` flag를 통합 status badge로 대체. 위치는 썸네일 좌상단 (12px, 12px), 형태는 pill (border-radius 9999px), 4px 10px padding, 11px / 600.
+
+| 상태 | 트리거 | 배경 | Pulse |
+|---|---|---|---|
+| `live` 모집중 | `!isDone && 진행중` | `#0043ff` (Tech Blue) | `pulse-blue 2s infinite` |
+| `urgent` 마감임박 | D-Day ≤ 3 && `!isDone` | `#D91C29` (Danger Red) | `pulse-danger 2s infinite` |
+| `upcoming` 예정 | 미래 시작일, D-Day > 3 | `#000040` (Tech Navy) | none (plain) |
+| `ended` 종료 | `isDone` | `#6C6E7E` (Hint Gray) | none |
+
+`pulse-*` keyframe은 DESIGN.md §7 에 정의된 형태 그대로 SCSS에 포함:
+
+```scss
+@keyframes pulse-blue {
+  0%   { box-shadow: 0 0 0 0 rgba(0, 67, 255, 0.55); }
+  70%  { box-shadow: 0 0 0 8px rgba(0, 67, 255, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(0, 67, 255, 0); }
+}
+@keyframes pulse-danger {
+  0%   { box-shadow: 0 0 0 0 rgba(217, 28, 41, 0.55); }
+  70%  { box-shadow: 0 0 0 8px rgba(217, 28, 41, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(217, 28, 41, 0); }
+}
+```
+
+### 4.5 Ended (만료) 상태
+
+- 썸네일 위 `rgba(0,0,0,0.4)` 어두운 오버레이 유지 (기존 `item__content__img__done`)
+- Title 색: `--gray-600` (#6C6E7E) (기존 `var(--gray-2)` 와 비슷한 톤)
+- Host 색: `--gray-500` (#8C8F9F)
+- Tag chip 톤 다운: 그대로 둘 수도, opacity 0.6 줄 수도 — **결정: opacity 변경 없이 톤만 유지** (chip은 이미 회색이라 충분히 secondary)
+- Status badge: `ended` variant (회색 plain)
+
+### 4.6 D-Day 처리
+
+기존 `DdayTag`는 title 옆에 inline으로 노출됨. 새 디자인에서는:
+- **Desktop**: D-Day tag를 title 옆 inline 유지 (현재 위치 유지, 다만 색·radius 토큰 정렬)
+- **Mobile**: D-Day는 status badge로 통합 — D-Day ≤ 3이면 `urgent` 뱃지 노출, `DdayTag` 렌더 생략
+- `urgent` 상태에서는 D-Day 숫자를 status badge 텍스트로: `"D-2"`, `"D-1"`, `"오늘"`
+
+## 5. Component Contract
+
+### Item.tsx 변경 사항
+
+```tsx
+type Props = {
+  data: Event;
+  isEventDone: () => boolean;
+  isEventNew?: () => boolean;        // NEW 플래그 — 유지하되 status badge로 흡수
+  isFavorite: () => boolean;
+  onClickFavorite?: any;
+  childLast?: boolean;
+  parentLast?: boolean;
+  isLast?: boolean;
+};
+```
+
+내부 새 로직:
+```tsx
+type EventStatus = 'live' | 'urgent' | 'upcoming' | 'ended';
+
+function getEventStatus(data: Event, isDone: boolean): EventStatus {
+  if (isDone) return 'ended';
+  const daysUntil = getDaysUntil(data.start_date_time || data.end_date_time);
+  if (daysUntil <= 3 && daysUntil >= 0) return 'urgent';
+  if (daysUntil < 0) return 'live'; // 시작했지만 종료 전
+  return 'upcoming';
+}
+```
+
+`<StatusBadge status={status} dDay={dDay} />` 형태의 internal helper로 분리하거나 Item 내부 JSX로 인라인 처리. **결정: Item 내부 인라인 + scss className만 토글** (별도 컴포넌트 분리는 추후).
+
+## 6. Files Touched
+
+| File | Change |
+|---|---|
+| `components/common/item/Item.tsx` | status badge JSX 추가, `EndBulletIcon`/`NewBulletIcon` flag JSX 제거, organizer/host 위치 동일 유지, calendar 아이콘 inline SVG 추가 |
+| `components/common/item/Item.module.scss` | 전체 색·radius·간격·타이포를 DESIGN.md 토큰으로 교체. `pulse-blue`/`pulse-danger` keyframe 추가. `.status-badge` 및 variant 4종 정의. 1200px 미만 vertical 카드 재작성 |
+| `components/common/tag/FilterTag` (또는 `.module.scss`) | chip 스타일 정렬 — radius 8px(desktop)/6px(mobile), bg `--gray-100`, text `--gray-800`, font-weight 500 |
+| `components/common/tag/DdayTag` | 색·radius·font 토큰 정렬. mobile에서는 conditional render(`status !== 'urgent'`일 때만) |
+| `styles/_color.scss` 또는 `_variables.scss` | DESIGN.md 토큰을 SCSS variable로 추가 (`--gray-100` ~ `--gray-900`, `--ktb-tech-blue`, `--text-danger` 등) — `var(--*)` 직접 사용 vs SCSS 변수 둘 다 OK, 일관성을 위해 CSS custom property로 글로벌 선언 |
+
+## 7. Edge Cases
+
+- **organizer 없음**: 현재 `data.organizer`가 null일 가능성? — 코드 확인 후 null 가드 추가
+- **tags 없음**: `data.tags` 빈 배열일 때 chip row 자리 차지 안 함 (이미 빈 배열이면 nothing 렌더링)
+- **title 매우 김**: Desktop 2-line clamp, Mobile single-line ellipsis로 안전
+- **시작/종료 일자 없음**: 현재 `getEventDate()` 로직 그대로 — null 케이스 대응됨
+- **D-Day 계산**: 현재 `DdayTag` 내부 로직 재사용, `getDaysUntil()` 헬퍼는 `lib/utils/dateUtil`에 있을 가능성 — 확인 후 결정
+
+## 8. Testing Plan
+
+자동화 테스트는 없는 프로젝트로 보임 (next 12 + SCSS). 수동 검증:
+
+- [ ] `pnpm run dev` → `http://localhost:5000/events` 에서 desktop (>1200px) horizontal row 확인
+- [ ] DevTools로 viewport 1199px / 768px / 375px 각각 vertical 카드 확인
+- [ ] 카드 hover 시 썸네일 scale 1.05 확인 (기존 `item__content__img__mask transition`)
+- [ ] 4가지 상태 (live / urgent / upcoming / ended) 시각 확인 — 가능하면 실제 데이터 또는 fixture
+- [ ] 만료 카드 (`isDone === true`) 시각 확인 — 오버레이 + 톤 다운
+- [ ] 공유/북마크 버튼 클릭 동작 — 기존 핸들러 변경 없음
+- [ ] D-Day 표시 위치 확인 — desktop title 옆, mobile은 urgent badge로 통합
+- [ ] tag chip 클릭 → 필터 동작 (기존 동작 유지)
+- [ ] `/myevent`, `/calender`, `/search` 등 `Item`을 재사용하는 다른 페이지 회귀 확인
+
+## 9. Open Questions
+
+- [ ] `Item` 컴포넌트가 다른 페이지(`/myevent`, `/calender`, `/search`)에서도 쓰이는지? 만약 그렇다면 prop으로 variant 분기 필요 여부 결정 — **기본 가정**: 모든 페이지에서 동일하게 적용 (단일 비주얼 시스템)
+- [ ] D-Day 계산 함수 위치 확인 (`DdayTag` 내부 vs `lib/utils/dateUtil`)
+- [ ] `data.organizer` null 가능성
+
+위 3가지는 구현 단계 첫 번째 task로 코드 읽으면서 확정.
+
+## 10. Non-Goals (다시 한 번 강조)
+
+- 페이지 레이아웃, banner, filter UI, modal, header/footer — **건드리지 않음**
+- 다크 모드 — 현재 동작 유지 (확장은 차후)
+- API / 데이터 모델 / SWR — 변경 없음
+- SCSS 변수 시스템 전면 재정비 — 이 PR에서는 token 추가만, 기존 변수 제거 없음

--- a/docs/superpowers/specs/2026-05-11-header-footer-banner-renewal-design.md
+++ b/docs/superpowers/specs/2026-05-11-header-footer-banner-renewal-design.md
@@ -1,0 +1,216 @@
+# Header / Footer / Banner Renewal — Design Spec
+
+**Date:** 2026-05-11
+**Scope:** Global chrome (Header + Footer) + `/events` 최상단 Banner
+**Source of truth:** 프로젝트 루트의 `DESIGN.md` (KTB 비주얼 시스템)
+
+## Goal
+
+전역 chrome(Header / Footer)과 `/events` 페이지 최상단 Banner를 DESIGN.md 토큰·타이포 체계로 정렬한다. 구조는 그대로 두고 토큰 cleanup + 사이즈 다이어트(banner) + Profile dropdown 미니 정리.
+
+## Out of Scope
+
+- HeaderTab (현재 본문 코드가 모두 주석 — 변경하지 않음)
+- NoticeModal (모달 묶음에서 별도 처리)
+- LoginModal (사용자 지시: 모달 묶음 전체 제외)
+- Logo SVG 자체 (외부 컴포넌트, 재사용)
+- 다크 테마 별도 정의 — 기존 `[data-theme]` 매핑 활용
+
+## Architecture
+
+영향 받는 파일:
+
+- `components/layout/header/Header.module.scss` — 토큰·dropdown cleanup
+- `components/common/banner/banner.module.scss` — 타이포·높이 다이어트
+- `components/layout/footer/Footer.module.scss` — 토큰·max-width 정렬
+- `components/layout/header/HeaderTab.module.scss` — 토큰 정리 (구조 그대로)
+- 토큰 소스: `styles/_color.scss`, `styles/Theme.scss` (이전 작업으로 정비됨, 변경 없음)
+
+JSX 변경 없음 (모두 SCSS 토큰/값 교체).
+
+## Decisions (사용자 확정)
+
+1. **Banner**: 토큰 정리 + 사이즈 다이어트 (display 스케일 38~48px로 축소). CTA·그라데이션 추가 없음
+2. **Header dropdown**: 토큰 + 미니 정리 (caret 제거, radius 12, hover gray-100, item 고정 높이 제거)
+3. **Footer**: 토큰 정리만, max-width 1200으로 정렬
+
+---
+
+## Header (`components/layout/header/Header.module.scss`)
+
+### Outer `.header`
+
+- `position: fixed; top: 0; left: 0; width: 100%; z-index: 99;` — 유지
+- `min-height: 3.5rem;` — 유지 (56px)
+- `background-color: hsla(0, 0%, 100%, .88);` → 그대로 (frosted 효과 유지)
+- `backdrop-filter: saturate(150%) blur(32px);` — 유지
+- `border-bottom: 1px solid $light-gray-4;` → `border-bottom: 1px solid var(--vapor-gray-300);`
+
+### `.header__inner` / `.header__inner__nav` / `.header__logo` / `.header__tab`
+
+- 구조 변경 없음
+- Token: 없음 (색상이 직접 적용된 곳 없음)
+
+### `.header__buttons`
+
+- `.toggle__container:hover { background-color: var(--gray-5); }` → `background-color: var(--vapor-gray-100);`
+
+### `.profile` 블록
+
+- `.profile-button svg path { fill: var(--gray-2); }` → `fill: var(--vapor-gray-500);`
+
+### `.profile-menu` (Dropdown)
+
+- **caret 제거**: `.profile-menu::after { ... }` 블록 전체 삭제 + `@keyframes appearIn` 블록 유지(자연스러운 height 등장 애니메이션)
+- `border-radius: 10px;` → `border-radius: 12px;`
+- `width: 136px; height: 135px;` → `width: 160px;` (height auto — 컨텐츠 길이 따라)
+- `top: 42px; margin-left: -102px;` → `top: 44px; margin-left: -128px;` (160px 너비에 맞춰 우측 정렬 유지)
+- `background-color: #fff;` → `background-color: var(--vapor-gray-000);`
+- `box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);` → `box-shadow: 0 8px 24px rgba(0, 0, 64, 0.08), 0 0 0 1px var(--vapor-gray-300);`
+- `&__item` 정리:
+  - `padding: 0.5rem 1.813rem 0.5rem 1.813rem;` → `padding: 10px 16px;`
+  - `height: 45px;` → 제거 (auto)
+  - `background-color: #fff;` → `background-color: transparent;`
+  - `font-size: 0.875rem; color: #757575;` → `font-size: 14px; color: var(--vapor-gray-800);`
+  - `&:hover { background: #ebebeb; }` → `&:hover { background-color: var(--vapor-gray-100); }`
+  - `&:focus { background-color: #ebebeb; }` → `&:focus-visible { background-color: var(--vapor-gray-100); }`
+  - first-child/last-child border-radius 10px → 12px (메뉴 radius와 일치)
+- `@keyframes appearIn` final height 135 → `auto` 불가하므로 keyframes 자체 제거하고 단순 fade-in으로 교체:
+  ```scss
+  animation: fadeIn 0.15s ease-out;
+
+  @keyframes fadeIn {
+    from { opacity: 0; transform: translateY(-4px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+  ```
+
+### Tablet/Mobile
+
+- `@include tablet { .header__inner { padding: 0 $tablet_padding; width: 100%; } }` — 유지
+- `@include mobile { .header__inner { padding: 0 $mobile_padding; width: 100%; } }` — 유지
+
+---
+
+## HeaderTab (`components/layout/header/HeaderTab.module.scss`)
+
+### `.tab .tab-text`
+
+- `color: var(--gray-2);` → `color: var(--vapor-gray-600);`
+- `&.active { color: #313234; }` → `&.active { color: var(--vapor-gray-900); }`
+
+### `.new-badge`
+
+- `background-color: #3182f6;` → `background-color: var(--ktb-tech-blue);`
+- 그 외 유지 (현재 사용되지 않지만 향후 활용 대비)
+
+---
+
+## Banner (`components/common/banner/banner.module.scss`)
+
+### `.banner` 외곽
+
+- `position: relative; width: 100%;` — 유지
+- 높이 (사이즈 다이어트):
+  - 기본 (`min-width >= 1200`): `height: 28rem;` (was 30rem)
+  - `max-width: 1075px`: `height: 24rem;` (was 28rem)
+  - `max-width: 800px`: `height: 22rem;` (was 26rem)
+  - `@include tablet` (≤960): `height: 22rem;` (was 24rem)
+  - `max-width: 500px`: `height: 20rem;` (was 22rem)
+  - `@include mobile` (≤480): `height: 18rem;` 유지
+- `padding: 0 20px;` — 유지
+- `margin-top: $header_height` — 유지
+
+### `.banner__title`
+
+- Desktop: `font-size: 3rem; line-height: 1.2;` (was 3.8rem / 5.1rem)
+- `font-weight: 800;` (was 700) — display 스케일은 800으로 강조
+- `letter-spacing: -0.012rem;` (was 0em)
+- `color: #ffffff;` — 유지
+- Responsive:
+  - `max-width: 1075px`: `font-size: 2.75rem;`
+  - `max-width: 800px`: `font-size: 2.5rem; line-height: 1.2;` (was 3.4rem / 4.5rem)
+  - `@include tablet`: `font-size: 2.125rem; line-height: 1.2;`
+  - `max-width: 500px`: `font-size: 1.875rem; line-height: 1.2;` (was 2.3rem)
+  - `max-width: 400px`: `font-size: 1.75rem;`
+  - `@include mobile`: `font-size: 1.75rem; line-height: 1.2;` (was 2rem / 2.5rem)
+
+### `.banner__desc`
+
+- `font-size: 1.125rem; line-height: 1.5;` (was 1.23rem / 1.813rem)
+- `font-weight: 500;` (was 400)
+- `color: rgba(255, 255, 255, 0.85);` (was `#ffffff` — 약간 톤다운)
+- `padding-top: 1.5rem;` (was 1.938rem)
+- Responsive:
+  - `max-width: 800px`: `font-size: 1rem;` — 유지
+  - `@include tablet`: `font-size: 1rem;` — 유지
+  - `max-width: 400px`: `font-size: 0.9rem;` — 유지
+  - `@include mobile`: `font-size: 0.9rem;` — 유지
+
+### `.banner__video`
+
+- 위치/사이즈/object-fit — 그대로
+
+### `.notice--true` / `.notice--false`
+
+- 그대로 유지 (`margin-top: $header_height` / `$header_height + 36px`)
+
+---
+
+## Footer (`components/layout/footer/Footer.module.scss`)
+
+### `.footer` 컨테이너
+
+- `max-width: 1104px;` → `max-width: 1200px;` (DESIGN.md 컨테이너 규격)
+- `height: 200px;` → `min-height: 200px;` (텍스트 길이 따라 자동 확장 허용)
+- `padding: 0 32px;` 추가 (데스크탑에서 좌우 여백)
+- `background-color: var(--background-1);` → `background-color: var(--vapor-gray-000);`
+
+### `&__column`
+
+- `display: flex; flex-direction: column;` — 유지
+- `.footer__desc`:
+  - `color: var(--gray-2);` → `color: var(--vapor-gray-700);`
+  - `font-size: 16px;` → `font-size: 14px;`
+  - `font-weight: 500;`
+  - `margin-top: 1rem;` — 유지
+- `.footer__copyright`:
+  - `color: var(--gray-3);` → `color: var(--vapor-gray-500);`
+  - `font-size: 16px;` → `font-size: 14px;`
+  - `font-weight: 500;`
+  - `margin-top: 3rem;` — 유지
+  - `a` 내부 링크: `color: var(--ktb-tech-blue); text-decoration: none;` hover `text-decoration: underline; color: var(--ktb-tech-navy-hover);`
+
+### `&__row` (아이콘 영역)
+
+- `gap: 12px;` 추가 (현재 인접 요소 간 간격 0)
+- 위치 유지 (`position: absolute; bottom: 32px; right: 0;`)
+- `.github__icon` (외부 컴포넌트 className): `color: var(--vapor-gray-500);` `&:hover { color: var(--ktb-tech-blue); }` — 컴포넌트가 currentColor 사용 시 적용. 안 될 경우 SCSS는 그대로 두고 JSX 미수정.
+
+### Tablet/Mobile
+
+- `@include tablet`:
+  - `padding: 32px;` (기존 `32px $tablet_padding` 단순화)
+  - `max-width: 1271px;` → 제거 (전역 max-width 1200 적용)
+  - display block — 유지
+  - `&__desc`, `&__copyright`: `font-size: 13px; font-weight: 500;`
+- `@include mobile`:
+  - `padding: 32px 16px;` (was `32px 20px`)
+  - `&__desc`, `&__copyright`: `font-size: 13px;`
+  - `&__row { right: 16px; bottom: 0; }`
+
+---
+
+## 검증 기준
+
+- [ ] Header가 모든 페이지 상단에 frosted 효과로 고정됨
+- [ ] Profile 클릭 시 dropdown이 caret 없이 자연스럽게 fade-in
+- [ ] dropdown 메뉴 hover 시 `var(--vapor-gray-100)` 적용
+- [ ] Banner 타이틀이 데스크탑에서 48px (3rem) 으로 보이고 letter-spacing 적용됨
+- [ ] Banner desc가 약간 톤다운된 흰색(85% opacity)
+- [ ] Footer max-width 1200, github/whale 아이콘이 우측에 자연스럽게 정렬
+- [ ] Footer 링크가 `--ktb-tech-blue`로 렌더링
+- [ ] 다크 테마 토글 시 모든 영역이 자동으로 반전 (기존 매핑 활용)
+- [ ] `pnpm lint` 통과
+- [ ] `pnpm build` 성공
+- [ ] 잔여 하드코딩 hex: 영상 위 흰색 `#ffffff`만 허용. `#3182f6`, `#313234`, `#757575`, `#ebebeb`, `$light-gray-4` 모두 제거됨

--- a/docs/superpowers/specs/2026-05-12-events-calendar-view-design.md
+++ b/docs/superpowers/specs/2026-05-12-events-calendar-view-design.md
@@ -1,0 +1,326 @@
+# `/events` 캘린더 보기 추가 — 디자인 스펙
+
+- **작성일**: 2026-05-12
+- **작성**: 고언약
+- **상태**: Draft (브레인스토밍 완료, 구현 계획 수립 전)
+- **관련 페이지**: `/events`, `/calender` (deprecate)
+
+---
+
+## 1. 배경 & 목표
+
+`/events` 페이지는 현재 진행/예정 이벤트를 카드 리스트로만 보여준다. "이번 달에 어떤 행사가 어느 날 있는지" 한눈에 보고 싶다는 요구가 있어, **캘린더 보기 모드**를 추가한다.
+
+기존 `/calender?year=YYYY&month=MM` 페이지는 이름과 달리 실제 달력 격자가 아니라 "해당 월에 해당하는 이벤트 리스트"였다. 이번 작업으로 캘린더 그리드 UX를 도입하고, 라우트는 `/events` 한 곳으로 통합한다.
+
+### 성공 기준
+- `/events` 페이지에서 한 번의 토글로 리스트 ↔ 캘린더 전환이 가능하다.
+- 캘린더 모드에서 한 달의 이벤트가 시각적 격자로 노출된다 (다중일 이벤트는 연속 막대로).
+- 모바일에서 격자가 깨지지 않고 사용 가능한 형태로 전환된다.
+- 기존 `/calender` 북마크가 깨지지 않는다 (리디렉트 처리).
+
+---
+
+## 2. 확정 결정 사항 (브레인스토밍 결과)
+
+| # | 결정 | 비고 |
+|---|------|------|
+| D1 | 캘린더는 `/events` 페이지 안의 **뷰 모드 토글**로 구현 (옵션 A) | 한 페이지에서 두 시각 |
+| D2 | 모바일은 **점(dot) 캘린더 + 선택일 상세 패널** (옵션 1) | 격자 시각은 유지, 텍스트는 한 단계 아래로 |
+| D3 | 셀 클릭 → **그 날 이벤트 리스트 (모달/시트)** → 카드 클릭으로 상세 페이지 (옵션 C) | 데스크탑/모바일 일관 |
+| D4 | 기본 뷰는 리스트 (기존 동작 보존) | 사용자 놀라지 않음 |
+| D5 | URL이 진실의 근원: `/events?view=calendar&year=YYYY&month=M` | 공유/뒤로가기/SSR 친화 |
+| D6 | 필터 칩 상태는 두 뷰 간 유지 | 컨텍스트 기반, 추가 작업 없음 |
+| D7 | 기존 `/calender` → `307` 리디렉트 to `/events?view=calendar&...` | 북마크/SEO 보호 |
+| D8 | 캘린더 그리드는 `event_time_type === 'DATE'` 만 표시 (RECRUIT 제외) | 그리드 가독성 보호 |
+| D9 | 다중일 이벤트는 시작~종료 셀에 걸친 **연속 막대**로 렌더 | |
+| D10 | 셀당 칩 한도(데스크탑 2, 모바일 점 3) 초과 시 `+N 더보기` 표기 | 셀 높이 폭주 방지 |
+| D11 | 데이터 호출은 기존 `/front/v2/events/{year}/{month}` 활용 | 신규 API 불필요 |
+
+### 비목표
+- 주(week) / 일(day) 뷰
+- 드래그앤드롭, 인라인 편집
+- iCal / 캘린더 내보내기
+- 즐겨찾기 이벤트만 보는 캘린더 필터
+- 키보드 네비게이션 (follow-up)
+
+---
+
+## 3. 컴포넌트 구조
+
+### 신규 파일
+
+```
+components/events/calendar/
+├── CalendarView.tsx              # 뷰 진입점, viewport 분기 (desktop ↔ mobile)
+├── CalendarHeader.tsx            # "‹ 2026년 5월 › / 오늘" 월 네비게이션
+├── CalendarGrid.tsx              # 데스크탑 7×6 그리드
+├── CalendarDotGrid.tsx           # 모바일 점 캘린더
+├── DayDetailSheet.tsx            # 셀 클릭 시 그 날 이벤트 리스트
+├── ViewToggle.tsx                # "📋 리스트 / 📅 캘린더" 세그먼트
+├── CalendarView.module.scss
+└── utils/
+    ├── buildCalendarMatrix.ts    # year/month → 6주×7일 Date 행렬
+    ├── layoutMultiDayEvents.ts   # 이벤트 → 주 단위 segment 배치
+    └── tagColor.ts               # 태그명 → KTB 색
+```
+
+### 변경되는 파일
+
+| 파일 | 변경 |
+|------|------|
+| `pages/events.tsx` | `view`/`year`/`month` 쿼리 읽기 → 리스트 vs `CalendarView` 분기. SSR에서 모드별 API 호출. `ViewToggle` 마운트 |
+| `pages/calender.tsx` | 컴포넌트 본체 제거, `getServerSideProps`에서 `/events?view=calendar&year=&month=`로 307 리디렉트만 처리 |
+| `lib/hooks/useSWR.ts` | 신규 `useMonthlyEvents(year, month, fallbackData)` 추가 |
+| `components/features/filters/EventFilter.tsx` | 두 뷰에서 동일 동작 검증 (코드 변경 가능성 낮음) |
+
+### 책임 분리
+
+- **`CalendarView`**: 디바이스 분기, 선택일 상태, 데이터 페치 트리거. 자체 UI는 최소.
+- **`CalendarGrid` / `CalendarDotGrid`**: 받은 props만으로 순수 렌더, 내부 상태 없음.
+- **`DayDetailSheet`**: 선택일 이벤트 배열 표시. 카드 디자인은 기존 `components/common/item/Item` 재사용.
+- **`utils/*`**: 순수 함수, 단위 테스트 가능.
+
+---
+
+## 4. 데이터 흐름
+
+### URL 상태 모델
+
+```
+/events                                       → 리스트 (기본)
+/events?view=list                             → 리스트 (명시적)
+/events?view=calendar                         → 캘린더, 현재 월
+/events?view=calendar&year=2026&month=5       → 캘린더, 특정 월
+```
+
+규칙
+- `view` 없거나 `list` → 리스트
+- `view=calendar` 인데 `year`/`month` 없음 → SSR 시점의 현재 년/월로 폴백
+- `year=NaN`/`month=NaN` → 현재 년/월로 폴백
+- 모드 전환 / 월 이동은 `router.push({ query }, undefined, { shallow: true })`
+
+### SSR 분기 (의사 코드)
+
+```ts
+// pages/events.tsx
+getServerSideProps(ctx) {
+  const view = (ctx.query.view ?? 'list') === 'calendar' ? 'calendar' : 'list';
+
+  if (view === 'calendar') {
+    const now = dayjs().tz('Asia/Seoul');
+    const year  = Number(ctx.query.year)  || now.year();
+    const month = Number(ctx.query.month) || now.month() + 1;
+    const res = await fetch(`${BASE}/front/v2/events/${year}/${month}`);
+    return { props: { view, year, month, fallbackData: await res.json() } };
+  }
+
+  const res = await fetch(`${BASE}/front/v2/events/current`);
+  return { props: { view: 'list', fallbackData: await res.json() } };
+}
+```
+
+### 클라이언트 데이터
+
+- 리스트: 기존 `useScheduledEvents(fallbackData)`
+- 캘린더: 신규 `useMonthlyEvents(year, month, fallbackData)` — SWR key `['monthly', year, month]`
+- 월 이동 시 SWR이 새 키로 fetch, 직전 달은 캐시에 남아 뒤로 가기 즉시 표시
+
+### 토글 동작
+
+```
+"📅 캘린더" 클릭
+  → URL → /events?view=calendar&year=&month=  (shallow push)
+  → events.tsx가 view=calendar 감지 → <CalendarView /> 렌더
+  → useMonthlyEvents(year, month) — SSR fallbackData 즉시 노출 + revalidate
+```
+
+### 다중일 이벤트 segment
+
+`utils/layoutMultiDayEvents.ts`:
+- 입력: `events: Event[]`, `weeks: Date[][]`
+- 출력: `WeekSegments[]` — 주차별로 `{event, startCol, endCol, isStart, isEnd, isOutside}` 배열
+- 한 이벤트가 주 경계를 넘어가면 주 단위로 쪼개 별도 segment 생성
+- 같은 셀의 segment 정렬: `display_sequence` ASC → `start_date_time` ASC
+- 셀당 표시 한도 초과 시 `hasOverflow: true`, 화면에서 `+N 더보기` 마커
+
+---
+
+## 5. 렌더링 규칙
+
+### 뷰포트 분기
+
+- `useMediaQuery('(max-width: 720px)')` 결과로 `CalendarGrid` vs `CalendarDotGrid` 선택
+- breakpoint: **720px**
+
+### 데스크탑 그리드 (`CalendarGrid`)
+
+| 항목 | 값 |
+|------|-----|
+| 격자 | 7열 × 6행 (42칸 고정) |
+| 셀 최소 높이 | 110px |
+| 셀 패딩 | 8px |
+| 셀 hover | bg `#F7F7FA` |
+| outside 셀 | bg `#F7F7FA`, 글씨 `#8C8F9F` |
+| 그리드 라인 | gap 1px / bg `#E8E8EE` |
+| 외곽 라운드 | 8px |
+| 일요일 숫자 | `#D91C29` |
+| 토요일 숫자 | `#1D6CE0` |
+| 오늘 | 숫자 배경 22px 원 `#0043FF`, 글씨 흰색 |
+
+### 이벤트 칩 (데스크탑)
+
+| 항목 | 값 |
+|------|-----|
+| 높이 | 약 20px |
+| 폰트 | 11px / weight 500 |
+| 배경 | `rgba(태그색, 0.08)` |
+| 좌측 보더 | 2px solid `태그색` |
+| 텍스트 색 | `태그색` |
+| overflow | `ellipsis` 1줄 |
+| 다중일 segment | 시작/끝 셀만 라운드, 가운데는 0. `margin-left/-right: -9px` 로 셀 경계 넘기 |
+
+### 태그 색 매핑 (utils/tagColor.ts)
+
+`model/tag.ts` 기반. 최종 키는 구현 단계에서 실제 태그명 보고 확정. 색 팔레트:
+
+| 카테고리 | KTB 색 |
+|----------|--------|
+| 컨퍼런스 | `#0043FF` (Tech Blue) |
+| 웨비나 / 세미나 | `#08785E` (Success) |
+| 해커톤 / 공모전 | `#B45209` (Warning) |
+| 네트워킹 / 밋업 | `#7A0CFF` (Violet) |
+| 기본 / 미분류 | `#525463` (Gray-700) |
+
+### 모바일 점 캘린더 (`CalendarDotGrid`)
+
+| 항목 | 값 |
+|------|-----|
+| 셀 | `aspect-ratio: 1`, flex center |
+| 점 | 4×4 원, 셀당 최대 3개 (초과 시 마지막은 회색 "+" 점) |
+| 점 색 | 태그 색 |
+| 선택일 outline | 2px `#0043FF` |
+| 오늘 | 셀 배경 `#0043FF`, 글씨 흰색 |
+| 셀 탭 → | 하단 `DayDetailSheet` 슬라이드 인 |
+
+### 헤더 (`CalendarHeader`)
+
+```
+[‹]  2026년 5월  [›]   [오늘]                       [📋 리스트] [📅 캘린더]
+```
+
+- 좌측 월 네비 + "오늘" 버튼: 캘린더 모드에서만 노출
+- 우측 `ViewToggle`: 두 모드 모두 노출
+- sticky 적용 안 함 (MVP)
+
+### 선택일 상세 (`DayDetailSheet`)
+
+| 항목 | 값 |
+|------|-----|
+| 데스크탑 | `react-modal` 기반 중앙 모달 (`LoginModal` 패턴 재사용) |
+| 모바일 | 하단 슬라이드 시트 (translateY 트랜지션) |
+| 헤더 | `5월 14일 (목) · 행사 2건` + 닫기 |
+| 본문 | 기존 `components/common/item/Item` 카드 재사용 |
+| 다중일 보조 라벨 | `5/14 ~ 5/16 · 진행 1일차` |
+| 빈 날짜 | "이 날은 등록된 행사가 없어요" + 가까운 다음 행사 이동 버튼 |
+| 카드 클릭 | `/event/detail/{id}` 이동 |
+
+### 캘린더 행렬
+
+`utils/buildCalendarMatrix(year, month): Date[][]`
+- 6행 × 7열 (일요일 시작)
+- 첫/마지막 주의 빈 칸은 인접 월 날짜로 채우고 `isOutside: true` 표기
+- `dayjs` + `Asia/Seoul` 고정
+
+### 접근성 (MVP)
+
+- 셀: `role="button" tabIndex={0}` + `aria-label="5월 14일 행사 1건"`
+- 토글: `role="tablist"` / `aria-selected`
+- 키보드 화살표 네비게이션은 follow-up
+
+### 성능
+
+- segment 계산은 `useMemo`로 `events`/`year`/`month` 변화 시만
+- 그리드 42칸 고정 → 가상화 불필요
+- `DayDetailSheet`는 열릴 때 lazy mount
+
+---
+
+## 6. 엣지 케이스
+
+| 케이스 | 처리 |
+|--------|------|
+| 이벤트 0건인 달 | 그리드 그대로, 상단에 안내 문구 |
+| 5주 vs 6주 표시 | **항상 6주(42칸) 고정** |
+| 다중일이 월 경계 걸침 | 보이는 부분만 segment, outside 셀에도 흐리게 막대 |
+| 같은 날 이벤트 N개 (데스크탑 ≥3) | 2개 표시 + `+N 더보기` |
+| 같은 날 이벤트 N개 (모바일 ≥4) | 점 3개 + 회색 "+" 점 |
+| `RECRUIT` 타입 | 그리드 제외, 시트에도 노출 안 함 (MVP) |
+| `use_start_date_time_yn === 'N'` | 그리드 제외, 시트 하단 "날짜 미정 행사 N건" 별도 섹션 |
+| 잘못된 URL 쿼리 | SSR에서 현재 년/월 폴백 |
+| API 실패 | 기존 `EventNull` 빈 상태 |
+| `/calender` 직접 접속 | 307 → `/events?view=calendar&year=&month=` |
+| 토글 후 뒤로가기 | URL 기반이라 브라우저 히스토리 자연스럽게 |
+
+---
+
+## 7. 테스트 계획
+
+### 유닛 테스트 (`utils/__tests__/`)
+
+- `buildCalendarMatrix`:
+  - 2026년 5월 → 42칸, 앞 5칸 outside (4/26~4/30), 뒤 6칸 outside (6/1~6/6)
+  - 윤년 2월 / 평년 2월 / 12월(다음 해 1월 outside)
+- `layoutMultiDayEvents`:
+  - 단일일 → 단일 segment
+  - 같은 주 다중일 → 1 segment, `isStart && isEnd`
+  - 주 경계 걸침 → 2 segments
+  - 월 경계 걸침 → outside segment 포함
+  - 정렬: `display_sequence` 우선
+- `tagColor`: 알려진 태그 매핑 / 미지 태그 폴백
+
+### 컴포넌트 테스트
+
+- `CalendarGrid`: events 주입 → 셀 수, segment 클래스(`span-start/mid/end`), `+N` 마커
+- `CalendarDotGrid`: 점 개수/색/"+" 마커, 선택일 outline
+- `DayDetailSheet`: 빈 날짜 안내, 카드 클릭 시 라우팅
+- `ViewToggle`: 클릭 시 `router.push` 호출, 쿼리 변경
+
+### 수동 QA 체크리스트
+
+- [ ] 데스크탑 1280 / 1024 폭에서 그리드 깨짐 없음
+- [ ] 모바일 375 / 360 폭에서 점 캘린더 정상
+- [ ] 월 이동 후 브라우저 뒤로가기 정상 동작
+- [ ] 토글 ↔ 필터 칩 ↔ 월 이동 조합 데이터 정합
+- [ ] `/calender?year=2026&month=5` 직접 접속 → 307 리디렉트 확인
+- [ ] 다중일 이벤트(예: 5/14~5/16)가 연속 막대로 보임
+- [ ] 오늘(5/12) 강조 정상
+- [ ] DayDetailSheet에서 카드 클릭 → 이벤트 상세 페이지 정상 이동
+- [ ] `RECRUIT` 타입은 그리드에 안 보임 (리스트 모드에서는 그대로 보임)
+
+---
+
+## 8. 롤아웃
+
+단일 PR, 단계별 커밋:
+
+1. `utils/buildCalendarMatrix` + `layoutMultiDayEvents` + `tagColor` + 단위 테스트
+2. `CalendarHeader` + `ViewToggle` + URL 상태 wiring
+3. `CalendarGrid` (데스크탑) + 다중일 segment 렌더 + 스타일
+4. `CalendarDotGrid` (모바일) + 선택일 상태
+5. `DayDetailSheet` + 기존 `Item` 카드 재사용
+6. `pages/events.tsx` SSR 분기 + `useMonthlyEvents` 훅 + `pages/calender.tsx` 307 redirect
+7. 수동 QA + 스크린샷 첨부 PR 본문
+
+피처 플래그는 도입하지 않는다 (UX 변경이고 데이터 호환성 이슈 없음, 기본 뷰가 리스트라 점진 노출).
+
+---
+
+## 9. 미정 / 후속 작업
+
+- 키보드 네비게이션 (셀 ←↑→↓, Enter, Esc)
+- 모바일 가로 스와이프로 월 이동
+- 즐겨찾기 이벤트만 보는 캘린더 필터
+- 주(week) / 일(day) 뷰
+- iCal 내보내기
+- `RECRUIT` 타입 별도 시각 (예: 배경 stripe 패턴)

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,13 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  moduleDirectories: ['node_modules', '<rootDir>'],
+  moduleNameMapper: {
+    '\\.(scss|css)$': '<rootDir>/__mocks__/styleMock.js',
+  },
+  testMatch: ['**/__tests__/**/*.test.ts', '**/__tests__/**/*.test.tsx'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.json' }],
+  },
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,2 @@
+// Test setup placeholder. Will be populated as needed.
+export {};

--- a/lib/utils/eventUtil.tsx
+++ b/lib/utils/eventUtil.tsx
@@ -61,13 +61,11 @@ export const checkCondition = (
   const eventTag = event.tags;
   if (handleUndefined(jobGroups, eventType, location, coast)) return true;
   for (let i = 0; i < eventTag.length; i++) {
-    if (jobGroups !== undefined && jobGroups.includes(eventTag[i].tag_name))
-      return true;
-    if (eventType !== undefined && eventType === eventTag[i].tag_name)
-      return true;
-    if (location !== undefined && location === eventTag[i].tag_name)
-      return true;
-    if (coast !== undefined && coast === eventTag[i].tag_name) return true;
+    const tagName = eventTag[i].tag_name?.trim();
+    if (jobGroups !== undefined && jobGroups.includes(tagName)) return true;
+    if (eventType !== undefined && eventType === tagName) return true;
+    if (location !== undefined && location === tagName) return true;
+    if (coast !== undefined && coast === tagName) return true;
   }
   return false;
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "dev": "next dev -p 5000",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "axios": "^0.26.1",
@@ -34,6 +36,7 @@
     "@svgr/webpack": "^6.2.1",
     "@trivago/prettier-plugin-sort-imports": "^4.2.0",
     "@types/cookie": "^0.5.1",
+    "@types/jest": "29",
     "@types/js-cookie": "^3.0.4",
     "@types/marked": "^4.3.0",
     "@types/node": "17.0.23",
@@ -47,7 +50,10 @@
     "eslint": "^8.13.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.0.0",
+    "jest": "29",
+    "jest-environment-jsdom": "29",
     "prettier": "2.6.2",
+    "ts-jest": "29",
     "typescript": "4.6.3"
   }
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,6 +8,7 @@ import { useRouter } from 'next/router';
 import Head from 'next/head';
 import { EventProvider } from 'context/event';
 import { WindowProvider } from 'context/window';
+import Modal from 'react-modal';
 
 type NextPageWithLayout = NextPage & {
   getLayout?: (page: ReactElement) => ReactNode;
@@ -21,6 +22,7 @@ export default function MyApp({ Component, pageProps }: AppPropsWithLayout) {
   const router = useRouter();
 
   useEffect(() => {
+    Modal.setAppElement('#__next');
     document.documentElement.setAttribute('data-theme', 'light');
     const handleRouteChange = (url: URL) => {
       gtag.pageview(url);

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,6 +8,7 @@ import { useRouter } from 'next/router';
 import Head from 'next/head';
 import { EventProvider } from 'context/event';
 import { WindowProvider } from 'context/window';
+import { ToastProvider } from 'context/toast';
 import Modal from 'react-modal';
 
 type NextPageWithLayout = NextPage & {
@@ -43,7 +44,9 @@ export default function MyApp({ Component, pageProps }: AppPropsWithLayout) {
       <AuthProvider>
         <WindowProvider>
           <EventProvider>
-            {getLayout(<Component {...pageProps} />)}
+            <ToastProvider>
+              {getLayout(<Component {...pageProps} />)}
+            </ToastProvider>
           </EventProvider>
         </WindowProvider>
       </AuthProvider>

--- a/pages/calender.tsx
+++ b/pages/calender.tsx
@@ -1,139 +1,25 @@
-import React, { useContext, useEffect, useRef, useState } from 'react';
-import Layout from 'components/layout';
-import type { ReactElement } from 'react';
-import classNames from 'classnames/bind';
-import style from 'styles/Home.module.scss';
 import { GetServerSideProps } from 'next';
-import cookie from 'cookie';
-import { AuthContext } from 'context/auth';
-import LoginModal from 'components/common/modal/LoginModal';
-import MonthlyEventList from 'components/events/MonthlyEventList';
-import { Event } from 'model/event';
-import Head from 'next/head';
-import { useRouter } from 'next/router';
-import Banner from 'components/common/banner/banner';
-import Letter from 'components/features/letter/Letter';
-import { WindowContext } from 'context/window';
-import { blockMouseScroll, isModalOpen } from 'lib/utils/windowUtil';
-import FilterTagModal from 'components/common/modal/FilterTagModal';
-import FilterDateModal from 'components/common/modal/FilterDateModal';
+import dayjs from 'dayjs';
 
-const cn = classNames.bind(style);
-
-const Calender = ({
-  isLoggedIn,
-  fallbackData,
-}: {
-  isLoggedIn: boolean;
-  fallbackData: Event[];
-}) => {
-  const authContext = React.useContext(AuthContext);
-  const [loginModalIsOpen, setLoginModalIsOpen] = useState(false);
-  const router = useRouter();
-  const filteredDate = {
-    year: Number(router.query.year),
-    month: Number(router.query.month),
-  };
-  const { modalState } = useContext(WindowContext);
-  const bodyRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (isLoggedIn) {
-      authContext.login();
-    } else {
-      authContext.logout();
-    }
-    if (modalState.currentModal !== 0) {
-      document.body.style.position = 'fixed';
-      document.body.style.overflow = 'hidden';
-    }
-
-    return () => {
-      document.body.style.position = 'relative';
-      document.body.style.overflow = 'unset';
-      bodyRef.current?.removeEventListener('wheel', blockMouseScroll);
-    };
-  }, [isLoggedIn, modalState]);
-
-  return (
-    <main ref={bodyRef} className={cn('main')}>
-      <Head>
-        <title>
-          {filteredDate.year}년 {filteredDate.month}월 - 데브이벤트 행사 월별
-          검색
-        </title>
-        <meta
-          name="description"
-          content={`${filteredDate.year}년 ${filteredDate.month}월에 진행되는 개발자 행사, 데브이벤트에서 찾아보세요!`}
-        />
-        <meta
-          name="keywords"
-          content="데브이벤트 웹, 개발자 행사, 월별, 이벤트, 행사, 웨비나, 컨퍼런스, 해커톤, 네트워킹, IT"
-        />
-        <meta
-          property="og:image"
-          content="/default/og_image.png"
-        />
-        <meta
-          property="og:title"
-          content={`${filteredDate.year}년 ${filteredDate.month}월 - 데브이벤트 행사 월별 검색`}
-        />
-        <meta
-          property="og:description"
-          content={`${filteredDate.year}년 ${filteredDate.month}월에 진행되는 개발자 행사, 데브이벤트에서 찾아보세요!`}
-        />
-      </Head>
-      {modalState.currentModal === 0 ? (
-        <>
-          <Banner />
-          <section className={cn('section')}>
-            <MonthlyEventList events={fallbackData} date={filteredDate} />
-          </section>
-          <Letter />
-        </>
-      ) : null}
-      {isModalOpen(modalState.currentModal, 2) && <FilterTagModal />}
-      {isModalOpen(modalState.currentModal, 3) && <FilterDateModal />}
-      <LoginModal
-        isOpen={loginModalIsOpen}
-        onClose={() => setLoginModalIsOpen(false)}
-      ></LoginModal>
-    </main>
-  );
-};
+// This page only exists for backward compatibility.
+// It redirects /calender?year=&month= → /events?view=calendar&year=&month=
+const Calender = () => null;
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { year, month } = context.query;
-  const res = await fetch(
-    `${process.env.BASE_SERVER_URL}/front/v2/events/${year}/${month}`
-  );
-  const events = await res.json();
-  const cookies = context.req.headers.cookie || '';
-
-  if (cookies) {
-    const parsedCookies = cookie.parse(cookies);
-    const access_token = parsedCookies.access_token;
-    const refrest_token = parsedCookies.refresh_token;
-
-    if (access_token && refrest_token) {
-      return {
-        props: {
-          isLoggedIn: true,
-          fallbackData: events,
-        },
-      };
-    }
-  }
+  const now = dayjs();
+  const yearParam = Number(context.query.year);
+  const monthParam = Number(context.query.month);
+  const year = Number.isFinite(yearParam) && yearParam > 0 ? yearParam : now.year();
+  const month = Number.isFinite(monthParam) && monthParam >= 1 && monthParam <= 12
+    ? monthParam
+    : now.month() + 1;
 
   return {
-    props: {
-      isLoggedIn: false,
-      fallbackData: events,
+    redirect: {
+      destination: `/events?view=calendar&year=${year}&month=${month}`,
+      permanent: false, // 307
     },
   };
 };
 
-Calender.getLayout = function getLayout(page: ReactElement) {
-  return <Layout>{page}</Layout>;
-};
 export default Calender;

--- a/pages/event/detail/[eventId].tsx
+++ b/pages/event/detail/[eventId].tsx
@@ -7,6 +7,8 @@ import { marked } from 'marked';
 import Layout from 'components/layout';
 import ShareIcon from 'components/icons/ShareIcon';
 import BookmarkIcon from 'components/icons/BookmarkIcon';
+import DdayTag from 'components/common/tag/DdayTag';
+import FilterTag from 'components/common/tag/FilterTag';
 import SaveModal from 'components/common/modal/SaveModal';
 import LoginModal from 'components/common/modal/LoginModal';
 import { Event } from 'model/event';
@@ -26,12 +28,18 @@ interface EventDetailProps {
   eventData: Event;
 }
 
+const isEventDone = (endDate: string): boolean => {
+  return new Date(endDate).getTime() < Date.now();
+};
+
 const EventDetail: React.FC<EventDetailProps> = ({ eventData }) => {
   const router = useRouter();
   const { isLoggedIn } = useContext(AuthContext);
   const [loginModalIsOpen, setLoginModalIsOpen] = useState(false);
   const [showSaveModal, setShowSaveModal] = useState(false);
   const [saveMessage, setSaveMessage] = useState('');
+
+  const eventDone = isEventDone(eventData.end_date_time);
 
   const param = { filter: '' };
   const { myEvent } = useMyEvent(param, isLoggedIn);
@@ -177,7 +185,10 @@ const EventDetail: React.FC<EventDetailProps> = ({ eventData }) => {
           property="og:image"
           content={eventData.cover_image_link || '/default/event_img.png'}
         />
-        <meta property="og:url" content={`${process.env.NEXT_PUBLIC_BASE_URL}/event/detail/${eventData.id}`} />
+        <meta
+          property="og:url"
+          content={`${process.env.NEXT_PUBLIC_BASE_URL}/event/detail/${eventData.id}`}
+        />
         <meta property="og:type" content="website" />
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:title" content={`${eventData.title} | DEV EVENT`} />
@@ -204,6 +215,17 @@ const EventDetail: React.FC<EventDetailProps> = ({ eventData }) => {
                   objectFit="cover"
                   unoptimized
                 />
+                {eventDone && (
+                  <div className={cx('event-detail__image__done')} />
+                )}
+                {!eventDone && (
+                  <div className={cx('event-detail__image__badge')}>
+                    <DdayTag
+                      startDateTime={eventData.start_date_time}
+                      endDateTime={eventData.end_date_time}
+                    />
+                  </div>
+                )}
               </div>
             </div>
 
@@ -211,11 +233,15 @@ const EventDetail: React.FC<EventDetailProps> = ({ eventData }) => {
               {/* 공유/북마크 아이콘 */}
               <div className={cx('event-detail__header-actions')}>
                 <button className={cx('icon-btn')} onClick={handleShare}>
-                  <ShareIcon color="var(--gray-2)" />
+                  <ShareIcon color="var(--vapor-gray-500)" />
                 </button>
                 <button className={cx('icon-btn')} onClick={handleBookmark}>
                   <BookmarkIcon
-                    color={isBookmarked ? '#007AFF' : 'var(--gray-2)'}
+                    color={
+                      isBookmarked
+                        ? 'var(--ktb-tech-blue)'
+                        : 'var(--vapor-gray-500)'
+                    }
                     isFavorite={isBookmarked}
                   />
                 </button>
@@ -245,9 +271,12 @@ const EventDetail: React.FC<EventDetailProps> = ({ eventData }) => {
 
               <div className={cx('event-detail__tags')}>
                 {eventData.tags?.map((tag, index) => (
-                  <span key={index} className={cx('event-tag')}>
-                    {tag.tag_name}
-                  </span>
+                  <FilterTag
+                    key={index}
+                    label={tag.tag_name}
+                    size="regular"
+                    type="location"
+                  />
                 ))}
               </div>
 

--- a/pages/event/detail/[eventId].tsx
+++ b/pages/event/detail/[eventId].tsx
@@ -170,7 +170,7 @@ const EventDetail: React.FC<EventDetailProps> = ({ eventData }) => {
         />
         <meta
           property="og:image"
-          content={eventData.cover_image_link || '/default/event_img.png'}
+          content={eventData.cover_image_link || '/default/event-thumbnail-light.png'}
         />
         <meta
           property="og:url"
@@ -185,7 +185,7 @@ const EventDetail: React.FC<EventDetailProps> = ({ eventData }) => {
         />
         <meta
           name="twitter:image"
-          content={eventData.cover_image_link || '/default/event_img.png'}
+          content={eventData.cover_image_link || '/default/event-thumbnail-light.png'}
         />
       </Head>
 
@@ -196,7 +196,7 @@ const EventDetail: React.FC<EventDetailProps> = ({ eventData }) => {
             <div className={cx('event-detail__image-section')}>
               <div className={cx('event-detail__image')}>
                 <Image
-                  src={eventData.cover_image_link || '/default/event_img.png'}
+                  src={eventData.cover_image_link || '/default/event-thumbnail-light.png'}
                   alt={eventData.title}
                   layout="fill"
                   objectFit="cover"

--- a/pages/event/detail/[eventId].tsx
+++ b/pages/event/detail/[eventId].tsx
@@ -9,8 +9,8 @@ import ShareIcon from 'components/icons/ShareIcon';
 import BookmarkIcon from 'components/icons/BookmarkIcon';
 import DdayTag from 'components/common/tag/DdayTag';
 import FilterTag from 'components/common/tag/FilterTag';
-import SaveModal from 'components/common/modal/SaveModal';
 import LoginModal from 'components/common/modal/LoginModal';
+import { useToast } from 'context/toast';
 import { Event } from 'model/event';
 import { AuthContext } from 'context/auth';
 import { createMyEventApi } from 'lib/api/post';
@@ -36,8 +36,7 @@ const EventDetail: React.FC<EventDetailProps> = ({ eventData }) => {
   const router = useRouter();
   const { isLoggedIn } = useContext(AuthContext);
   const [loginModalIsOpen, setLoginModalIsOpen] = useState(false);
-  const [showSaveModal, setShowSaveModal] = useState(false);
-  const [saveMessage, setSaveMessage] = useState('');
+  const { pushToast } = useToast();
 
   const eventDone = isEventDone(eventData.end_date_time);
 
@@ -61,33 +60,15 @@ const EventDetail: React.FC<EventDetailProps> = ({ eventData }) => {
 
   const isBookmarked = eventData ? getFavoriteId(eventData.id) !== 0 : false;
 
-  // 북마크 모달 표시 헬퍼 함수
-  const showBookmarkMessage = (message: string) => {
-    setSaveMessage(message);
-    setShowSaveModal(true);
-    setTimeout(() => {
-      setShowSaveModal(false);
-    }, 2000);
-  };
-
   const handleShare = async () => {
     if (!eventData) return;
 
-    if (navigator.share) {
-      try {
-        await navigator.share({
-          title: eventData.title,
-          text: `${eventData.organizer}에서 주최하는 ${eventData.title}`,
-          url: window.location.href,
-        });
-      } catch (err) {
-        if ((err as Error).name !== 'AbortError') {
-          console.error(err);
-        }
-      }
-    } else {
-      navigator.clipboard.writeText(window.location.href);
-      alert('링크가 복사되었습니다!');
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      pushToast('링크가 복사되었어요');
+    } catch (err) {
+      console.error(err);
+      pushToast('링크 복사에 실패했어요');
     }
   };
 
@@ -123,7 +104,7 @@ const EventDetail: React.FC<EventDetailProps> = ({ eventData }) => {
           event_label: '관심행사',
         });
 
-        showBookmarkMessage('북마크에 추가되었습니다.');
+        pushToast('북마크에 추가되었어요');
       } else {
         // 북마크 삭제
         const filteredEvent = myEvent.filter(
@@ -141,14 +122,14 @@ const EventDetail: React.FC<EventDetailProps> = ({ eventData }) => {
           event_label: '관심행사',
         });
 
-        showBookmarkMessage('북마크에서 제거되었습니다.');
+        pushToast('북마크에서 제거되었어요');
       }
 
       // SWR 캐시 갱신
       mutate([`/front/v1/favorite/events`, param]);
     } catch (error) {
       console.error('북마크 처리 오류:', error);
-      showBookmarkMessage('처리 중 오류가 발생했습니다.');
+      pushToast('처리 중 오류가 발생했어요');
     }
   };
 
@@ -317,7 +298,6 @@ const EventDetail: React.FC<EventDetailProps> = ({ eventData }) => {
           </div>
         </div>
         <Letter />
-        <SaveModal isVisible={showSaveModal} message={saveMessage} />
         <LoginModal
           isOpen={loginModalIsOpen}
           onClose={() => setLoginModalIsOpen(false)}

--- a/pages/event/detail/[eventId].tsx
+++ b/pages/event/detail/[eventId].tsx
@@ -70,15 +70,21 @@ const EventDetail: React.FC<EventDetailProps> = ({ eventData }) => {
     }, 2000);
   };
 
-  const handleShare = () => {
+  const handleShare = async () => {
     if (!eventData) return;
 
     if (navigator.share) {
-      navigator.share({
-        title: eventData.title,
-        text: `${eventData.organizer}에서 주최하는 ${eventData.title}`,
-        url: window.location.href,
-      });
+      try {
+        await navigator.share({
+          title: eventData.title,
+          text: `${eventData.organizer}에서 주최하는 ${eventData.title}`,
+          url: window.location.href,
+        });
+      } catch (err) {
+        if ((err as Error).name !== 'AbortError') {
+          console.error(err);
+        }
+      }
     } else {
       navigator.clipboard.writeText(window.location.href);
       alert('링크가 복사되었습니다!');

--- a/pages/events.tsx
+++ b/pages/events.tsx
@@ -4,15 +4,17 @@ import FilterSearchModal from 'components/common/modal/FilterSearchModal';
 import FilterTagModal from 'components/common/modal/FilterTagModal';
 import LoginModal from 'components/common/modal/LoginModal';
 import ScheduledEventList from 'components/events/ScheduledEventList';
+import CalendarView from 'components/events/calendar/CalendarView';
 import Letter from 'components/features/letter/Letter';
 import Layout from 'components/layout';
 import { AuthContext } from 'context/auth';
 import { EventContext } from 'context/event';
 import { WindowContext } from 'context/window';
 import cookie from 'cookie';
-import { useScheduledEvents } from 'lib/hooks/useSWR';
+import dayjs from 'dayjs';
+import { useScheduledEvents, useMonthlyEvent } from 'lib/hooks/useSWR';
 import { blockMouseScroll, isModalOpen } from 'lib/utils/windowUtil';
-import { EventResponse } from 'model/event';
+import { Event, EventResponse } from 'model/event';
 import style from 'styles/Home.module.scss';
 import React, { useEffect, useContext, useState, useRef } from 'react';
 import type { ReactElement } from 'react';
@@ -22,21 +24,41 @@ import Head from 'next/head';
 
 const cn = classNames.bind(style);
 
-type Props = {
+type ListProps = {
+  view: 'list';
   isLoggedIn: boolean;
   fallbackData: EventResponse[];
 };
 
-const Events = ({ isLoggedIn, fallbackData }: Props) => {
+type CalendarProps = {
+  view: 'calendar';
+  year: number;
+  month: number;
+  isLoggedIn: boolean;
+  fallbackData: Event[];
+};
+
+type Props = ListProps | CalendarProps;
+
+const Events = (props: Props) => {
   const authContext = React.useContext(AuthContext);
   const [loginModalIsOpen, setLoginModalIsOpen] = useState(false);
   const { modalState } = useContext(WindowContext);
   const { date } = useContext(EventContext);
-  const { scheduledEvents, isError } = useScheduledEvents(fallbackData);
   const bodyRef = useRef<HTMLDivElement>(null);
 
+  const listSWR = useScheduledEvents(
+    props.view === 'list' ? props.fallbackData : undefined
+  );
+  const calendarSWR = useMonthlyEvent({
+    param: props.view === 'calendar'
+      ? { year: props.year, month: props.month }
+      : { year: 1970, month: 1 },
+    fallbackData: props.view === 'calendar' ? props.fallbackData : [],
+  });
+
   useEffect(() => {
-    if (isLoggedIn) {
+    if (props.isLoggedIn) {
       authContext.login();
     } else {
       authContext.logout();
@@ -52,7 +74,7 @@ const Events = ({ isLoggedIn, fallbackData }: Props) => {
       bodyRef.current?.removeEventListener('wheel', blockMouseScroll);
       setLoginModalIsOpen(false);
     };
-  }, [isLoggedIn, modalState, date]);
+  }, [props.isLoggedIn, modalState, date]);
 
   return (
     <main ref={bodyRef} className={cn('main')}>
@@ -66,66 +88,74 @@ const Events = ({ isLoggedIn, fallbackData }: Props) => {
           name="keywords"
           content="데브이벤트 웹, Dev Event, 데브이벤트, 개발자 행사, 용감한 친구들, 개발자, 이벤트, 행사, 웨비나, 컨퍼런스, 해커톤, 네트워킹, IT"
         />
-        <meta
-          property="og:image"
-          content="/default/og_image.png"
-        />
-        <meta
-          property="og:title"
-          content="Dev Event - 개발자 행사는 모두 데브이벤트 웹에서!"
-        />
-        <meta
-          property="og:description"
-          content="개발자를 위한 {웨비나, 컨퍼런스, 해커톤, 네트워킹} 소식을 알려드립니다."
-        />
+        <meta property="og:image" content="/default/og_image.png" />
+        <meta property="og:title" content="Dev Event - 개발자 행사는 모두 데브이벤트 웹에서!" />
+        <meta property="og:description" content="개발자를 위한 {웨비나, 컨퍼런스, 해커톤, 네트워킹} 소식을 알려드립니다." />
       </Head>
       {modalState.currentModal === 0 && (
         <>
           <Banner />
           <section className={cn('section')}>
-            <ScheduledEventList events={scheduledEvents} isError={isError} />
+            {props.view === 'list' ? (
+              <ScheduledEventList events={listSWR.scheduledEvents} isError={listSWR.isError} />
+            ) : (
+              <CalendarView
+                year={props.year}
+                month={props.month}
+                events={calendarSWR.monthlyEvent ?? []}
+              />
+            )}
           </section>
           <Letter />
         </>
       )}
-      {isModalOpen(modalState.currentModal, 1) && (
-        <FilterSearchModal events={scheduledEvents} isError={isError} />
+      {isModalOpen(modalState.currentModal, 1) && props.view === 'list' && (
+        <FilterSearchModal events={listSWR.scheduledEvents} isError={listSWR.isError} />
       )}
       {isModalOpen(modalState.currentModal, 2) && <FilterTagModal />}
       {isModalOpen(modalState.currentModal, 3) && <FilterDateModal />}
       <LoginModal
         isOpen={loginModalIsOpen}
         onClose={() => setLoginModalIsOpen(false)}
-      ></LoginModal>
+      />
     </main>
   );
 };
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const cookies = context.req.headers.cookie || '';
-  const res = await fetch(
-    `${process.env.BASE_SERVER_URL}/front/v2/events/current`
-  );
-  const events = await res.json();
+  const view = context.query.view === 'calendar' ? 'calendar' : 'list';
 
-  if (cookies) {
-    const parsedCookies = cookie.parse(cookies);
-    const access_token = parsedCookies.access_token;
-    const refrest_token = parsedCookies.refresh_token;
+  const parsedCookies = cookies ? cookie.parse(cookies) : {};
+  const isLoggedIn = Boolean(parsedCookies.access_token && parsedCookies.refresh_token);
 
-    if (access_token && refrest_token) {
-      return {
-        props: {
-          isLoggedIn: true,
-          fallbackData: events,
-        },
-      };
-    }
+  if (view === 'calendar') {
+    const now = dayjs();
+    const yearParam = Number(context.query.year);
+    const monthParam = Number(context.query.month);
+    const year = Number.isFinite(yearParam) && yearParam > 0 ? yearParam : now.year();
+    const month = Number.isFinite(monthParam) && monthParam >= 1 && monthParam <= 12
+      ? monthParam
+      : now.month() + 1;
+    const res = await fetch(`${process.env.BASE_SERVER_URL}/front/v2/events/${year}/${month}`);
+    const events = await res.json();
+    return {
+      props: {
+        view: 'calendar' as const,
+        year,
+        month,
+        isLoggedIn,
+        fallbackData: events,
+      },
+    };
   }
 
+  const res = await fetch(`${process.env.BASE_SERVER_URL}/front/v2/events/current`);
+  const events = await res.json();
   return {
     props: {
-      isLoggedIn: false,
+      view: 'list' as const,
+      isLoggedIn,
       fallbackData: events,
     },
   };

--- a/pages/myinfo.tsx
+++ b/pages/myinfo.tsx
@@ -44,7 +44,6 @@ const MyInfo = ({ isLoggedIn }: { isLoggedIn: boolean }) => {
     );
   }
 
-  // 계정 탈퇴
   const deleteAccount = async () => {
     const result = await deleteAccountApi(`/front/v1/users/witdraw`);
     if (result.status_code === 200) {
@@ -67,56 +66,86 @@ const MyInfo = ({ isLoggedIn }: { isLoggedIn: boolean }) => {
 
   return (
     <>
-      <div className={cx('info-container')}>
-        <div className={cx('info-container__inner')}>
+      <main className={cx('container')}>
+        <div className={cx('inner')}>
           <header className={cx('sub-header')}>
-            <div className={cx('sub-header__inner')}>
-              <div className={cx('sub-header__content')}>
-                <h1 className={cx('notice-title')}>내 정보</h1>
-                <div className={cx('underline')}></div>
-              </div>
-            </div>
+            <h1>내 정보</h1>
           </header>
 
-          {/* 사용자 상세 정보 */}
-          <div className={cx('info-form')}>
-            <div className={cx('info-form__profile_image_box')}>
-              <Image
-                src={
-                  user && user.profile_image_link
-                    ? user.profile_image_link
-                    : '/icon/profile.svg'
-                }
-                width={104}
-                height={104}
-                className={cx('profile')}
-              />
+          <section className={cx('profile-card')}>
+            <div
+              className={cx('profile-card__avatar', {
+                'profile-card__avatar--placeholder':
+                  !user?.profile_image_link,
+              })}
+            >
+              {user?.profile_image_link ? (
+                <Image
+                  src={user.profile_image_link}
+                  width={96}
+                  height={96}
+                  alt="프로필 이미지"
+                />
+              ) : (
+                <svg
+                  viewBox="0 0 48 48"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  aria-hidden
+                >
+                  <path
+                    d="M24 24C26.7625 24 29 21.7625 29 19C29 16.2375 26.7625 14 24 14C21.2375 14 19 16.2375 19 19C19 21.7625 21.2375 24 24 24Z"
+                    fill="currentColor"
+                  />
+                  <path
+                    d="M24 26.5C20.6625 26.5 14 28.175 14 31.5V32.75C14 33.4375 14.5625 34 15.25 34H32.75C33.4375 34 34 33.4375 34 32.75V31.5C34 28.175 27.3375 26.5 24 26.5Z"
+                    fill="currentColor"
+                  />
+                </svg>
+              )}
             </div>
-            <div className={cx('info-form__profile_txt_box')}>
-              {user?.username}
-            </div>
-            {/* 사용자 상세 정보 */}
-            <div className={cx('info-form__auth_box')}>
-              <div className={cx('email_box')}>
-                <div className={cx('txt')}>가입계정</div>
-                {/*  가입 유형 이미지 */}
-                <div className={cx('value')}>
-                  <div className={cx('value__box')}>
-                    <Image src={'/icon/email.svg'} width={16} height={16} />
-                  </div>
-                  {user?.email}
+            <div className={cx('profile-card__meta')}>
+              <div className={cx('profile-card__name')}>{user?.username}</div>
+              {user?.register_date && (
+                <div className={cx('profile-card__since')}>
+                  <span className={cx('profile-card__since-date')}>
+                    {dayjs(user?.register_date).format('YYYY년 MM월 DD일')}
+                  </span>
+                  <span className={cx('profile-card__since-chip')}>
+                    가입일 🎉
+                  </span>
                 </div>
-              </div>
+              )}
             </div>
-            <div className={cx('info-form__register_date')}>
-              {dayjs(user?.register_date).format('YYYY년 MM월 DD일')}
-              <div className={cx('info-form__register-info-button')}>
-                가입일 🎉
-              </div>
+          </section>
+
+          <section className={cx('info-card')}>
+            <h2 className={cx('info-card__title')}>계정 정보</h2>
+            <ul className={cx('info-list')}>
+              <li className={cx('info-row')}>
+                <span className={cx('info-row__label')}>가입계정</span>
+                <span className={cx('info-row__value')}>
+                  <span className={cx('info-row__icon')}>
+                    <Image
+                      src={'/icon/email.svg'}
+                      width={16}
+                      height={16}
+                      alt="email"
+                    />
+                  </span>
+                  <span className={cx('info-row__text')}>{user?.email}</span>
+                </span>
+              </li>
+            </ul>
+          </section>
+
+          <section className={cx('danger-card')}>
+            <div className={cx('danger-card__text')}>
+              <h3 className={cx('danger-card__title')}>회원 탈퇴</h3>
+              <p className={cx('danger-card__desc')}>
+                탈퇴 시 내 정보와 북마크가 모두 삭제되며 복구할 수 없어요.
+              </p>
             </div>
-          </div>
-          {/* // 사용자 상세 정보 */}
-          <div className={cx('info-form__withdraw_box')}>
             <WithdrawOkButton
               onClick={() => {
                 setDeleteAccountIsOpen(true);
@@ -127,10 +156,9 @@ const MyInfo = ({ isLoggedIn }: { isLoggedIn: boolean }) => {
                 });
               }}
             />
-          </div>
+          </section>
         </div>
 
-        {/* 탈퇴 재확인 알림 팝업 */}
         <DeleteAccountModal
           isOpen={DeleteAccountModalIsOpen}
           onCancel={() => {
@@ -143,7 +171,7 @@ const MyInfo = ({ isLoggedIn }: { isLoggedIn: boolean }) => {
           }}
           onClick={deleteAccount}
         />
-      </div>
+      </main>
       <Letter />
     </>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,9 @@ devDependencies:
   '@types/cookie':
     specifier: ^0.5.1
     version: 0.5.4
+  '@types/jest':
+    specifier: '29'
+    version: 29.5.14
   '@types/js-cookie':
     specifier: ^3.0.4
     version: 3.0.6
@@ -103,9 +106,18 @@ devDependencies:
   eslint-plugin-prettier:
     specifier: ^4.0.0
     version: 4.2.5(eslint-config-prettier@8.10.2)(eslint@8.57.1)(prettier@2.6.2)
+  jest:
+    specifier: '29'
+    version: 29.7.0(@types/node@17.0.23)
+  jest-environment-jsdom:
+    specifier: '29'
+    version: 29.7.0
   prettier:
     specifier: 2.6.2
     version: 2.6.2
+  ts-jest:
+    specifier: '29'
+    version: 29.4.9(@babel/core@7.28.5)(jest@29.7.0)(typescript@4.6.3)
   typescript:
     specifier: 4.6.3
     version: 4.6.3
@@ -448,6 +460,43 @@ packages:
       '@babel/core': 7.28.5
     dev: true
 
+  /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.5):
+    resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+    dev: true
+
+  /@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.5):
+    resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+    dev: true
+
+  /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.5):
+    resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+    dev: true
+
+  /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.5):
+    resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+    dev: true
+
   /@babel/plugin-syntax-import-assertions@7.27.1(@babel/core@7.28.5):
     resolution: {integrity: sha512-UT/Jrhw57xg4ILHLFnzFpPDlMbcdEicaAtjPQpbj9wa8T4r5KVWCimHcL/460g8Ht0DMxDyjsLgiWSkVjnwPFg==}
     engines: {node: '>=6.9.0'}
@@ -468,8 +517,100 @@ packages:
       '@babel/helper-plugin-utils': 7.27.1
     dev: true
 
+  /@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.5):
+    resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+    dev: true
+
+  /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.5):
+    resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+    dev: true
+
   /@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.28.5):
     resolution: {integrity: sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+    dev: true
+
+  /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.5):
+    resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+    dev: true
+
+  /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.5):
+    resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+    dev: true
+
+  /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.5):
+    resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+    dev: true
+
+  /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.5):
+    resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+    dev: true
+
+  /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.5):
+    resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+    dev: true
+
+  /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.5):
+    resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+    dev: true
+
+  /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.5):
+    resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+    dev: true
+
+  /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.5):
+    resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1342,6 +1483,10 @@ packages:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  /@bcoe/v8-coverage@0.2.3:
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+    dev: true
+
   /@emotion/is-prop-valid@1.2.2:
     resolution: {integrity: sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==}
     dependencies:
@@ -1413,6 +1558,236 @@ packages:
   /@humanwhocodes/object-schema@2.0.3:
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
+    dev: true
+
+  /@istanbuljs/load-nyc-config@1.1.0:
+    resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      camelcase: 5.3.1
+      find-up: 4.1.0
+      get-package-type: 0.1.0
+      js-yaml: 3.14.2
+      resolve-from: 5.0.0
+    dev: true
+
+  /@istanbuljs/schema@0.1.6:
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /@jest/console@29.7.0:
+    resolution: {integrity: sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/node': 17.0.23
+      chalk: 4.1.2
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+      slash: 3.0.0
+    dev: true
+
+  /@jest/core@29.7.0:
+    resolution: {integrity: sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 17.0.23
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@17.0.23)
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    dev: true
+
+  /@jest/environment@29.7.0:
+    resolution: {integrity: sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/fake-timers': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 17.0.23
+      jest-mock: 29.7.0
+    dev: true
+
+  /@jest/expect-utils@29.7.0:
+    resolution: {integrity: sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      jest-get-type: 29.6.3
+    dev: true
+
+  /@jest/expect@29.7.0:
+    resolution: {integrity: sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      expect: 29.7.0
+      jest-snapshot: 29.7.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@jest/fake-timers@29.7.0:
+    resolution: {integrity: sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/types': 29.6.3
+      '@sinonjs/fake-timers': 10.3.0
+      '@types/node': 17.0.23
+      jest-message-util: 29.7.0
+      jest-mock: 29.7.0
+      jest-util: 29.7.0
+    dev: true
+
+  /@jest/globals@29.7.0:
+    resolution: {integrity: sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/expect': 29.7.0
+      '@jest/types': 29.6.3
+      jest-mock: 29.7.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@jest/reporters@29.7.0:
+    resolution: {integrity: sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@bcoe/v8-coverage': 0.2.3
+      '@jest/console': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/node': 17.0.23
+      chalk: 4.1.2
+      collect-v8-coverage: 1.0.3
+      exit: 0.1.2
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-instrument: 6.0.3
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 4.0.1
+      istanbul-reports: 3.2.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+      jest-worker: 29.7.0
+      slash: 3.0.0
+      string-length: 4.0.2
+      strip-ansi: 6.0.1
+      v8-to-istanbul: 9.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@jest/schemas@29.6.3:
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@sinclair/typebox': 0.27.10
+    dev: true
+
+  /@jest/source-map@29.6.3:
+    resolution: {integrity: sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      callsites: 3.1.0
+      graceful-fs: 4.2.11
+    dev: true
+
+  /@jest/test-result@29.7.0:
+    resolution: {integrity: sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/istanbul-lib-coverage': 2.0.6
+      collect-v8-coverage: 1.0.3
+    dev: true
+
+  /@jest/test-sequencer@29.7.0:
+    resolution: {integrity: sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/test-result': 29.7.0
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      slash: 3.0.0
+    dev: true
+
+  /@jest/transform@29.7.0:
+    resolution: {integrity: sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@babel/core': 7.28.5
+      '@jest/types': 29.6.3
+      '@jridgewell/trace-mapping': 0.3.31
+      babel-plugin-istanbul: 6.1.1
+      chalk: 4.1.2
+      convert-source-map: 2.0.0
+      fast-json-stable-stringify: 2.1.0
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-util: 29.7.0
+      micromatch: 4.0.8
+      pirates: 4.0.7
+      slash: 3.0.0
+      write-file-atomic: 4.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@jest/types@29.6.3:
+    resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.6.3
+      '@types/istanbul-lib-coverage': 2.0.6
+      '@types/istanbul-reports': 3.0.4
+      '@types/node': 17.0.23
+      '@types/yargs': 17.0.35
+      chalk: 4.1.2
     dev: true
 
   /@jridgewell/gen-mapping@0.3.13:
@@ -1723,6 +2098,22 @@ packages:
     dev: false
     optional: true
 
+  /@sinclair/typebox@0.27.10:
+    resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
+    dev: true
+
+  /@sinonjs/commons@3.0.1:
+    resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
+    dependencies:
+      type-detect: 4.0.8
+    dev: true
+
+  /@sinonjs/fake-timers@10.3.0:
+    resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+    dev: true
+
   /@svgr/babel-plugin-add-jsx-attribute@6.5.1(@babel/core@7.28.5):
     resolution: {integrity: sha512-9PYGcXrAxitycIjRmZB+Q0JaN07GZIWaTBIGQzfaZv+qr1n8X1XUEJ5rZ/vx6OVD9RRYlrNnXWExQXcmZeD/BQ==}
     engines: {node: '>=10'}
@@ -1876,6 +2267,11 @@ packages:
       - supports-color
     dev: true
 
+  /@tootallnate/once@2.0.1:
+    resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
+    engines: {node: '>= 10'}
+    dev: true
+
   /@trivago/prettier-plugin-sort-imports@4.3.0(prettier@2.6.2):
     resolution: {integrity: sha512-r3n0onD3BTOVUNPhR4lhVK4/pABGpbA7bW3eumZnYdKaHkf1qEC+Mag6DPbGNuuh0eG8AaYj+YqmVHSiGslaTQ==}
     peerDependencies:
@@ -1901,6 +2297,35 @@ packages:
     engines: {node: '>=10.13.0'}
     dev: true
 
+  /@types/babel__core@7.20.5:
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+    dependencies:
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+    dev: true
+
+  /@types/babel__generator@7.27.0:
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+    dependencies:
+      '@babel/types': 7.28.5
+    dev: true
+
+  /@types/babel__template@7.4.4:
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+    dependencies:
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
+    dev: true
+
+  /@types/babel__traverse@7.28.0:
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+    dependencies:
+      '@babel/types': 7.28.5
+    dev: true
+
   /@types/cookie@0.5.4:
     resolution: {integrity: sha512-7z/eR6O859gyWIAjuvBWFzNURmf2oPBmJlfVWkwehU5nzIyjwBsTh7WMmEEV4JFnHuQ3ex4oyTvfKzcyJVDBNA==}
     dev: true
@@ -1923,8 +2348,45 @@ packages:
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
     dev: true
 
+  /@types/graceful-fs@4.1.9:
+    resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
+    dependencies:
+      '@types/node': 17.0.23
+    dev: true
+
+  /@types/istanbul-lib-coverage@2.0.6:
+    resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
+    dev: true
+
+  /@types/istanbul-lib-report@3.0.3:
+    resolution: {integrity: sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==}
+    dependencies:
+      '@types/istanbul-lib-coverage': 2.0.6
+    dev: true
+
+  /@types/istanbul-reports@3.0.4:
+    resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
+    dependencies:
+      '@types/istanbul-lib-report': 3.0.3
+    dev: true
+
+  /@types/jest@29.5.14:
+    resolution: {integrity: sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==}
+    dependencies:
+      expect: 29.7.0
+      pretty-format: 29.7.0
+    dev: true
+
   /@types/js-cookie@3.0.6:
     resolution: {integrity: sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==}
+    dev: true
+
+  /@types/jsdom@20.0.1:
+    resolution: {integrity: sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==}
+    dependencies:
+      '@types/node': 17.0.23
+      '@types/tough-cookie': 4.0.5
+      parse5: 7.3.0
     dev: true
 
   /@types/json-schema@7.0.15:
@@ -1975,9 +2437,27 @@ packages:
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
     dev: true
 
+  /@types/stack-utils@2.0.3:
+    resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+    dev: true
+
   /@types/stylis@4.2.5:
     resolution: {integrity: sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==}
     dev: false
+
+  /@types/tough-cookie@4.0.5:
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+    dev: true
+
+  /@types/yargs-parser@21.0.3:
+    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
+    dev: true
+
+  /@types/yargs@17.0.35:
+    resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
+    dependencies:
+      '@types/yargs-parser': 21.0.3
+    dev: true
 
   /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.57.1)(typescript@4.6.3):
     resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
@@ -2227,6 +2707,18 @@ packages:
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
     dev: true
 
+  /abab@2.0.6:
+    resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
+    deprecated: Use your platform's native atob() and btoa() methods instead
+    dev: true
+
+  /acorn-globals@7.0.1:
+    resolution: {integrity: sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==}
+    dependencies:
+      acorn: 8.15.0
+      acorn-walk: 8.3.5
+    dev: true
+
   /acorn-import-phases@1.0.4(acorn@8.15.0):
     resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
     engines: {node: '>=10.13.0'}
@@ -2244,10 +2736,26 @@ packages:
       acorn: 8.15.0
     dev: true
 
+  /acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
+    engines: {node: '>=0.4.0'}
+    dependencies:
+      acorn: 8.15.0
+    dev: true
+
   /acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+    dev: true
+
+  /agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /ajv-formats@2.1.1(ajv@8.17.1):
@@ -2296,6 +2804,13 @@ packages:
       require-from-string: 2.0.2
     dev: true
 
+  /ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      type-fest: 0.21.3
+    dev: true
+
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -2308,6 +2823,25 @@ packages:
       color-convert: 2.0.1
     dev: true
 
+  /ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.1
+    dev: true
+
+  /argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+    dependencies:
+      sprintf-js: 1.0.3
+    dev: true
+
   /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
     dev: true
@@ -2317,6 +2851,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+    dev: true
+
   /axios@0.26.1:
     resolution: {integrity: sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==}
     dependencies:
@@ -2324,6 +2862,24 @@ packages:
     transitivePeerDependencies:
       - debug
     dev: false
+
+  /babel-jest@29.7.0(@babel/core@7.28.5):
+    resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@babel/core': ^7.8.0
+    dependencies:
+      '@babel/core': 7.28.5
+      '@jest/transform': 29.7.0
+      '@types/babel__core': 7.20.5
+      babel-plugin-istanbul: 6.1.1
+      babel-preset-jest: 29.6.3(@babel/core@7.28.5)
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /babel-loader@8.4.1(@babel/core@7.28.5)(webpack@5.104.1):
     resolution: {integrity: sha512-nXzRChX+Z1GoE6yWavBQg6jDslyFF3SDjl2paADuoQtQW10JqShJt62R6eJQ5m/pjJFDT8xgKIWSP85OY8eXeA==}
@@ -2338,6 +2894,29 @@ packages:
       make-dir: 3.1.0
       schema-utils: 2.7.1
       webpack: 5.104.1
+    dev: true
+
+  /babel-plugin-istanbul@6.1.1:
+    resolution: {integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+      '@istanbuljs/load-nyc-config': 1.1.0
+      '@istanbuljs/schema': 0.1.6
+      istanbul-lib-instrument: 5.2.1
+      test-exclude: 6.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /babel-plugin-jest-hoist@29.6.3:
+    resolution: {integrity: sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@babel/template': 7.27.2
+      '@babel/types': 7.28.5
+      '@types/babel__core': 7.20.5
+      '@types/babel__traverse': 7.28.0
     dev: true
 
   /babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.28.5):
@@ -2378,6 +2957,40 @@ packages:
 
   /babel-plugin-transform-remove-console@6.9.4:
     resolution: {integrity: sha512-88blrUrMX3SPiGkT1GnvVY8E/7A+k6oj3MNvUtTIxJflFzXTw1bHkuJ/y039ouhFMp2prRn5cQGzokViYi1dsg==}
+    dev: true
+
+  /babel-preset-current-node-syntax@1.2.0(@babel/core@7.28.5):
+    resolution: {integrity: sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0 || ^8.0.0-0
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.5)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.5)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.28.5)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.28.5)
+      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.5)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.5)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.5)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.5)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.5)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.5)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.5)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.5)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.5)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.5)
+    dev: true
+
+  /babel-preset-jest@29.6.3(@babel/core@7.28.5):
+    resolution: {integrity: sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.28.5
+      babel-plugin-jest-hoist: 29.6.3
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.5)
     dev: true
 
   /balanced-match@1.0.2:
@@ -2421,12 +3034,38 @@ packages:
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
+  /bs-logger@0.2.6:
+    resolution: {integrity: sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==}
+    engines: {node: '>= 6'}
+    dependencies:
+      fast-json-stable-stringify: 2.1.0
+    dev: true
+
+  /bser@2.1.1:
+    resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
+    dependencies:
+      node-int64: 0.4.0
+    dev: true
+
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
     dev: true
 
+  /call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+    dev: true
+
   /callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /camelcase@5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
     dev: true
 
@@ -2450,6 +3089,11 @@ packages:
       supports-color: 7.2.0
     dev: true
 
+  /char-regex@1.0.2:
+    resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
+    engines: {node: '>=10'}
+    dev: true
+
   /chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
@@ -2462,9 +3106,36 @@ packages:
     engines: {node: '>=6.0'}
     dev: true
 
+  /ci-info@3.9.0:
+    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /cjs-module-lexer@1.4.3:
+    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+    dev: true
+
   /classnames@2.5.1:
     resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
     dev: false
+
+  /cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+    dev: true
+
+  /co@4.6.0:
+    resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
+    engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
+    dev: true
+
+  /collect-v8-coverage@1.0.3:
+    resolution: {integrity: sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==}
+    dev: true
 
   /color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -2475,6 +3146,13 @@ packages:
 
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+    dev: true
+
+  /combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      delayed-stream: 1.0.0
     dev: true
 
   /commander@2.20.3:
@@ -2517,6 +3195,25 @@ packages:
       parse-json: 5.2.0
       path-type: 4.0.0
       yaml: 1.10.2
+    dev: true
+
+  /create-jest@29.7.0(@types/node@17.0.23):
+    resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@17.0.23)
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
     dev: true
 
   /cross-spawn@7.0.6:
@@ -2571,12 +3268,36 @@ packages:
       css-tree: 1.1.3
     dev: true
 
+  /cssom@0.3.8:
+    resolution: {integrity: sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==}
+    dev: true
+
+  /cssom@0.5.0:
+    resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
+    dev: true
+
+  /cssstyle@2.3.0:
+    resolution: {integrity: sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==}
+    engines: {node: '>=8'}
+    dependencies:
+      cssom: 0.3.8
+    dev: true
+
   /csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
     dev: false
 
   /csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+    dev: true
+
+  /data-urls@3.0.2:
+    resolution: {integrity: sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      abab: 2.0.6
+      whatwg-mimetype: 3.0.0
+      whatwg-url: 11.0.0
     dev: true
 
   /dayjs@1.11.19:
@@ -2594,6 +3315,19 @@ packages:
     dependencies:
       ms: 2.1.3
 
+  /decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+    dev: true
+
+  /dedent@1.7.2:
+    resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
+    peerDependencies:
+      babel-plugin-macros: ^3.1.0
+    peerDependenciesMeta:
+      babel-plugin-macros:
+        optional: true
+    dev: true
+
   /deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
     dev: true
@@ -2603,6 +3337,11 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+    dev: true
+
   /detect-libc@1.0.3:
     resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
     engines: {node: '>=0.10'}
@@ -2610,6 +3349,16 @@ packages:
     requiresBuild: true
     dev: false
     optional: true
+
+  /detect-newline@3.1.0:
+    resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dev: true
 
   /dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -2637,6 +3386,14 @@ packages:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
     dev: true
 
+  /domexception@4.0.0:
+    resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
+    engines: {node: '>=12'}
+    deprecated: Use your platform's native DOMException instead
+    dependencies:
+      webidl-conversions: 7.0.0
+    dev: true
+
   /domhandler@4.3.1:
     resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
     engines: {node: '>= 4'}
@@ -2652,8 +3409,26 @@ packages:
       domhandler: 4.3.1
     dev: true
 
+  /dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+    dev: true
+
   /electron-to-chromium@1.5.267:
     resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
+
+  /emittery@0.13.1:
+    resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+    dev: true
 
   /emojis-list@3.0.0:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
@@ -2677,23 +3452,72 @@ packages:
     engines: {node: '>=0.12'}
     dev: true
 
+  /entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+    dev: true
+
   /error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
     dependencies:
       is-arrayish: 0.2.1
     dev: true
 
+  /es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
+  /es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
   /es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+    dev: true
+
+  /es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-errors: 1.3.0
+    dev: true
+
+  /es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
     dev: true
 
   /escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  /escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
+    dev: true
+
   /escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+    dev: true
+
+  /escodegen@2.1.0:
+    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
+    engines: {node: '>=6.0'}
+    hasBin: true
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+    optionalDependencies:
+      source-map: 0.6.1
     dev: true
 
   /eslint-config-prettier@8.10.2(eslint@8.57.1):
@@ -2800,6 +3624,12 @@ packages:
       eslint-visitor-keys: 3.4.3
     dev: true
 
+  /esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+    dev: true
+
   /esquery@1.6.0:
     resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
     engines: {node: '>=0.10'}
@@ -2834,9 +3664,40 @@ packages:
     engines: {node: '>=0.8.x'}
     dev: true
 
+  /execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+    dev: true
+
   /exenv@1.2.2:
     resolution: {integrity: sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw==}
     dev: false
+
+  /exit@0.1.2:
+    resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
+    engines: {node: '>= 0.8.0'}
+    dev: true
+
+  /expect@29.7.0:
+    resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/expect-utils': 29.7.0
+      jest-get-type: 29.6.3
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+    dev: true
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2873,6 +3734,12 @@ packages:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
     dependencies:
       reusify: 1.1.0
+    dev: true
+
+  /fb-watchman@2.0.2:
+    resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
+    dependencies:
+      bser: 2.1.1
     dev: true
 
   /file-entry-cache@6.0.1:
@@ -2937,9 +3804,28 @@ packages:
         optional: true
     dev: false
 
+  /form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+    dev: true
+
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
+
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -2948,6 +3834,45 @@ packages:
   /gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  /get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+    dev: true
+
+  /get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+    dev: true
+
+  /get-package-type@0.1.0:
+    resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
+    engines: {node: '>=8.0.0'}
+    dev: true
+
+  /get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+    dev: true
+
+  /get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+    dev: true
 
   /glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -3003,6 +3928,11 @@ packages:
       slash: 3.0.0
     dev: true
 
+  /gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
     dev: true
@@ -3011,9 +3941,34 @@ packages:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
     dev: true
 
+  /handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
+    engines: {node: '>=0.4.7'}
+    hasBin: true
+    dependencies:
+      minimist: 1.2.8
+      neo-async: 2.6.2
+      source-map: 0.6.1
+      wordwrap: 1.0.0
+    optionalDependencies:
+      uglify-js: 3.19.3
+    dev: true
+
   /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+    dev: true
+
+  /has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
+  /has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      has-symbols: 1.1.0
     dev: true
 
   /hasown@2.0.2:
@@ -3021,6 +3976,50 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       function-bind: 1.1.2
+    dev: true
+
+  /html-encoding-sniffer@3.0.0:
+    resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
+    engines: {node: '>=12'}
+    dependencies:
+      whatwg-encoding: 2.0.0
+    dev: true
+
+  /html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+    dev: true
+
+  /http-proxy-agent@5.0.0:
+    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
+    engines: {node: '>= 6'}
+    dependencies:
+      '@tootallnate/once': 2.0.1
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
+    dev: true
+
+  /iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      safer-buffer: 2.1.2
     dev: true
 
   /ignore@5.3.2:
@@ -3038,6 +4037,15 @@ packages:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
+    dev: true
+
+  /import-local@3.2.0:
+    resolution: {integrity: sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      pkg-dir: 4.2.0
+      resolve-cwd: 3.0.0
     dev: true
 
   /imurmurhash@0.1.4:
@@ -3072,6 +4080,16 @@ packages:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
 
+  /is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /is-generator-fn@2.1.0:
+    resolution: {integrity: sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==}
+    engines: {node: '>=6'}
+    dev: true
+
   /is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
@@ -3088,12 +4106,482 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+    dev: true
+
+  /is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+    dev: true
+
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
 
+  /istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /istanbul-lib-instrument@5.2.1:
+    resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/parser': 7.28.5
+      '@istanbuljs/schema': 0.1.6
+      istanbul-lib-coverage: 3.2.2
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /istanbul-lib-instrument@6.0.3:
+    resolution: {integrity: sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==}
+    engines: {node: '>=10'}
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/parser': 7.28.5
+      '@istanbuljs/schema': 0.1.6
+      istanbul-lib-coverage: 3.2.2
+      semver: 7.7.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+    dev: true
+
+  /istanbul-lib-source-maps@4.0.1:
+    resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
+    engines: {node: '>=10'}
+    dependencies:
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      source-map: 0.6.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+    dev: true
+
   /javascript-natural-sort@0.7.1:
     resolution: {integrity: sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==}
+    dev: true
+
+  /jest-changed-files@29.7.0:
+    resolution: {integrity: sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      execa: 5.1.1
+      jest-util: 29.7.0
+      p-limit: 3.1.0
+    dev: true
+
+  /jest-circus@29.7.0:
+    resolution: {integrity: sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/expect': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 17.0.23
+      chalk: 4.1.2
+      co: 4.6.0
+      dedent: 1.7.2
+      is-generator-fn: 2.1.0
+      jest-each: 29.7.0
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      p-limit: 3.1.0
+      pretty-format: 29.7.0
+      pure-rand: 6.1.0
+      slash: 3.0.0
+      stack-utils: 2.0.6
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+    dev: true
+
+  /jest-cli@29.7.0(@types/node@17.0.23):
+    resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@17.0.23)
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@17.0.23)
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    dev: true
+
+  /jest-config@29.7.0(@types/node@17.0.23):
+    resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@types/node': '*'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      '@babel/core': 7.28.5
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 17.0.23
+      babel-jest: 29.7.0(@babel/core@7.28.5)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+    dev: true
+
+  /jest-diff@29.7.0:
+    resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 29.6.3
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+    dev: true
+
+  /jest-docblock@29.7.0:
+    resolution: {integrity: sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      detect-newline: 3.1.0
+    dev: true
+
+  /jest-each@29.7.0:
+    resolution: {integrity: sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      jest-get-type: 29.6.3
+      jest-util: 29.7.0
+      pretty-format: 29.7.0
+    dev: true
+
+  /jest-environment-jsdom@29.7.0:
+    resolution: {integrity: sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      canvas: ^2.5.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/fake-timers': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/jsdom': 20.0.1
+      '@types/node': 17.0.23
+      jest-mock: 29.7.0
+      jest-util: 29.7.0
+      jsdom: 20.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /jest-environment-node@29.7.0:
+    resolution: {integrity: sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/fake-timers': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 17.0.23
+      jest-mock: 29.7.0
+      jest-util: 29.7.0
+    dev: true
+
+  /jest-get-type@29.6.3:
+    resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dev: true
+
+  /jest-haste-map@29.7.0:
+    resolution: {integrity: sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/graceful-fs': 4.1.9
+      '@types/node': 17.0.23
+      anymatch: 3.1.3
+      fb-watchman: 2.0.2
+      graceful-fs: 4.2.11
+      jest-regex-util: 29.6.3
+      jest-util: 29.7.0
+      jest-worker: 29.7.0
+      micromatch: 4.0.8
+      walker: 1.0.8
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
+  /jest-leak-detector@29.7.0:
+    resolution: {integrity: sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+    dev: true
+
+  /jest-matcher-utils@29.7.0:
+    resolution: {integrity: sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      chalk: 4.1.2
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+    dev: true
+
+  /jest-message-util@29.7.0:
+    resolution: {integrity: sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@jest/types': 29.6.3
+      '@types/stack-utils': 2.0.3
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      stack-utils: 2.0.6
+    dev: true
+
+  /jest-mock@29.7.0:
+    resolution: {integrity: sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/node': 17.0.23
+      jest-util: 29.7.0
+    dev: true
+
+  /jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
+    resolution: {integrity: sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==}
+    engines: {node: '>=6'}
+    peerDependencies:
+      jest-resolve: '*'
+    peerDependenciesMeta:
+      jest-resolve:
+        optional: true
+    dependencies:
+      jest-resolve: 29.7.0
+    dev: true
+
+  /jest-regex-util@29.6.3:
+    resolution: {integrity: sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dev: true
+
+  /jest-resolve-dependencies@29.7.0:
+    resolution: {integrity: sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      jest-regex-util: 29.6.3
+      jest-snapshot: 29.7.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /jest-resolve@29.7.0:
+    resolution: {integrity: sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      jest-pnp-resolver: 1.2.3(jest-resolve@29.7.0)
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      resolve: 1.22.11
+      resolve.exports: 2.0.3
+      slash: 3.0.0
+    dev: true
+
+  /jest-runner@29.7.0:
+    resolution: {integrity: sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/environment': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 17.0.23
+      chalk: 4.1.2
+      emittery: 0.13.1
+      graceful-fs: 4.2.11
+      jest-docblock: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-haste-map: 29.7.0
+      jest-leak-detector: 29.7.0
+      jest-message-util: 29.7.0
+      jest-resolve: 29.7.0
+      jest-runtime: 29.7.0
+      jest-util: 29.7.0
+      jest-watcher: 29.7.0
+      jest-worker: 29.7.0
+      p-limit: 3.1.0
+      source-map-support: 0.5.13
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /jest-runtime@29.7.0:
+    resolution: {integrity: sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/fake-timers': 29.7.0
+      '@jest/globals': 29.7.0
+      '@jest/source-map': 29.6.3
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 17.0.23
+      chalk: 4.1.2
+      cjs-module-lexer: 1.4.3
+      collect-v8-coverage: 1.0.3
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-mock: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      slash: 3.0.0
+      strip-bom: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /jest-snapshot@29.7.0:
+    resolution: {integrity: sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/generator': 7.28.5
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.5)
+      '@babel/types': 7.28.5
+      '@jest/expect-utils': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.5)
+      chalk: 4.1.2
+      expect: 29.7.0
+      graceful-fs: 4.2.11
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+      natural-compare: 1.4.0
+      pretty-format: 29.7.0
+      semver: 7.7.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /jest-util@29.7.0:
+    resolution: {integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/node': 17.0.23
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      graceful-fs: 4.2.11
+      picomatch: 2.3.1
+    dev: true
+
+  /jest-validate@29.7.0:
+    resolution: {integrity: sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/types': 29.6.3
+      camelcase: 6.3.0
+      chalk: 4.1.2
+      jest-get-type: 29.6.3
+      leven: 3.1.0
+      pretty-format: 29.7.0
+    dev: true
+
+  /jest-watcher@29.7.0:
+    resolution: {integrity: sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 17.0.23
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      emittery: 0.13.1
+      jest-util: 29.7.0
+      string-length: 4.0.2
     dev: true
 
   /jest-worker@27.5.1:
@@ -3105,6 +4593,37 @@ packages:
       supports-color: 8.1.1
     dev: true
 
+  /jest-worker@29.7.0:
+    resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@types/node': 17.0.23
+      jest-util: 29.7.0
+      merge-stream: 2.0.0
+      supports-color: 8.1.1
+    dev: true
+
+  /jest@29.7.0(@types/node@17.0.23):
+    resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 29.7.0
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@17.0.23)
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    dev: true
+
   /js-cookie@3.0.5:
     resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
     engines: {node: '>=14'}
@@ -3113,11 +4632,60 @@ packages:
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  /js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    hasBin: true
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+    dev: true
+
   /js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
     dependencies:
       argparse: 2.0.1
+    dev: true
+
+  /jsdom@20.0.3:
+    resolution: {integrity: sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      canvas: ^2.5.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+    dependencies:
+      abab: 2.0.6
+      acorn: 8.15.0
+      acorn-globals: 7.0.1
+      cssom: 0.5.0
+      cssstyle: 2.3.0
+      data-urls: 3.0.2
+      decimal.js: 10.6.0
+      domexception: 4.0.0
+      escodegen: 2.1.0
+      form-data: 4.0.5
+      html-encoding-sniffer: 3.0.0
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 4.1.4
+      w3c-xmlserializer: 4.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 2.0.0
+      whatwg-mimetype: 3.0.0
+      whatwg-url: 11.0.0
+      ws: 8.20.0
+      xml-name-validator: 4.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
     dev: true
 
   /jsesc@2.5.2:
@@ -3166,6 +4734,16 @@ packages:
       json-buffer: 3.0.1
     dev: true
 
+  /kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /leven@3.1.0:
+    resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
+    engines: {node: '>=6'}
+    dev: true
+
   /levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -3210,6 +4788,10 @@ packages:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
     dev: true
 
+  /lodash.memoize@4.1.2:
+    resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
+    dev: true
+
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: true
@@ -3237,11 +4819,33 @@ packages:
       semver: 6.3.1
     dev: true
 
+  /make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+    dependencies:
+      semver: 7.7.3
+    dev: true
+
+  /make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+    dev: true
+
+  /makeerror@1.0.12:
+    resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
+    dependencies:
+      tmpl: 1.0.5
+    dev: true
+
   /marked@4.3.0:
     resolution: {integrity: sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==}
     engines: {node: '>= 12'}
     hasBin: true
     dev: false
+
+  /math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+    dev: true
 
   /mdn-data@2.0.14:
     resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
@@ -3275,10 +4879,19 @@ packages:
       mime-db: 1.52.0
     dev: true
 
+  /mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+    dev: true
+
   /minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
       brace-expansion: 1.1.12
+    dev: true
+
+  /minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
     dev: true
 
   /ms@2.1.3:
@@ -3352,13 +4965,33 @@ packages:
     dev: false
     optional: true
 
+  /node-int64@0.4.0:
+    resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
+    dev: true
+
   /node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+
+  /normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+    dependencies:
+      path-key: 3.1.1
+    dev: true
 
   /nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
     dependencies:
       boolbase: 1.0.0
+    dev: true
+
+  /nwsapi@2.2.23:
+    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
     dev: true
 
   /object-assign@4.1.1:
@@ -3370,6 +5003,13 @@ packages:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
+    dev: true
+
+  /onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+    dependencies:
+      mimic-fn: 2.1.0
     dev: true
 
   /optionator@0.9.4:
@@ -3434,6 +5074,12 @@ packages:
       lines-and-columns: 1.2.4
     dev: true
 
+  /parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+    dependencies:
+      entities: 6.0.1
+    dev: true
+
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -3465,6 +5111,11 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
     requiresBuild: true
+
+  /pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+    dev: true
 
   /pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
@@ -3513,6 +5164,23 @@ packages:
     hasBin: true
     dev: true
 
+  /pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+    dev: true
+
+  /prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
+    dev: true
+
   /prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
     dependencies:
@@ -3521,9 +5189,23 @@ packages:
       react-is: 16.13.1
     dev: false
 
+  /psl@1.15.0:
+    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+    dependencies:
+      punycode: 2.3.1
+    dev: true
+
   /punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+    dev: true
+
+  /pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+    dev: true
+
+  /querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
     dev: true
 
   /queue-microtask@1.2.3:
@@ -3561,7 +5243,6 @@ packages:
 
   /react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
-    dev: false
 
   /react-lifecycles-compat@3.0.4:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
@@ -3641,14 +5322,40 @@ packages:
       jsesc: 3.1.0
     dev: true
 
+  /require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+    dev: true
+
+  /resolve-cwd@3.0.0:
+    resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
+    engines: {node: '>=8'}
+    dependencies:
+      resolve-from: 5.0.0
+    dev: true
+
   /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
+    dev: true
+
+  /resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /resolve.exports@2.0.3:
+    resolution: {integrity: sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==}
+    engines: {node: '>=10'}
     dev: true
 
   /resolve@1.22.11:
@@ -3684,6 +5391,10 @@ packages:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
     dev: true
 
+  /safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+    dev: true
+
   /sass@1.97.1:
     resolution: {integrity: sha512-uf6HoO8fy6ClsrShvMgaKUn14f2EHQLQRtpsZZLeU/Mv0Q1K5P0+x2uvH6Cub39TVVbWNSrraUhDAoFph6vh0A==}
     engines: {node: '>=14.0.0'}
@@ -3695,6 +5406,13 @@ packages:
     optionalDependencies:
       '@parcel/watcher': 2.5.1
     dev: false
+
+  /saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+    dependencies:
+      xmlchars: 2.2.0
+    dev: true
 
   /scheduler@0.20.2:
     resolution: {integrity: sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==}
@@ -3732,6 +5450,12 @@ packages:
     hasBin: true
     dev: true
 
+  /semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dev: true
+
   /serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
     dependencies:
@@ -3754,6 +5478,14 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+    dev: true
+
+  /sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+    dev: true
+
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -3763,6 +5495,13 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
     dev: false
+
+  /source-map-support@0.5.13:
+    resolution: {integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==}
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+    dev: true
 
   /source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
@@ -3781,9 +5520,37 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+    dev: true
+
   /stable@0.1.8:
     resolution: {integrity: sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==}
     deprecated: 'Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility'
+    dev: true
+
+  /stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      escape-string-regexp: 2.0.0
+    dev: true
+
+  /string-length@4.0.2:
+    resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      char-regex: 1.0.2
+      strip-ansi: 6.0.1
+    dev: true
+
+  /string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
     dev: true
 
   /strip-ansi@6.0.1:
@@ -3791,6 +5558,16 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       ansi-regex: 5.0.1
+    dev: true
+
+  /strip-bom@4.0.0:
+    resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
     dev: true
 
   /strip-json-comments@3.1.1:
@@ -3884,6 +5661,10 @@ packages:
       react: 17.0.2
     dev: false
 
+  /symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+    dev: true
+
   /tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
@@ -3924,8 +5705,21 @@ packages:
       source-map-support: 0.5.21
     dev: true
 
+  /test-exclude@6.0.0:
+    resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 7.2.3
+      minimatch: 3.1.2
+    dev: true
+
   /text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+    dev: true
+
+  /tmpl@1.0.5:
+    resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
     dev: true
 
   /to-fast-properties@2.0.0:
@@ -3939,6 +5733,64 @@ packages:
     requiresBuild: true
     dependencies:
       is-number: 7.0.0
+
+  /tough-cookie@4.1.4:
+    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
+    engines: {node: '>=6'}
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
+      universalify: 0.2.0
+      url-parse: 1.5.10
+    dev: true
+
+  /tr46@3.0.0:
+    resolution: {integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==}
+    engines: {node: '>=12'}
+    dependencies:
+      punycode: 2.3.1
+    dev: true
+
+  /ts-jest@29.4.9(@babel/core@7.28.5)(jest@29.7.0)(typescript@4.6.3):
+    resolution: {integrity: sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@jest/transform': ^29.0.0 || ^30.0.0
+      '@jest/types': ^29.0.0 || ^30.0.0
+      babel-jest: ^29.0.0 || ^30.0.0
+      esbuild: '*'
+      jest: ^29.0.0 || ^30.0.0
+      jest-util: ^29.0.0 || ^30.0.0
+      typescript: '>=4.3 <7'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@jest/transform':
+        optional: true
+      '@jest/types':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+      jest-util:
+        optional: true
+    dependencies:
+      '@babel/core': 7.28.5
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      handlebars: 4.7.9
+      jest: 29.7.0(@types/node@17.0.23)
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.8.0
+      type-fest: 4.41.0
+      typescript: 4.6.3
+      yargs-parser: 21.1.1
+    dev: true
 
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
@@ -3965,9 +5817,24 @@ packages:
       prelude-ls: 1.2.1
     dev: true
 
+  /type-detect@4.0.8:
+    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
+    engines: {node: '>=4'}
+    dev: true
+
   /type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
+    dev: true
+
+  /type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
     dev: true
 
   /typescript@4.6.3:
@@ -3975,6 +5842,14 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true
+
+  /uglify-js@3.19.3:
+    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
+    engines: {node: '>=0.8.0'}
+    hasBin: true
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -3999,6 +5874,11 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
+  /universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+    dev: true
+
   /update-browserslist-db@1.2.3(browserslist@4.28.1):
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -4015,6 +5895,13 @@ packages:
       punycode: 2.3.1
     dev: true
 
+  /url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
+    dev: true
+
   /use-subscription@1.5.1(react@17.0.2):
     resolution: {integrity: sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==}
     peerDependencies:
@@ -4023,6 +5910,28 @@ packages:
       object-assign: 4.1.1
       react: 17.0.2
     dev: false
+
+  /v8-to-istanbul@9.3.0:
+    resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
+    engines: {node: '>=10.12.0'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/istanbul-lib-coverage': 2.0.6
+      convert-source-map: 2.0.0
+    dev: true
+
+  /w3c-xmlserializer@4.0.0:
+    resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
+    engines: {node: '>=14'}
+    dependencies:
+      xml-name-validator: 4.0.0
+    dev: true
+
+  /walker@1.0.8:
+    resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
+    dependencies:
+      makeerror: 1.0.12
+    dev: true
 
   /warning@4.0.3:
     resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
@@ -4036,6 +5945,11 @@ packages:
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
+    dev: true
+
+  /webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
     dev: true
 
   /webpack-sources@3.3.3:
@@ -4084,6 +5998,27 @@ packages:
       - uglify-js
     dev: true
 
+  /whatwg-encoding@2.0.0:
+    resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
+    engines: {node: '>=12'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+    dependencies:
+      iconv-lite: 0.6.3
+    dev: true
+
+  /whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /whatwg-url@11.0.0:
+    resolution: {integrity: sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      tr46: 3.0.0
+      webidl-conversions: 7.0.0
+    dev: true
+
   /which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -4097,8 +6032,56 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /wordwrap@1.0.0:
+    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
+    dev: true
+
+  /wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+    dev: true
+
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+    dev: true
+
+  /write-file-atomic@4.0.2:
+    resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    dependencies:
+      imurmurhash: 0.1.4
+      signal-exit: 3.0.7
+    dev: true
+
+  /ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: true
+
+  /xml-name-validator@4.0.0:
+    resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+    dev: true
+
+  /y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
     dev: true
 
   /yallist@3.1.1:
@@ -4107,6 +6090,24 @@ packages:
   /yaml@1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
+    dev: true
+
+  /yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
     dev: true
 
   /yocto-queue@0.1.0:

--- a/styles/EventDetail.module.scss
+++ b/styles/EventDetail.module.scss
@@ -25,20 +25,20 @@
     // 1199px: 1열 레이아웃 (이미지 상단, 정보 하단)
     @media (max-width: 1199px) {
       flex-direction: column;
-      padding: 32px 32px;
+      padding: 56px 32px 32px;
       gap: 32px;
       min-height: auto;
     }
 
     // 600px: 더 컴팩트한 레이아웃
     @media (max-width: 600px) {
-      padding: 24px 16px !important;
+      padding: 40px 16px 24px !important;
       gap: 24px;
     }
 
     // 320px: 모바일 최적화
     @media (max-width: 320px) {
-      padding: 24px 16px !important;
+      padding: 32px 16px 24px !important;
       gap: 16px;
     }
   }
@@ -111,7 +111,7 @@
   // 헤더 액션 버튼 (공유/북마크)
   &__header-actions {
     display: flex;
-    gap: 4px;
+    gap: 6px;
 
     @media (min-width: 1200px) {
       position: absolute;
@@ -126,10 +126,12 @@
       z-index: 3;
 
       .icon-btn {
-        width: 32px;
-        height: 32px;
-        background-color: rgba(255, 255, 255, 0.85);
-        backdrop-filter: blur(4px);
+        width: 36px;
+        height: 36px;
+        background-color: rgba(255, 255, 255, 0.9);
+        backdrop-filter: saturate(150%) blur(8px);
+        -webkit-backdrop-filter: saturate(150%) blur(8px);
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
 
         &:hover {
           background-color: rgba(255, 255, 255, 1);
@@ -138,21 +140,31 @@
     }
 
     .icon-btn {
-      width: 36px;
-      height: 36px;
+      width: 40px;
+      height: 40px;
       border: none;
       background: transparent;
       cursor: pointer;
-      border-radius: 8px;
+      border-radius: 12px;
       display: flex;
       align-items: center;
       justify-content: center;
-      transition: background-color 0.2s ease;
+      transition: background-color 0.18s ease, transform 0.12s ease;
       padding: 4px;
       color: var(--vapor-gray-500);
+      -webkit-tap-highlight-color: transparent;
 
       &:hover {
         background-color: var(--vapor-gray-100);
+      }
+
+      &:active {
+        transform: scale(0.92);
+      }
+
+      &:focus-visible {
+        outline: 2px solid var(--ktb-tech-blue);
+        outline-offset: 2px;
       }
 
       svg {

--- a/styles/EventDetail.module.scss
+++ b/styles/EventDetail.module.scss
@@ -4,48 +4,49 @@
 .event-detail {
   width: 100%;
   padding-top: 64px; // Header 높이만큼 추가
-  background-color: var(--background-1);
+  background-color: var(--vapor-gray-000);
 
   // 이벤트 헤더 영역
   &__header {
     width: 100%;
     display: flex;
+    position: relative;
 
     // 1200px 이상: 2열 레이아웃 (이미지 왼쪽, 정보 오른쪽)
     @media (min-width: 1200px) {
       flex-direction: row;
       max-width: 1200px;
       margin: 0 auto;
-      padding: 64px 20px;
-      gap: 60px;
-      min-height: 100px;
+      padding: 64px 32px;
+      gap: 32px;
+      min-height: auto;
     }
 
     // 1199px: 1열 레이아웃 (이미지 상단, 정보 하단)
     @media (max-width: 1199px) {
       flex-direction: column;
-      padding: 64px 64px;
+      padding: 32px 32px;
       gap: 32px;
       min-height: auto;
     }
 
     // 600px: 더 컴팩트한 레이아웃
     @media (max-width: 600px) {
-      padding: 64px 10px !important;
-      gap: 32px;
+      padding: 24px 16px !important;
+      gap: 24px;
     }
 
     // 320px: 모바일 최적화
     @media (max-width: 320px) {
-      padding: 64px 20px !important;
-      gap: 12px;
+      padding: 24px 16px !important;
+      gap: 16px;
     }
   }
 
   // 이미지 섹션
   &__image-section {
     position: relative;
-    aspect-ratio: 400 / 223; // 16:9에 가까운 비율 유지
+    aspect-ratio: 5 / 3;
 
     // 1200px 이상: 고정 너비 이미지
     @media (min-width: 1200px) {
@@ -57,25 +58,32 @@
     @media (max-width: 1199px) {
       width: 100%;
     }
-
-    // 600px 이하: 최대 높이 제한으로 너무 작아지는 것 방지
-    @media (max-width: 600px) {
-      max-height: 300px;
-    }
-
-    // 320px: 모바일에서 최소 높이 보장
-    @media (max-width: 320px) {
-      max-height: 200px;
-    }
   }
 
   &__image {
     position: relative;
     width: 100%;
     height: 100%;
-    border-radius: 4px;
+    border-radius: 12px;
     overflow: hidden;
-    border: 1px solid #ebebeb;
+
+    &__done {
+      width: 100%;
+      height: 100%;
+      position: absolute;
+      left: 0;
+      top: 0;
+      background-color: rgba(0, 0, 0, 0.4);
+      border-radius: 12px;
+      z-index: 1;
+    }
+
+    &__badge {
+      position: absolute;
+      top: 12px;
+      left: 12px;
+      z-index: 2;
+    }
   }
 
   // 정보 섹션
@@ -88,19 +96,22 @@
     // 1200px 이상: flex로 나머지 공간 차지
     @media (min-width: 1200px) {
       flex: 1;
-      padding: 8px 0 0;
+      padding: 0;
+      padding-right: 88px;
+      position: relative;
     }
 
-    // 1199px 이하: 전체 너비
+    // 1199px 이하: 전체 너비 (action 버튼은 &__header 기준으로 absolute → 썸네일 위)
     @media (max-width: 1199px) {
       width: 100%;
+      padding-right: 0;
     }
   }
 
   // 헤더 액션 버튼 (공유/북마크)
   &__header-actions {
     display: flex;
-    gap: 2px;
+    gap: 4px;
 
     @media (min-width: 1200px) {
       position: absolute;
@@ -108,39 +119,40 @@
       right: 0;
     }
 
-    @media (min-width: 601px) and (max-width: 1199px) {
+    @media (max-width: 1199px) {
       position: absolute;
-      top: 0;
-      right: 0;
-    }
+      top: 12px;
+      right: 12px;
+      z-index: 3;
 
-    @media (min-width: 321px) and (max-width: 600px) {
-      position: absolute;
-      top: -10px; // 공유 & 북마크 버튼 위치 조정
-      right: 2.5px; // 공유 & 북마크 버튼 위치 조정
-    }
+      .icon-btn {
+        width: 32px;
+        height: 32px;
+        background-color: rgba(255, 255, 255, 0.85);
+        backdrop-filter: blur(4px);
 
-    @media (max-width: 320px) {
-      position: absolute;
-      top: -2px; // 공유 & 북마크 버튼 위치 조정
-      right: 5px !important; // 공유 & 북마크 버튼 위치 조정
+        &:hover {
+          background-color: rgba(255, 255, 255, 1);
+        }
+      }
     }
 
     .icon-btn {
-      width: 32px;
-      height: 32px;
+      width: 36px;
+      height: 36px;
       border: none;
-      background: none;
+      background: transparent;
       cursor: pointer;
-      border-radius: 4px;
+      border-radius: 8px;
       display: flex;
       align-items: center;
       justify-content: center;
       transition: background-color 0.2s ease;
       padding: 4px;
+      color: var(--vapor-gray-500);
 
       &:hover {
-        background-color: rgba(0, 0, 0, 0.05);
+        background-color: var(--vapor-gray-100);
       }
 
       svg {
@@ -157,43 +169,31 @@
     align-items: center;
     gap: 6px;
 
-    @media (max-width: 320px) {
-      gap: 5px;
-    }
-
-    .organizer-badge {
-      width: 20px;
-      height: 20px;
-      border-radius: 2px;
-      background: url('/default/event_img.png') center/cover;
-
-      @media (max-width: 320px) {
-        width: 19px;
-        height: 19px;
-      }
-    }
-
     .organizer-text {
-      font-weight: 600;
-      font-size: 15px;
-      line-height: 1.2;
-      letter-spacing: -0.02em;
-      color: var(--text-1);
-
-      @media (max-width: 320px) {
-        font-size: 14px;
-      }
+      font-size: 14px;
+      font-weight: 500;
+      line-height: 1.4;
+      color: var(--vapor-gray-600);
     }
   }
 
   // 이벤트 제목
   &__title {
-    font-weight: 600;
-    font-size: 20px;
+    font-weight: 700;
+    font-size: 32px;
     line-height: 1.3;
-    letter-spacing: -0.02em;
-    color: var(--text-1);
+    letter-spacing: -0.012rem;
+    color: var(--vapor-gray-900);
     margin: 0;
+    word-break: keep-all;
+
+    @media (max-width: 1199px) {
+      font-size: 24px;
+    }
+
+    @media (max-width: 600px) {
+      font-size: 20px;
+    }
 
     @media (max-width: 320px) {
       font-size: 18px;
@@ -208,24 +208,22 @@
 
     .meta-item {
       display: flex;
-      gap: 4px;
-      align-items: flex-start;
+      align-items: baseline;
+      gap: 8px;
 
       .meta-label {
         font-weight: 500;
-        font-size: 16px;
+        font-size: 14px;
         line-height: 1.5;
-        letter-spacing: -0.02em;
-        color: var(--gray-2);
+        color: var(--vapor-gray-500);
         flex-shrink: 0;
       }
 
       .meta-value {
         font-weight: 500;
-        font-size: 16px;
+        font-size: 14px;
         line-height: 1.5;
-        letter-spacing: -0.02em;
-        color: var(--gray-2);
+        color: var(--vapor-gray-700);
       }
     }
   }
@@ -233,44 +231,11 @@
   // 태그들
   &__tags {
     display: flex;
-    gap: 10px;
+    flex-wrap: wrap;
+    gap: 6px;
 
-    // 600px 이하: 수평 스크롤
     @media (max-width: 600px) {
-      overflow-x: auto;
-      scrollbar-width: none;
-      -ms-overflow-style: none;
-
-      &::-webkit-scrollbar {
-        display: none;
-      }
-    }
-
-    @media (max-width: 320px) {
       gap: 4px;
-    }
-
-    .event-tag {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: 4px 16px;
-      height: 36px;
-      border: 1px solid #d3d4d8;
-      border-radius: 1000px;
-      background: transparent;
-      font-weight: 500;
-      font-size: 14px;
-      line-height: 1;
-      letter-spacing: -0.02em;
-      color: var(--text-1);
-      white-space: nowrap;
-      flex-shrink: 0;
-
-      @media (max-width: 320px) {
-        height: 32px;
-        padding: 4px 16px;
-      }
     }
   }
 
@@ -282,33 +247,30 @@
 
     .apply-btn {
       font-weight: 700;
-      font-size: 14px;
-      line-height: 1;
-      letter-spacing: -0.02em;
+      font-size: 16px;
+      line-height: 1.4;
+      letter-spacing: -0.012rem;
       color: #ffffff;
-      background: #2c4cef;
+      background: var(--ktb-tech-blue);
       border: none;
-      border-radius: 100px;
-      padding: 4px 40px;
+      border-radius: 12px;
+      padding: 12px 24px;
       cursor: pointer;
-      transition: all 0.2s ease;
-      width: 100%;
-      height: 48px;
-      display: flex;
+      transition: background-color 0.2s ease;
+      align-self: flex-start;
+      min-height: 48px;
+      display: inline-flex;
       align-items: center;
       justify-content: center;
       text-decoration: none;
 
       &:hover {
-        background: #1e3bcf;
-        transform: translateY(-1px);
+        background: var(--ktb-tech-navy-hover);
       }
 
-      &:active {
-        transform: translateY(0);
+      @media (max-width: 1199px) {
+        width: 100%;
       }
-
-
     }
   }
 
@@ -319,16 +281,17 @@
     display: flex;
     flex-direction: column;
     margin: 0 auto;
-    gap: 40px;
-    padding: 0 64px 40px;
+    gap: 24px;
+    padding: 24px 32px 64px;
+    border-top: 1px solid var(--vapor-gray-300);
 
     @media (max-width: 600px) {
-      padding: 0 10px 50px;
+      padding: 24px 16px 48px;
     }
 
     @media (max-width: 320px) {
-      padding: 0 10px 50px;
-      gap: 24px;
+      padding: 24px 16px 40px;
+      gap: 20px;
     }
 
     .content-title {
@@ -337,7 +300,7 @@
       font-size: 24px;
       line-height: 1.3;
       letter-spacing: -0.02em;
-      color: var(--text-1);
+      color: var(--vapor-gray-900);
       margin: 0;
 
       @media (max-width: 320px) {
@@ -346,17 +309,15 @@
     }
 
     .content-description {
-      color: var(--text-1);
+      color: var(--vapor-gray-900);
       line-height: 1.6;
       max-width: none;
 
-      // 문단
       p {
         margin: 0 0 16px 0;
         font-weight: 400;
         font-size: 16px;
         line-height: 1.5;
-        letter-spacing: -0.02em;
 
         @media (max-width: 320px) {
           font-size: 15px;
@@ -367,12 +328,11 @@
         }
       }
 
-      // 제목들
       h1, h2, h3, h4, h5, h6 {
-        color: var(--text-1);
+        color: var(--vapor-gray-900);
         margin: 32px 0 16px 0;
         font-weight: 700;
-        letter-spacing: -0.02em;
+        letter-spacing: -0.012rem;
         line-height: 1.3;
 
         &:first-child {
@@ -380,67 +340,24 @@
         }
       }
 
-      h1 {
-        font-size: 32px;
+      h1 { font-size: 32px; @media (max-width: 320px) { font-size: 26px; } }
+      h2 { font-size: 24px; @media (max-width: 320px) { font-size: 22px; } }
+      h3 { font-size: 20px; @media (max-width: 320px) { font-size: 18px; } }
+      h4 { font-size: 18px; @media (max-width: 320px) { font-size: 16px; } }
+      h5 { font-size: 16px; @media (max-width: 320px) { font-size: 15px; } }
+      h6 { font-size: 14px; @media (max-width: 320px) { font-size: 13px; } }
 
-        @media (max-width: 320px) {
-          font-size: 26px;
-        }
-      }
-
-      h2 {
-        font-size: 28px;
-
-        @media (max-width: 320px) {
-          font-size: 22px;
-        }
-      }
-
-      h3 {
-        font-size: 24px;
-
-        @media (max-width: 320px) {
-          font-size: 20px;
-        }
-      }
-
-      h4 {
-        font-size: 20px;
-
-        @media (max-width: 320px) {
-          font-size: 18px;
-        }
-      }
-
-      h5 {
-        font-size: 18px;
-
-        @media (max-width: 320px) {
-          font-size: 16px;
-        }
-      }
-
-      h6 {
-        font-size: 16px;
-
-        @media (max-width: 320px) {
-          font-size: 15px;
-        }
-      }
-
-      // 구분선
       hr {
         margin: 32px 0;
         border: none;
-        border-top: 1px solid #e1e2e6;
+        border-top: 1px solid var(--vapor-gray-300);
 
         @media (max-width: 320px) {
           margin: 24px 0;
         }
       }
 
-      // 순서 없는 리스트
-      ul {
+      ul, ol {
         margin: 16px 0;
         padding-left: 24px;
 
@@ -448,8 +365,7 @@
           margin: 8px 0;
           font-size: 16px;
           line-height: 1.6;
-          letter-spacing: -0.02em;
-          color: var(--text-1);
+          color: var(--vapor-gray-900);
 
           @media (max-width: 320px) {
             font-size: 15px;
@@ -457,80 +373,56 @@
         }
       }
 
-      // 순서 있는 리스트
-      ol {
-        margin: 16px 0;
-        padding-left: 24px;
-
-        li {
-          margin: 8px 0;
-          font-size: 16px;
-          line-height: 1.6;
-          letter-spacing: -0.02em;
-          color: var(--text-1);
-
-          @media (max-width: 320px) {
-            font-size: 15px;
-          }
-        }
-      }
-
-      // 이미지
       img {
         max-width: 100%;
         height: auto;
         margin: 24px 0;
-        border-radius: 8px;
-        border: 1px solid #ebebeb;
+        border-radius: 12px;
 
         @media (max-width: 320px) {
           margin: 16px 0;
-          border-radius: 4px;
         }
       }
 
-      // 인라인 코드
       code {
-        background-color: #f5f5f5;
+        background-color: var(--vapor-gray-100);
         padding: 2px 6px;
-        border-radius: 4px;
-        font-family: 'Courier New', Courier, monospace;
+        border-radius: 6px;
+        font-family: 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace;
         font-size: 14px;
-        color: #e53e3e;
+        color: var(--vapor-text-danger);
 
         @media (max-width: 320px) {
           font-size: 13px;
         }
       }
 
-      // 코드 블록
       pre {
-        background-color: #f5f5f5;
+        background-color: var(--vapor-gray-100);
         padding: 16px;
-        border-radius: 8px;
+        border-radius: 12px;
         overflow-x: auto;
         margin: 24px 0;
 
         @media (max-width: 320px) {
           padding: 12px;
           margin: 16px 0;
-          border-radius: 4px;
         }
 
         code {
           background-color: transparent;
           padding: 0;
-          color: var(--text-1);
+          color: var(--vapor-gray-900);
         }
       }
 
-      // 인용문
       blockquote {
         margin: 24px 0;
         padding: 16px 20px;
-        border-left: 4px solid #2c4cef;
-        background-color: #f5f7ff;
-        color: var(--text-1);
+        border-left: 4px solid var(--ktb-tech-blue);
+        background-color: var(--vapor-gray-050);
+        color: var(--vapor-gray-900);
+        border-radius: 0 8px 8px 0;
 
         @media (max-width: 320px) {
           margin: 16px 0;
@@ -542,19 +434,17 @@
         }
       }
 
-      // 링크
       a {
-        color: #2c4cef;
+        color: var(--ktb-tech-blue);
         text-decoration: none;
         transition: color 0.2s ease;
 
         &:hover {
-          color: #1e3bcf;
+          color: var(--ktb-tech-navy-hover);
           text-decoration: underline;
         }
       }
 
-      // 테이블
       table {
         width: 100%;
         border-collapse: collapse;
@@ -568,7 +458,7 @@
         th, td {
           padding: 12px;
           text-align: left;
-          border: 1px solid #e1e2e6;
+          border: 1px solid var(--vapor-gray-300);
 
           @media (max-width: 320px) {
             padding: 8px;
@@ -576,27 +466,25 @@
         }
 
         th {
-          background-color: #f5f5f5;
-          font-weight: 600;
-          color: var(--text-1);
+          background-color: var(--vapor-gray-100);
+          font-weight: 700;
+          color: var(--vapor-gray-900);
         }
 
         td {
-          color: var(--text-1);
+          color: var(--vapor-gray-900);
         }
 
         tr:hover {
-          background-color: #f9f9f9;
+          background-color: var(--vapor-gray-050);
         }
       }
 
-      // 강조
       strong, b {
         font-weight: 700;
-        color: var(--text-1);
+        color: var(--vapor-gray-900);
       }
 
-      // 기울임
       em, i {
         font-style: italic;
       }
@@ -606,16 +494,14 @@
       display: flex;
       justify-content: center;
       align-items: center;
-      min-height: 50px;
-      background: #f5f5f5;
-      border: 1px solid rgba(44, 76, 239, 0.1);
-      border-radius: 16px;
+      min-height: 120px;
+      background: var(--vapor-gray-050);
+      border-radius: 24px;
       padding: 40px 20px;
 
       @media (max-width: 320px) {
-        min-height: 160px;
         padding: 32px 16px;
-        border-radius: 12px;
+        border-radius: 16px;
       }
 
       .placeholder-message {
@@ -625,74 +511,24 @@
         p {
           margin: 0 0 8px 0;
           font-weight: 500;
-          font-size: 16px;
+          font-size: 15px;
           line-height: 1.5;
-          letter-spacing: -0.02em;
-          color: var(--gray-2);
+          color: var(--vapor-gray-600);
 
           @media (max-width: 320px) {
-            font-size: 15px;
+            font-size: 14px;
           }
 
           &:first-child {
-            font-weight: 600;
-            color: var(--text-1);
-            margin-bottom: 12px;
+            font-weight: 700;
+            font-size: 16px;
+            color: var(--vapor-gray-900);
+            margin-bottom: 8px;
           }
 
           &:last-child {
             margin-bottom: 0;
           }
-        }
-      }
-
-      h1, h2, h3, h4 {
-        color: var(--text-1);
-        margin: 32px 0 16px 0;
-        letter-spacing: -0.02em;
-
-        &:first-child {
-          margin-top: 0;
-        }
-      }
-
-      h1 {
-        font-weight: 600;
-        font-size: 32px;
-        line-height: 1.3;
-
-        @media (max-width: 320px) {
-          font-size: 26px;
-        }
-      }
-
-      h2 {
-        font-weight: 600;
-        font-size: 28px;
-        line-height: 1.3;
-
-        @media (max-width: 320px) {
-          font-size: 22px;
-        }
-      }
-
-      h3 {
-        font-weight: 600;
-        font-size: 24px;
-        line-height: 1.3;
-
-        @media (max-width: 320px) {
-          font-size: 20px;
-        }
-      }
-
-      h4 {
-        font-weight: 700;
-        font-size: 18px;
-        line-height: 1.4;
-
-        @media (max-width: 320px) {
-          font-size: 16px;
         }
       }
     }

--- a/styles/MyEvent.module.scss
+++ b/styles/MyEvent.module.scss
@@ -7,6 +7,7 @@
 
   &__list {
     max-width: 1080px;
+    min-height: 50vh;
     margin: 0 auto;
 
     @media (max-width: 1200px) {
@@ -31,6 +32,7 @@
 
 .list {
   @extend %grid-responsive;
+  margin-top: 24px;
 
   &:last-child {
     margin-bottom: 44px;
@@ -40,12 +42,70 @@
     }
   }
 
-  @media (max-width: 1200px) {
-    margin-top: 24px;
-  }
-
   @media (max-width: 599px) {
     margin-top: 20px;
+  }
+}
+
+.tabs {
+  display: flex;
+  align-items: stretch;
+  max-width: 1080px;
+  margin: 0 auto;
+  padding-top: 8px;
+  border-bottom: 1px solid var(--vapor-gray-200);
+
+  @media (max-width: 1200px) {
+    max-width: calc(100% - #{$tablet-padding * 2});
+    padding-left: $tablet-padding;
+    padding-right: $tablet-padding;
+  }
+
+  @include tablet {
+    max-width: 100%;
+    padding-left: $mobile-padding;
+    padding-right: $mobile-padding;
+  }
+}
+
+.tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 12px 16px;
+  margin-bottom: -1px;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  font-size: 1rem;
+  font-weight: 500;
+  color: var(--vapor-gray-600);
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease;
+
+  &:first-child {
+    padding-left: 0;
+  }
+
+  &:hover:not(.tab--active) {
+    color: var(--vapor-gray-800);
+  }
+
+  &__count {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--vapor-gray-500);
+  }
+
+  &--active {
+    color: var(--vapor-gray-900);
+    font-weight: 700;
+    border-bottom-color: var(--ktb-tech-blue);
+
+    .tab__count {
+      color: var(--ktb-tech-blue);
+      font-weight: 700;
+    }
   }
 }
 

--- a/styles/Myinfo.module.scss
+++ b/styles/Myinfo.module.scss
@@ -11,491 +11,293 @@
   font-weight: 400;
   font-size: 1.5rem;
   line-height: 1.8rem;
-  color: #a8a8a8;
-}
+  color: var(--vapor-gray-500);
+  word-break: keep-all;
 
-.info-container {
-  display: flex;
-  flex-direction: column;
-  //align-items: center; // 내정보 요소를 가운데 정렬
-  background-color: #fff;
-  //max-width: 100%;
-  width: 100%;
-  height: 720px;
-
-  &__inner {
-    display: flex;
-    flex-direction: column;
-    align-items: center; // 내정보 요소를 가운데 정렬
-    padding: 0 10px;
-    // max-width: 100%;
-    width: 100%;
-
-    .sub-header {
-      width: 1104px;
-      padding-top: 85px;
-      justify-content: left;
-      align-items: center; // 내정보 요소를 가운데 정렬
-
-      &__content {
-        margin-top: 54px;
-        justify-content: space-between;
-        align-items: flex-start;
-        float: left;
-
-        // 내 정보 h1 최상단
-        .notice-title {
-          float: left; // h1의 우측으로 이동
-          margin-bottom: 16px;
-          font-weight: 700;
-          font-size: 24px;
-          line-height: 5.5px;
-          color: #313234;
-        }
-
-        // 내 정보 하단 선
-        .underline {
-          width: 1104px;
-          height: 1px;
-          background: #d3d4d8;
-          gap: 8px;
-          transform: matrix(1, 0, 0, -1, 0, 0);
-          float: left;
-        }
-
-        .notice-alert {
-          // box - 형태
-          background-color: #fbfaf1;
-          border-radius: 4px;
-          // 추후 업데이트 예정 알림 박스의 감싼 요소 배경
-          width: 290px;
-          height: 40px;
-          float: left;
-          margin-left: 8px;
-          margin-bottom: 16px;
-          // 자식 요소의 가운데 정렬
-          display: flex;
-          align-items: center;
-          justify-content: center;
-
-          &__box {
-            // box - 위치
-            float: left;
-            margin-right: 6px;
-            padding: 5px 6px 5px 6px;
-            gap: 8px;
-            // box - 형태
-            border-radius: 4px;
-            width: 53px;
-            height: 24px;
-            // box 안의 글자
-            background-color: #f7f3cd;
-            color: #80732d;
-            font-weight: 600;
-            // box 글자 정렬
-            display: flex;
-            align-items: center;
-            justify-content: center;
-          }
-
-          &__txt {
-            // 위치 지정
-            float: left;
-            display: flex;
-            // 글자 형태
-            font-weight: 500;
-            color: #848273;
-          }
-        }
-      } // content
-    }
-
-    .info-form {
-      align-items: center;
-      padding-top: 36px;
-      padding-bottom: 48px;
-      width: 600px;
-      margin-bottom: 24px;
-      border-bottom: 1px solid #e9e9e9;
-
-      &__profile_image_box {
-        display: flex;
-        justify-content: center;
-        .profile {
-          border: 1px solid #f2f2f2 !important; // todo checkme: !important 사용 안하는 방법
-          border-radius: 100px;
-        }
-      }
-
-      &__profile_txt_box {
-        width: 600px;
-        font-weight: 600;
-        display: flex;
-        padding-top: 8px;
-        justify-content: center; /* 수평 가운데 정렬 */
-        align-items: center; /* 수직 가운데 정렬 */
-        font-size: 20px;
-        color: #313234;
-      }
-
-      &__auth_box {
-        margin-top: 24px;
-        margin-bottom: 16px;
-
-        .email_box {
-          display: flex;
-          align-items: center;
-          justify-content: center;
-
-          width: 600px;
-          height: 72px;
-          padding: 18px 16px 18px 16px;
-          background: #f8f8f8;
-          border-radius: 8px;
-
-          .txt {
-            color: #abacb2;
-            font-size: 16px;
-          }
-          .value {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            color: #747579;
-            font-size: 14px;
-            margin-left: auto;
-            gap: 10px;
-          }
-
-          .value__box {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-
-            width: 24px;
-            height: 24px;
-            padding: 1px;
-            border-radius: 4px;
-            border: 1px solid var(--light-Gray5, #e7e8ec);
-            background: #fff;
-          }
-        }
-      }
-
-      &__register_date {
-        display: flex;
-        align-items: center;
-        justify-content: left;
-        width: 253px;
-        font-size: 14px;
-        color: #abacb2;
-      }
-
-      &__register-info-button {
-        padding: 7px 8px 7px 9px;
-        gap: 8px;
-        width: 80px;
-        height: 28px;
-        border-radius: 32px;
-        margin-left: 6px;
-        background-color: #efffe5;
-        font-weight: 600;
-        font-size: 14px;
-        line-height: 100%;
-        letter-spacing: -0.02em;
-        color: #49a972;
-      }
-
-      &__withdraw_box {
-        width: 600px;
-        float: left;
-      }
-    }
-  }
-}
-
-@include tablet {
-  .info-container {
-    min-width: 29.5rem; // 전체 가로 폭
-    //padding: 0 $tablet_padding;
-
-    &__inner {
-      display: flex;
-      flex-direction: column;
-      padding: 0 10px;
-
-      .sub-header {
-        width: 100%;
-        padding: 85px $tablet_padding 0;
-
-        &__content {
-          width: 100%;
-          margin-top: 54px;
-
-          // 내 정보 h1 최상단
-          .notice-title {
-            float: left; // h1의 우측으로 이동
-            margin-bottom: 16px;
-            font-weight: 700;
-            font-size: 18px;
-            line-height: 5.5px;
-          }
-
-          // 내 정보 하단 선
-          .underline {
-            width: 100%;
-            height: 1px;
-            background: #d3d4d8;
-            gap: 8px;
-            transform: matrix(1, 0, 0, -1, 0, 0);
-            float: left;
-          }
-
-          .notice-alert {
-            // box - 형태
-            background-color: #fbfaf1;
-            border-radius: 4px;
-            // 추후 업데이트 예정 알림 박스의 감싼 요소 배경
-            width: 255px;
-            height: 30px;
-            float: left;
-            padding-right: 8px;
-            padding-top: 6px;
-            padding-bottom: 6px;
-
-            &__box {
-              // box - 위치
-              margin-right: 6px;
-              padding: 3px 4px;
-              gap: 8px;
-              // box - 형태
-              border-radius: 4px;
-              width: 44px;
-              height: 18px;
-              // box 안의 글자
-              font-size: 12px;
-              font-weight: 600;
-            }
-
-            &__txt {
-              font-size: 12px;
-            }
-          }
-        }
-      }
-
-      .info-form {
-        padding-top: 20px;
-        padding-bottom: 48px;
-        width: 472px;
-
-        margin-bottom: 24px;
-
-        &__profile_image_box {
-          .profile {
-            border: 1px solid #f2f2f2 !important; // todo checkme: !important 사용 안하는 방법
-            border-radius: 100px;
-          }
-        }
-
-        // 이미지 아래 사람 이름
-        &__profile_txt_box {
-          width: 472px;
-          font-weight: 600;
-          padding-top: 6px;
-          font-size: 20px;
-          color: #313234;
-        }
-
-        &__auth_box {
-          margin-top: 18px;
-          margin-bottom: 16px;
-
-          .email_box {
-            width: 472px;
-            height: 56px;
-
-            padding: 18px 16px;
-            background: #f8f8f8;
-            border-radius: 8px;
-
-            .txt {
-              font-size: 16px;
-            }
-
-            .value {
-              font-size: 14px;
-              gap: 10px;
-            }
-          }
-        }
-
-        &__register_date {
-          width: 253px;
-          font-size: 14px;
-          color: #abacb2;
-        }
-
-        &__register-info-button {
-          padding: 7px 8px 7px 9px;
-          gap: 8px;
-          width: 80px;
-          height: 28px;
-          border-radius: 32px;
-          margin-left: 6px;
-          background-color: #efffe5;
-          font-weight: 600;
-          font-size: 14px;
-          letter-spacing: -0.02em;
-        }
-
-        &__withdraw_box {
-          width: 472px;
-          float: left;
-        }
-      }
-    }
-  }
-}
-
-@include mobile {
-  .info-container {
-    &__inner {
-      padding: 0 $mobile_padding;
-
-      .sub-header {
-        width: 100%;
-        padding-top: 85px;
-
-        &__content {
-          width: 100%;
-
-          // 내 정보 h1 최상단
-          .notice-title {
-            width: 80%;
-            margin-bottom: 18px;
-            font-size: 18px;
-            font-weight: 700;
-            line-height: 5.5px;
-          }
-
-          // 내 정보 하단 선
-          .underline {
-            width: 100%;
-            height: 1px;
-            background: #d3d4d8;
-            gap: 8px;
-            transform: matrix(1, 0, 0, -1, 0, 0);
-            float: left;
-          }
-
-          .notice-alert {
-            border-radius: 4px;
-            // 추후 업데이트 예정 알림 박스의 감싼 요소 배경
-            width: 255px;
-            height: 30px;
-            float: left;
-            margin-left: 0;
-            padding-right: 8px;
-            padding-top: 6px;
-            padding-bottom: 6px;
-
-            &__box {
-              // box - 위치
-              margin-right: 6px;
-              padding: 3px 4px;
-              gap: 8px;
-              // box - 형태
-              border-radius: 4px;
-              width: 44px;
-              height: 18px;
-              // box 안의 글자
-              font-size: 12px;
-              font-weight: 600;
-            }
-
-            &__txt {
-              font-size: 12px;
-            }
-          }
-        }
-      }
-
-      .info-form {
-        padding-top: 20px;
-        padding-bottom: 48px;
-        //width: 360px;
-        width: 100%;
-        margin-bottom: 24px;
-
-        // 이미지 아래 사람 이름
-        &__profile_txt_box {
-          width: 100%;
-          text-align: center;
-          font-weight: 600;
-          padding-top: 6px;
-          font-size: 16px;
-          color: #313234;
-        }
-
-        &__auth_box {
-          margin-top: 18px;
-          margin-bottom: 16px;
-
-          .email_box {
-            width: 100%;
-            height: 56px;
-
-            padding: 18px 16px;
-            background: #f8f8f8;
-            border-radius: 8px;
-
-            .txt {
-              font-size: 16px;
-            }
-
-            .value {
-              font-size: 14px;
-              gap: 10px;
-            }
-          }
-        }
-
-        &__register_date {
-          width: 253px;
-          font-size: 14px;
-        }
-
-        &__register-info-button {
-          padding: 7px 8px 7px 9px;
-          gap: 8px;
-          width: 80px;
-          height: 28px;
-          border-radius: 32px;
-          margin-left: 6px;
-          font-weight: 600;
-          font-size: 14px;
-          letter-spacing: -0.02em;
-        }
-
-        &__withdraw_box {
-          width: 100%;
-          float: left;
-        }
-      }
-    }
-  }
-
-  .null-container {
-    height: 100vh;
-    width: 100%;
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: center;
-    font-weight: 400;
+  @include mobile {
     font-size: 1rem;
     line-height: 1.2rem;
-    color: #a8a8a8;
+  }
+}
+
+.container {
+  width: 100%;
+  background-color: var(--vapor-gray-000);
+  padding-bottom: 80px;
+}
+
+.inner {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 $laptop-padding;
+  word-break: keep-all;
+
+  @media (max-width: 1200px) {
+    max-width: 100%;
+    padding: 0 $tablet-padding;
+  }
+
+  @include tablet {
+    padding: 0 $mobile-padding * 2;
+  }
+
+  @include mobile {
+    padding: 0 $mobile-padding;
+  }
+}
+
+// 페이지 헤더
+.sub-header {
+  padding: 136px 0 24px;
+
+  h1 {
+    margin: 0;
+    padding-bottom: 16px;
+    border-bottom: 1px solid var(--vapor-gray-200);
+    font-size: 24px;
+    font-weight: 700;
+    line-height: 120%;
+    letter-spacing: -0.012rem;
+    color: var(--vapor-gray-900);
+  }
+
+  @include tablet {
+    padding-top: 136px;
+
+    h1 {
+      font-size: 22px;
+    }
+  }
+
+  @include mobile {
+    padding-top: 120px;
+
+    h1 {
+      font-size: 20px;
+    }
+  }
+}
+
+// 프로필 카드
+.profile-card {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  margin-top: 32px;
+  padding: 32px;
+  background-color: var(--vapor-gray-050);
+  border-radius: 24px;
+
+  &__avatar {
+    flex-shrink: 0;
+    width: 96px;
+    height: 96px;
+    border-radius: 24px;
+    overflow: hidden;
+    background-color: var(--vapor-gray-100);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+
+    &--placeholder {
+      background-color: var(--vapor-gray-100);
+      color: var(--vapor-gray-400);
+
+      svg {
+        width: 56%;
+        height: 56%;
+      }
+    }
+  }
+
+  &__meta {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-width: 0;
+  }
+
+  &__name {
+    font-size: 22px;
+    font-weight: 700;
+    line-height: 1.3;
+    letter-spacing: -0.012rem;
+    color: var(--vapor-gray-900);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__since {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
+  &__since-date {
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--vapor-gray-600);
+  }
+
+  &__since-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 10px;
+    border-radius: 9999px;
+    background-color: var(--vapor-gray-000);
+    border: 1px solid var(--vapor-gray-200);
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--ktb-tech-blue);
+  }
+
+  @include mobile {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+    padding: 24px;
+
+    &__avatar {
+      width: 80px;
+      height: 80px;
+      border-radius: 20px;
+    }
+
+    &__name {
+      font-size: 20px;
+    }
+  }
+}
+
+// 계정 정보 카드
+.info-card {
+  margin-top: 16px;
+  padding: 28px 32px;
+  background-color: var(--vapor-gray-050);
+  border-radius: 24px;
+
+  &__title {
+    margin: 0 0 16px;
+    font-size: 16px;
+    font-weight: 700;
+    line-height: 1.5;
+    letter-spacing: -0.012rem;
+    color: var(--vapor-gray-900);
+  }
+
+  @include mobile {
+    padding: 20px;
+  }
+}
+
+.info-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.info-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 16px;
+  background-color: var(--vapor-gray-000);
+  border-radius: 12px;
+  min-height: 56px;
+
+  &__label {
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--vapor-gray-600);
+    flex-shrink: 0;
+  }
+
+  &__value {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--vapor-gray-900);
+  }
+
+  &__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    padding: 2px;
+    border-radius: 6px;
+    background-color: var(--vapor-gray-000);
+    border: 1px solid var(--vapor-gray-200);
+    flex-shrink: 0;
+  }
+
+  &__text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+// 위험 영역 (탈퇴)
+.danger-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 24px;
+  padding: 24px 32px;
+  background-color: var(--vapor-gray-000);
+  border: 1px solid var(--vapor-gray-200);
+  border-radius: 24px;
+
+  &__text {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+  }
+
+  &__title {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 700;
+    line-height: 1.5;
+    letter-spacing: -0.012rem;
+    color: var(--vapor-gray-900);
+  }
+
+  &__desc {
+    margin: 0;
+    font-size: 13px;
+    font-weight: 400;
+    color: var(--vapor-gray-600);
+    line-height: 1.4;
+  }
+
+  @include mobile {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 16px;
+    padding: 20px;
+
+    button {
+      width: 100%;
+    }
   }
 }

--- a/styles/Theme.scss
+++ b/styles/Theme.scss
@@ -9,6 +9,32 @@ html[data-theme='light'] {
   --gray-3: #{$light-gray-3};
   --gray-4: #{$light-gray-4};
   --gray-5: #{$light-gray-5};
+
+  // KTB brand
+  --ktb-tech-blue: #{$ktb-tech-blue};
+  --ktb-tech-navy: #{$ktb-tech-navy};
+  --ktb-tech-navy-hover: #{$ktb-tech-navy-hover};
+  --ktb-tech-sky: #{$ktb-tech-sky};
+
+  // Vapor gray ramp (light theme: 000 = white → 950 = near-black)
+  --vapor-gray-000: #{$vapor-gray-000};
+  --vapor-gray-050: #{$vapor-gray-050};
+  --vapor-gray-100: #{$vapor-gray-100};
+  --vapor-gray-200: #{$vapor-gray-200};
+  --vapor-gray-300: #{$vapor-gray-300};
+  --vapor-gray-400: #{$vapor-gray-400};
+  --vapor-gray-500: #{$vapor-gray-500};
+  --vapor-gray-600: #{$vapor-gray-600};
+  --vapor-gray-700: #{$vapor-gray-700};
+  --vapor-gray-800: #{$vapor-gray-800};
+  --vapor-gray-900: #{$vapor-gray-900};
+  --vapor-gray-950: #{$vapor-gray-950};
+
+  // Semantic
+  --vapor-text-danger: #{$vapor-text-danger};
+  --vapor-text-success: #{$vapor-text-success};
+  --vapor-text-warning: #{$vapor-text-warning};
+  --vapor-text-primary: #{$vapor-text-primary};
 }
 
 html[data-theme='dark'] {
@@ -20,4 +46,30 @@ html[data-theme='dark'] {
   --gray-3: #{$dark-gray-3};
   --gray-4: #{$dark-gray-4};
   --gray-5: #{$dark-gray-5};
+
+  // KTB brand (same hex in dark — saturated blue still reads on dark)
+  --ktb-tech-blue: #{$ktb-tech-blue};
+  --ktb-tech-navy: #{$ktb-tech-navy};
+  --ktb-tech-navy-hover: #{$ktb-tech-navy-hover};
+  --ktb-tech-sky: #{$ktb-tech-sky};
+
+  // Vapor gray ramp (dark theme: 000 = near-black bg → 950 = white text)
+  --vapor-gray-000: #{$vapor-gray-950};
+  --vapor-gray-050: #{$vapor-gray-900};
+  --vapor-gray-100: #{$vapor-gray-800};
+  --vapor-gray-200: #{$vapor-gray-800};
+  --vapor-gray-300: #{$vapor-gray-700};
+  --vapor-gray-400: #{$vapor-gray-500};
+  --vapor-gray-500: #{$vapor-gray-400};
+  --vapor-gray-600: #{$vapor-gray-300};
+  --vapor-gray-700: #{$vapor-gray-200};
+  --vapor-gray-800: #{$vapor-gray-100};
+  --vapor-gray-900: #{$vapor-gray-050};
+  --vapor-gray-950: #{$vapor-gray-000};
+
+  // Semantic
+  --vapor-text-danger: #{$vapor-text-danger};
+  --vapor-text-success: #{$vapor-text-success};
+  --vapor-text-warning: #{$vapor-text-warning};
+  --vapor-text-primary: #{$vapor-text-primary};
 }

--- a/styles/_color.scss
+++ b/styles/_color.scss
@@ -21,3 +21,33 @@ $dark-gray-4: rgba(51, 52, 57, 1);
 
 $light-gray-5: rgba(231, 232, 236, 1);
 $dark-gray-5: rgba(34, 35, 38, 1);
+
+// ========================================
+// KTB / Vapor design tokens (DESIGN.md)
+// ========================================
+
+// KTB brand
+$ktb-tech-blue: #0043ff;
+$ktb-tech-navy: #000040;
+$ktb-tech-navy-hover: #0238D1;
+$ktb-tech-sky: #78CDFF;
+
+// Vapor gray ramp
+$vapor-gray-000: #ffffff;
+$vapor-gray-050: #F7F7FA;
+$vapor-gray-100: #F0F0F5;
+$vapor-gray-200: #E8E8EE;
+$vapor-gray-300: #E1E1E8;
+$vapor-gray-400: #CDCED6;
+$vapor-gray-500: #8C8F9F;
+$vapor-gray-600: #6C6E7E;
+$vapor-gray-700: #525463;
+$vapor-gray-800: #3E404C;
+$vapor-gray-900: #2B2D36;
+$vapor-gray-950: #252730;
+
+// Semantic
+$vapor-text-danger: #D91C29;
+$vapor-text-success: #08785E;
+$vapor-text-warning: #B45209;
+$vapor-text-primary: #1D6CE0;

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -2,6 +2,10 @@
 @import '~styles/_mixin.scss';
 @import '~styles/_variables.scss';
 
+html {
+  scrollbar-gutter: stable;
+}
+
 html,
 body {
   padding: 0;
@@ -10,7 +14,6 @@ body {
     Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue,
     sans-serif;
   font-size: 14px;
-  width: 100vw;
   min-width: 350px;
   overflow-x: hidden;
   background-color: var(--background-1);


### PR DESCRIPTION
## ✨ 요약

`DESIGN.md`에 정리된 KTB 기반 디자인 시스템에 맞춰 **카드 / 행사 상세 / 마이페이지 / 헤더·푸터·배너 / 필터**를 전반적으로 리뉴얼했습니다. 동시에 **`/events`에 캘린더 뷰**를 신규 추가해 한 달치 행사를 격자(데스크탑) 또는 점 캘린더(모바일)로 확인할 수 있게 했습니다. 그 외 공유 버튼/로그인 모달의 자잘한 버그를 수정했고, 향후 작업을 위한 **Jest 단위 테스트 인프라**와 **에이전트용 문서(`CLAUDE.md`, `docs/superpowers/`)**를 함께 추가했습니다.

## 🧭 변경 사항 (영역별)

### 1. 디자인 리뉴얼
- **이벤트 카드 / 리스트** 신규 디자인 (`components/common/item`, `styles/Home.module.scss`)
- **행사 상세 페이지** 리디자인 — 4-column hero, status badge, 메타 정보 재배치 (`pages/event/detail/[eventId].tsx`, `styles/EventDetail.module.scss`)
- **필터 / Job 태그** UI 정리 — pill chip 컨벤션 통일, hover/active/selected 상태 추가, focus ring (`components/features/filters/*`, `components/common/tag/JobGroupTag.module.scss`)
- **마이페이지 / 북마크 / 메뉴** 갱신 (`pages/myinfo.tsx`, `components/myEvent/*`, `styles/MyEvent.module.scss`, `styles/Myinfo.module.scss`)
- **헤더 / 푸터 / 배너** 톤 정돈 (`components/layout/header/*`)

### 2. 신규 기능 — `/events` 캘린더 뷰
- `/events?view=calendar&year=YYYY&month=M`에서 한 달 그리드 표시 (SSR 기반)
- 리스트 ↔ 캘린더 토글 (`ViewToggle`) — 리스트 모드는 `EventFilter` 칩 줄에, 캘린더 모드는 `CalendarHeader`에 배치
- 모바일(≤720px)은 점(dot) 캘린더 + 선택일 상세 시트로 자동 전환
- 셀 클릭 → 그 날의 이벤트 리스트 모달/시트 → 카드 클릭으로 상세 이동
- 다중일 이벤트 처리, `RECRUIT` 타입 / 날짜 미정 이벤트 자동 제외, "+N 더보기" 오버플로우
- 기존 `/calender` 라우트는 `/events?view=calendar&...`로 **307 리디렉트** (북마크/SEO 호환)
- 데이터: 기존 `/front/v2/events/{year}/{month}` API 재사용 — 신규 엔드포인트 없음

### 3. 버그 수정
- 공유하기 클릭 시 콘솔에 출력되던 불필요한 에러 로그 제거 (`3ca0d505`)
- 로그인 버튼 클릭 시 발생하던 에러 메시지 처리 (`8ebb549b`)

### 4. 인프라 / 문서
- **Jest + ts-jest** 단위 테스트 셋업 추가 (`jest.config.js`, `jest.setup.ts`, `__mocks__/styleMock.js`) — 캘린더 utils 3개(`buildCalendarMatrix`, `layoutMultiDayEvents`, `tagColor`)에 단위 테스트 18건
- **`CLAUDE.md`** 추가 — 향후 Claude Code 인스턴스용 프로젝트 가이드 (아키텍처, 컨벤션, 함정 노트)
- **`docs/superpowers/specs/`, `docs/superpowers/plans/`** — 카드/상세/필터/헤더 리뉴얼 + 캘린더 뷰의 디자인 스펙·구현 플랜
- `.gitignore`에 `.claude/` 통합 (로컬 에이전트 상태 제외)

## 🧪 테스트

```bash
pnpm test       # ✅ 18/18 통과 (calendar utils)
pnpm build      # ✅ 성공 (/events 7.49kB, /calender 250B redirect)
npx tsc --noEmit  # ✅ 클린
```

## ✅ QA 체크리스트

### 데스크탑 (1280px)
- [ ] `/events` 진입 시 카드 리스트 정상
- [ ] 우측 토글로 캘린더 ↔ 리스트 전환 (URL `?view=calendar&year=&month=` 갱신)
- [ ] 캘린더: 일요일 빨강 / 토요일 파랑 / 오늘 파란 원 / outside 셀 회색
- [ ] ‹ › 월 네비 + "오늘" 버튼 동작
- [ ] 셀 클릭 → DayDetailSheet → 카드 클릭 → `/event/detail/{id}` 이동
- [ ] 다중일 이벤트가 시작 셀에 1개 칩 + 같은 날 중첩 시 "+N 더보기"로 표시 (합산 일관)

### 모바일 (DevTools 375px)
- [ ] 점 캘린더 자동 전환
- [ ] 셀 탭 → 하단 시트 슬라이드 인
- [ ] 선택 셀 outline + 점 색 매핑 확인
- [ ] 캘린더 컨테이너와 Letter 사이 적당한 여백

### 리디자인 영역
- [ ] 카드 리스트 hover / 즐겨찾기 / 공유 동작
- [ ] 행사 상세 페이지 hero / 메타 / 본문 / 외부 링크
- [ ] 마이페이지(예정/완료 탭) 정상
- [ ] 헤더 / 푸터 / 배너 일관성

### 리디렉트
- [ ] `/calender?year=2026&month=5` → `/events?view=calendar&year=2026&month=5`
- [ ] `/calender` (쿼리 없음) → 현재 년/월 폴백

## ⚠️ 알려진 제약

- **다중일 이벤트의 "연속 막대" 시각화 미구현** — 칩이 `.grid__cell`(flex 컨테이너) 안에 있어 `gridColumn: span N`이 무효. 따라서 멀티데이 이벤트는 **시작 셀에만 칩 1개**가 표시되고, 이어지는 날짜는 셀의 "+N 더보기" 카운트와 셀 클릭 시 시트에서 확인 가능합니다. 후속 PR에서 absolute overlay 방식으로 해결 예정 (`docs/superpowers/plans/2026-05-12-events-calendar-view.md > 알려진 제약` 참고).
- **`pnpm lint` 첫 실행 시 ESLint 셋업 프롬프트**가 뜨는 상태 — 별도 PR에서 자동화 결정 필요.

## 🚫 비목표 (이번 PR에선 안 함)

- 주(week)/일(day) 캘린더 뷰
- 드래그앤드롭, 인라인 편집
- iCal 내보내기
- 즐겨찾기 이벤트만 필터링하는 캘린더 모드
- 캘린더 키보드 네비게이션 (←↑→↓, Enter, Esc)

## 📚 참고 문서

- `DESIGN.md` — KTB 기반 디자인 토큰 (Pretendard, KTB Tech Blue `#0043FF`, Vapor 스케일)
- `CLAUDE.md` — 프로젝트 아키텍처 & 컨벤션 가이드 (신규)
- 디자인 스펙: `docs/superpowers/specs/2026-05-1*.md`
- 구현 플랜: `docs/superpowers/plans/2026-05-1*.md`

## 🗂️ 커밋 히스토리

| Commit | 설명 |
|---|---|
| `c6e10949` | 카드 디자인 신규화 |
| `c01b6f91` | 행사 상세 페이지 리디자인 |
| `3ca0d505` | 공유하기 오류 로그 수정 |
| `8ebb549b` | 로그인 버튼 오류 메시지 해결 |
| `a28879ed` | 디자인 최신화(마이페이지, 북마크, 메뉴) |
| `dce8cde4` | job 태그 갱신 |
| `15f25d26` | 마이페이지 디자인 갱신 |
| `f9403f48` | 캘린더 디자인 추가 |
| `c79c746f` | `.claude/` ignore 추가 |
| `303f7310` | 슈퍼파워즈 스팩 문서 추가 |
| `13268906` | CLAUDE.md 추가 |
