### PR TITLE
`[release/2.5.0]` 북마크 모바일 정렬 수정 | Vercel Analytics 도입 | README 갱신 | 캘린더 내보내기 · 다크 모드 · SNS 배너 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,6 @@ fabric.properties
 
 # End of https://www.toptal.com/developers/gitignore/api/intellij
 .superpowers/
+
+# Local Claude MCP config (contains tokens — do not commit)
+.mcp.json

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -84,6 +84,82 @@ The overall aesthetic is **flat-but-confident**: 그림자 거의 없음, 미디
 - `--background-normal` = `#ffffff` — primary surface
 - `--background-alternative` = `#F7F7FA` — section banding, common-card surface
 
+### Dark Mode Palette — Wanted Design System
+
+다크 모드는 라이트의 Vapor 스케일을 **역순 매핑하지 않는다**. 대신 Wanted Design System의 다크 시맨틱 토큰 (Figma `qQPdpnglONbuWul4cvodyj` → node `15625:32983` → Color/Semantic/Dark)을 직접 채용한다. 역순 매핑이 만들던 함정(예: `--vapor-gray-950` 이 다크에선 흰색으로 뒤집혀 카드 active 상태가 흰색 박스가 되던 버그)을 제거하기 위함.
+
+#### Background — page + elevated surfaces
+
+| Wanted 토큰 | hex | 우리 매핑 | Use |
+|---|---|---|---|
+| `background-normal-normal` | `#1B1C1E` | `--vapor-gray-000`, `--background-1` | 페이지 베이스 캔버스 |
+| `background-normal-alternative` | `#0F0F10` | (예약) | 가장 깊은 알트 (필요 시) |
+| `background-elevated-normal` | `#212225` | `--vapor-gray-050`, `--background-2`, `--toggle-track-bg` | 카드, 모달, alt 표면 |
+| `background-elevated-alternative` | `#141415` | (예약) | 깊은 alt elevated |
+
+#### Line — borders + dividers
+
+| Wanted 토큰 | hex | 우리 매핑 | Use |
+|---|---|---|---|
+| `line-solid-normal` | `#37383C` | `--vapor-gray-300`, `--gray-4`, `--toggle-active-bg` | 표준 1px 보더, 토글 active 표면 |
+| `line-solid-neutral` | `#333438` | `--vapor-gray-200` | subtle 구분선 |
+| `line-solid-alternative` | `#2E2F33` | `--vapor-gray-100`, `--gray-5` | placeholder bg, search field bg |
+
+#### Interaction
+
+| Wanted 토큰 | hex | 우리 매핑 |
+|---|---|---|
+| `interaction-inactive` | `#5A5C63` | `--vapor-gray-400`, `--gray-3` |
+| `interaction-disable` | `#2E2F33` | (line-solid-alt와 동일) |
+
+#### Label — text scale
+
+| Wanted 토큰 | hex | 우리 매핑 | Use |
+|---|---|---|---|
+| `label-strong` | `#FFFFFF` | `--vapor-gray-900`, `--vapor-gray-950`, `--gray-1` | body, heading, 최강 강조 |
+| `label-normal` | `#F7F7F8` | `--vapor-gray-800` | secondary 텍스트 |
+| `label-neutral` | `#C2C4C8` | `--vapor-gray-700` | 대체 표면 위의 보조 텍스트 |
+| `label-alternative` | `#AEB0B6` | `--vapor-gray-600`, `--gray-2` | hint, meta |
+| `label-disable` | `#989BA2` | `--vapor-gray-500` | placeholder, icon default |
+
+#### Primary — brand blue (dark variant)
+
+다크에서는 KTB Tech Blue (`#0043FF`)가 어두운 배경 위에서 가독성이 떨어져 Wanted primary scale로 한 단계 밝힌다.
+
+| Wanted 토큰 | hex | 우리 매핑 |
+|---|---|---|
+| `primary-normal` | `#3385FF` | `--ktb-tech-blue` (dark only), `--primary`, `--vapor-text-primary` |
+| `primary-strong` | `#1A75FF` | `--ktb-tech-navy-hover` (dark only) |
+| `primary-heavy` | `#0066FF` | (예약) |
+
+라이트는 `#0043FF`를 그대로 유지. 브랜드 색은 유지하되 다크에서만 한 단계 밝힌 변종을 쓰는 패턴.
+
+#### Status — saturated for dark legibility
+
+| Wanted 토큰 | hex | 우리 매핑 |
+|---|---|---|
+| `status-positive` | `#1ED45A` | `--vapor-text-success` (dark) |
+| `status-cautionary` | `#FFA938` | `--vapor-text-warning` (dark) |
+| `status-negative` | `#FF6363` | `--vapor-text-danger` (dark) |
+
+#### Translucent — sticky header + glass overlays
+
+다크 전용 반투명 토큰 (light에선 별도 white 알파 값 사용):
+
+| 토큰 | dark 값 | Use |
+|---|---|---|
+| `--header-bg` | `rgba(27, 28, 30, 0.86)` | sticky 헤더 |
+| `--glass-overlay` | `rgba(33, 34, 37, 0.72)` | 모바일 카드 아이콘 글래스 |
+| `--glass-overlay-strong` | `rgba(33, 34, 37, 0.94)` | 글래스 hover |
+| `--notice-bg` | `rgba(51, 133, 255, 0.12)` | 상단 공지 배너 틴트 |
+
+### Dark Mode Iteration Notes
+- 다크 모드 토큰은 `styles/_color.scss`의 `$wanted-dark-*` 변수에 한 곳에 모아두고, `styles/Theme.scss`의 `html[data-theme='dark']` 블록에서 시맨틱 토큰에 매핑한다.
+- 새 컴포넌트가 다크 변종이 필요하면 **반드시 시맨틱 토큰**(`var(--vapor-gray-*)`, `var(--ktb-tech-blue)` 등)을 통해 접근. 하드코딩한 흰색(`#fff`, `rgba(255,255,255,...)`)이 다크에 떨어지면 시각적 부조화 발생.
+- 예외 1 (어두운 brand surface 위 텍스트): light/dark 무관하게 항상 어두운 SNS 배너의 흰 pill 같은 surface는 그 위 텍스트도 하드코딩된 다크 값(`#2B2D36`)을 써야 함. 토큰 inversion이 텍스트를 흰색으로 뒤집어 invisible 화하는 사고 방지.
+- 예외 2 (KTB Blue surface 위 텍스트): KTB Tech Blue 배경(`--ktb-tech-blue` / `--primary`) 위 텍스트는 **반드시 하드코딩된 `#ffffff`** 를 쓴다. `var(--vapor-gray-000)` 이나 `var(--background-1)` 을 쓰면 다크에서 페이지 bg(`#1B1C1E`)로 뒤집혀 검정 글씨가 파란 버튼 위에 나타나는 사고가 발생. 이 패턴이 적용된 곳: `FillButton.color--primary`, `EmailSubscribeButton`.
+- 예외 3 (인라인 동적 색상): 캘린더 chip(`CalendarGrid.tsx`)처럼 인라인 `style={{ color: tagHex, background: rgba(tagHex, 0.08) }}` 으로 카테고리 색을 칠하는 케이스는 라이트 bg 가정으로 튜닝됨. 다크에선 dark-on-dark 가독성 붕괴 → SCSS 모듈에서 `:global(html[data-theme='dark']) &` 셀렉터로 `color`/`background`를 `!important` override하여 대비를 회복하고, 카테고리 색은 `border-left` 만 유지하여 시각적 큐로 남긴다.
+
 ## 3. Typography Rules
 
 ### Font Family

--- a/README.md
+++ b/README.md
@@ -1,43 +1,117 @@
 # Dev Event Web
-> 🎉🎈 개발자 {웨비나, 컨퍼런스, 해커톤} 행사를 웹으로 알려드립니다.<br />
 
-👉 <strong>웹 바로가기</strong> : [https://dev-event.vercel.app/events](https://dev-event.vercel.app/events)
+> 🎉 개발자 행사(웨비나·컨퍼런스·해커톤·네트워킹)를 큐레이션해서 한 곳에 모아 보여주는 웹사이트 입니다.
+
+👉 **웹 바로가기**: [https://dev-event.vercel.app/events](https://dev-event.vercel.app/events)
+
+<br />
+
+## 주요 기능
+
+- **행사 리스트 / 캘린더 듀얼 뷰** — `/events`에서 카드 리스트와 월간 캘린더 그리드를 토글. 모바일은 점(dot) 캘린더로 자동 전환.
+- **다중 필터** — 직군·행사 유형·지역·비용·검색어·기간을 조합. 필터 상태는 `EventContext`로 리스트/캘린더 뷰 간 공유.
+- **북마크(내 행사)** — 로그인 사용자가 관심 행사를 저장하고 진행중/종료 탭으로 추적.
+- **행사 상세 페이지** — 외부 API의 마크다운 본문을 `marked`로 렌더링.
+- **SSR 우선** — 모든 페이지가 `getServerSideProps` 기반, SWR로 클라이언트 hydrate 후 revalidate.
+
+<br />
+
+## 기술 스택
+
+- **Framework**: Next.js 12 (Pages Router) · React 17 · TypeScript 4.6
+- **Styling**: SCSS Modules · Pretendard · KTB Tech Blue 디자인 토큰 (`DESIGN.md` 참고)
+- **State**: React Context (Auth · Event · Window · Toast)
+- **Data**: SWR + axios, 외부 API (`${BASE_SERVER_URL}/front/v2/...`)
+- **Test**: Jest 29 + ts-jest + jsdom
+- **Analytics**: Vercel Analytics
+- **Deploy**: Vercel
 
 <br />
 
 ## 개발 환경
-- node 20.15.1
-- npm 6.14.15
-- react 17.0.2
-- next 12.1.2
+
+- Node.js **20.15.1** (`.nvmrc` 고정)
+- pnpm **8+**
 
 <br />
 
-## 사용 방법
-### 코드 포맷팅
-```sh
-command + alt + shift + p
-```
+## 시작하기
 
-### 라이브러리 설치
 ```sh
+# 의존성 설치
 $ pnpm install
+
+# 개발 서버 (http://localhost:5000, 3000 아님)
+$ pnpm dev
+
+# 빌드 / 프로덕션 서빙
+$ pnpm build
+$ pnpm start
+
+# 린트
+$ pnpm lint
+
+# 테스트
+$ pnpm test
+$ pnpm test:watch
+$ pnpm test -- buildCalendarMatrix    # 단일 파일
+
+# 타입 체크만
+$ npx tsc --noEmit
 ```
 
-### developer 환경으로 실행
-```sh
-$ pnpm run dev
+<br />
+
+## 디렉터리 구조
+
+```
+pages/              # Next.js Pages Router 진입점 (SSR)
+  api/              # auth/세션용 얇은 헬퍼 (데이터 레이어 아님)
+components/
+  events/calendar/  # 캘린더 그리드·점 캘린더·뷰 토글 + 순수 로직 + 유닛 테스트
+  myEvent/          # 북마크 탭·리스트
+  common/item/      # 행사 카드
+  layout/           # 공통 레이아웃 래퍼
+context/            # AuthProvider · EventProvider · WindowProvider · ToastProvider
+lib/
+  api/              # axios 인스턴스 (인증/비인증)
+  hooks/useSWR.tsx  # 데이터 페치 훅 (fallbackData 패턴)
+  utils/            # 날짜·gTag 등 헬퍼
+model/event.ts      # 도메인 타입
+styles/             # 글로벌 SCSS·변수·믹스인·CSS Module
+docs/superpowers/   # 최근 작업의 디자인 스펙·구현 플랜
 ```
 
-## 배포 
-```sh
-# 로컬 빌드 테스트 
-$ pnpm run build 
+<br />
 
-# 배포
+## 컨벤션
+
+- `tsconfig.json`의 `baseUrl: './'`로 절대 경로 import (`import { Event } from 'model/event'`).
+- SCSS Module 공유 import는 `@import '~styles/_variables.scss'` 형식(틸드 + 확장자 + 언더스코어 모두 필수).
+- 디자인 토큰은 `DESIGN.md` (Pretendard · KTB Tech Blue `#0043FF` · 12/24px radius · `#E1E1E8` border)에 정리.
+- 새 데이터 페치는 `lib/hooks/useSWR.tsx` 패턴(`fallbackData` 주입) 사용. 컴포넌트에서 `fetch` 직접 호출 금지.
+
+<br />
+
+## 배포
+
+```sh
+# 로컬 빌드 테스트
+$ pnpm build
+
+# 프리뷰 배포
 $ vercel build && vercel deploy
 
-# prod 배포 
+# 프로덕션 배포
 $ vercel build && vercel deploy --prod
 ```
 
+`main` 브랜치가 배포 대상. 기능 작업은 `feature/*` 또는 `release/*` 브랜치에서 진행하고 PR로 머지합니다.
+
+<br />
+
+## 참고 문서
+
+- [`CLAUDE.md`](./CLAUDE.md) — 아키텍처 개요 & Claude Code 작업 가이드
+- [`DESIGN.md`](./DESIGN.md) — 비주얼 디자인 시스템
+- `docs/superpowers/` — 최근 작업의 스펙·플랜 (events card/detail/filter/header 리뉴얼, calendar view 등)

--- a/components/common/buttons/EmailSubscribeButton.module.scss
+++ b/components/common/buttons/EmailSubscribeButton.module.scss
@@ -10,20 +10,36 @@
   height: 48px;
   @extend %button-rounded;
   padding: 4px 40px;
-  background-color: var(--primary);
+  background-color: var(--ktb-tech-blue);
   border: none;
+  cursor: pointer;
+  box-shadow:
+    0 1px 2px rgba(0, 67, 255, 0.20),
+    0 2px 6px rgba(0, 67, 255, 0.18);
+  transition: background-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
 
-  // 폰트 스타일
+  // 폰트 스타일 — KTB Blue surface is always-blue in both themes,
+  // so text must be hardcoded white. var(--background-1) would invert
+  // to #1B1C1E in dark and render as dark text on blue.
   font-style: normal;
-  font-weight: 600;
+  font-weight: 700;
   font-size: 14px;
   line-height: 100%;
   text-align: center;
   letter-spacing: -0.4px;
-  color: var(--background-1);
+  color: #ffffff;
 
   &:hover {
-    background: #1e3bcf;
+    background-color: #0035CC;
+    transform: translateY(-1px);
+    box-shadow:
+      0 2px 4px rgba(0, 67, 255, 0.24),
+      0 6px 12px rgba(0, 67, 255, 0.20);
+  }
+
+  &:active {
+    background-color: #002CA8;
+    transform: translateY(0);
   }
 
   @include tablet {

--- a/components/common/buttons/FillButton.module.scss
+++ b/components/common/buttons/FillButton.module.scss
@@ -21,6 +21,10 @@
   &.color {
     &--primary {
       background-color: var(--ktb-tech-blue);
+      // KTB Blue surface stays saturated blue in both themes, so the label
+      // must be hardcoded white. Using var(--vapor-gray-000) would invert
+      // to the dark page bg (#1B1C1E) and render as black text on blue.
+      color: #ffffff;
       font-size: 14px;
       font-weight: 700;
       box-shadow:

--- a/components/common/calendar-export/CalendarExportButton.module.scss
+++ b/components/common/calendar-export/CalendarExportButton.module.scss
@@ -147,13 +147,13 @@
   .trigger {
     width: 36px;
     height: 36px;
-    background-color: rgba(255, 255, 255, 0.9);
+    background-color: var(--glass-overlay);
     backdrop-filter: saturate(150%) blur(8px);
     -webkit-backdrop-filter: saturate(150%) blur(8px);
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
 
     &:hover {
-      background-color: rgba(255, 255, 255, 1);
+      background-color: var(--glass-overlay-strong);
     }
   }
 

--- a/components/common/calendar-export/CalendarExportButton.module.scss
+++ b/components/common/calendar-export/CalendarExportButton.module.scss
@@ -1,0 +1,163 @@
+@import '~styles/_variables.scss';
+@import '~styles/_mixin.scss';
+
+.wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.trigger {
+  width: 40px;
+  height: 40px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.18s ease, transform 0.12s ease, color 0.18s ease;
+  padding: 4px;
+  color: var(--vapor-gray-500);
+  -webkit-tap-highlight-color: transparent;
+
+  &:hover {
+    background-color: var(--vapor-gray-100);
+    color: var(--vapor-gray-700);
+  }
+
+  &:active {
+    transform: scale(0.92);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--ktb-tech-blue);
+    outline-offset: 2px;
+  }
+
+  &.is-open {
+    background-color: var(--vapor-gray-100);
+    color: var(--ktb-tech-blue);
+  }
+
+  svg {
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+  }
+}
+
+.menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 50;
+  width: 240px;
+  padding: 6px;
+  border-radius: 14px;
+  background-color: var(--vapor-gray-000);
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 64, 0.06),
+    0 12px 32px rgba(0, 0, 64, 0.1),
+    0 4px 8px rgba(0, 0, 64, 0.04);
+  transform-origin: top right;
+  animation: menuIn 0.18s cubic-bezier(0.22, 1, 0.36, 1) both;
+  text-align: left;
+
+  &__head {
+    padding: 8px 10px 6px;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--vapor-gray-500);
+  }
+
+  &__item {
+    width: 100%;
+    padding: 9px 10px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    background-color: transparent;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--vapor-gray-900);
+    transition: background-color 0.15s ease, transform 0.1s ease;
+    -webkit-tap-highlight-color: transparent;
+    text-align: left;
+
+    &:hover {
+      background-color: var(--vapor-gray-050);
+    }
+    &:active {
+      background-color: var(--vapor-gray-100);
+      transform: scale(0.99);
+    }
+    &:focus-visible {
+      background-color: var(--vapor-gray-050);
+      outline: 2px solid var(--ktb-tech-blue);
+      outline-offset: -2px;
+    }
+  }
+
+  &__swatch {
+    width: 28px;
+    height: 28px;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    font-size: 13px;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    flex-shrink: 0;
+  }
+
+  &__label {
+    flex: 1;
+    letter-spacing: -0.005em;
+  }
+
+  &__hint {
+    font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+    font-size: 10.5px;
+    font-weight: 500;
+    color: var(--vapor-gray-500);
+  }
+}
+
+@keyframes menuIn {
+  from {
+    opacity: 0;
+    transform: translateY(-4px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+// Mobile parity with EventDetail's icon-btn
+@media (max-width: 1199px) {
+  .trigger {
+    width: 36px;
+    height: 36px;
+    background-color: rgba(255, 255, 255, 0.9);
+    backdrop-filter: saturate(150%) blur(8px);
+    -webkit-backdrop-filter: saturate(150%) blur(8px);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+
+    &:hover {
+      background-color: rgba(255, 255, 255, 1);
+    }
+  }
+
+  .menu {
+    width: 220px;
+  }
+}

--- a/components/common/calendar-export/CalendarExportButton.tsx
+++ b/components/common/calendar-export/CalendarExportButton.tsx
@@ -1,0 +1,155 @@
+import React, { useEffect, useRef, useState } from 'react';
+import classNames from 'classnames/bind';
+import { Event } from 'model/event';
+import { openInCalendar, CalendarTarget } from 'lib/utils/calendar';
+import { useToast } from 'context/toast';
+import style from './CalendarExportButton.module.scss';
+
+const cn = classNames.bind(style);
+
+interface Option {
+  target: CalendarTarget;
+  label: string;
+  hint: string;
+  initial: string;
+  swatch: string;
+}
+
+const OPTIONS: Option[] = [
+  {
+    target: 'apple',
+    label: 'Apple 캘린더',
+    hint: '.ics',
+    initial: '',
+    swatch: '#0E0E14',
+  },
+  {
+    target: 'google',
+    label: 'Google 캘린더',
+    hint: '새 탭 열기',
+    initial: 'G',
+    swatch: '#4285F4',
+  },
+  {
+    target: 'outlook',
+    label: 'Outlook',
+    hint: '.ics',
+    initial: 'O',
+    swatch: '#0078D4',
+  },
+];
+
+interface CalendarExportButtonProps {
+  event: Event;
+  className?: string;
+}
+
+const CalendarExportButton: React.FC<CalendarExportButtonProps> = ({
+  event,
+  className,
+}) => {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const { pushToast } = useToast();
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        wrapperRef.current &&
+        !wrapperRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEsc);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEsc);
+    };
+  }, [open]);
+
+  const handleSelect = (target: CalendarTarget) => {
+    setOpen(false);
+    const baseUrl =
+      typeof window !== 'undefined' ? window.location.origin : '';
+    try {
+      openInCalendar(target, event, baseUrl);
+      if (target === 'apple' || target === 'outlook') {
+        pushToast('캘린더 파일을 다운로드했어요');
+      }
+    } catch (err) {
+      console.error('[calendar-export]', err);
+      pushToast('캘린더 추가에 실패했어요');
+    }
+  };
+
+  return (
+    <div
+      ref={wrapperRef}
+      className={cn('wrapper', className)}
+    >
+      <button
+        type="button"
+        className={cn('trigger', { 'is-open': open })}
+        onClick={() => setOpen((prev) => !prev)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="내 캘린더에 추가"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={18}
+          height={18}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden
+        >
+          <rect x={3} y={4} width={18} height={18} rx={2} />
+          <line x1={16} y1={2} x2={16} y2={6} />
+          <line x1={8} y1={2} x2={8} y2={6} />
+          <line x1={3} y1={10} x2={21} y2={10} />
+          <line x1={12} y1={14} x2={12} y2={18} />
+          <line x1={10} y1={16} x2={14} y2={16} />
+        </svg>
+      </button>
+
+      {open && (
+        <div className={cn('menu')} role="menu">
+          <div className={cn('menu__head')}>캘린더 선택</div>
+          {OPTIONS.map((opt) => (
+            <button
+              key={opt.target}
+              type="button"
+              role="menuitem"
+              className={cn('menu__item')}
+              onClick={() => handleSelect(opt.target)}
+            >
+              <span
+                className={cn('menu__swatch')}
+                style={{ background: opt.swatch }}
+                aria-hidden
+              >
+                {opt.initial}
+              </span>
+              <span className={cn('menu__label')}>{opt.label}</span>
+              <span className={cn('menu__hint')}>{opt.hint}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CalendarExportButton;

--- a/components/common/item/Item.module.scss
+++ b/components/common/item/Item.module.scss
@@ -367,11 +367,11 @@
       .button {
         width: 32px;
         height: 32px;
-        background-color: rgba(255, 255, 255, 0.85);
+        background-color: var(--glass-overlay);
         backdrop-filter: blur(4px);
 
         &:hover {
-          background-color: rgba(255, 255, 255, 1);
+          background-color: var(--glass-overlay-strong);
         }
       }
 

--- a/components/common/modal/NoticeModal.module.scss
+++ b/components/common/modal/NoticeModal.module.scss
@@ -91,7 +91,7 @@
 }
 
 .notice--light {
-  background-color: rgba(0, 67, 255, 0.08);
+  background-color: var(--notice-bg);
 }
 
 @keyframes appearIn {

--- a/components/common/tag/JobGroupTag.module.scss
+++ b/components/common/tag/JobGroupTag.module.scss
@@ -6,7 +6,7 @@
   height: 36px;
   font-weight: 500;
   color: var(--vapor-gray-800);
-  background-color: #fff;
+  background-color: var(--vapor-gray-000);
   border: 1px solid var(--vapor-gray-300);
   border-radius: 999px;
   display: inline-flex;
@@ -41,7 +41,7 @@
   &:hover {
     border-color: var(--ktb-tech-blue);
     color: var(--ktb-tech-blue);
-    background-color: var(--vapor-gray-950);
+    background-color: rgba(0, 67, 255, 0.12);
   }
 }
 
@@ -56,7 +56,7 @@
 .checked--dark {
   border-color: var(--ktb-tech-blue);
   color: var(--ktb-tech-blue);
-  background-color: var(--vapor-gray-950);
+  background-color: rgba(0, 67, 255, 0.18);
   font-weight: 600;
 }
 

--- a/components/common/theme-toggle/ThemeToggle.module.scss
+++ b/components/common/theme-toggle/ThemeToggle.module.scss
@@ -13,9 +13,11 @@
   justify-content: center;
   transition: background-color 0.18s ease, transform 0.12s ease;
   -webkit-tap-highlight-color: transparent;
+  color: var(--vapor-gray-600);
 
   &:hover {
     background-color: var(--vapor-gray-100);
+    color: var(--vapor-gray-900);
   }
 
   &:active {
@@ -36,17 +38,13 @@
     transition: opacity 0.25s ease, transform 0.35s cubic-bezier(0.22, 1, 0.36, 1);
 
     svg {
-      width: 18px;
-      height: 18px;
-    }
-
-    svg path {
-      fill: var(--vapor-gray-600);
-      transition: fill 0.2s ease;
+      width: 20px;
+      height: 20px;
+      overflow: visible;
     }
   }
 
-  // Default state (light): show sun, hide moon
+  // Default (light): show sun, hide moon
   &__icon--sun {
     opacity: 1;
     transform: rotate(0deg) scale(1);
@@ -56,7 +54,7 @@
     transform: rotate(-90deg) scale(0.6);
   }
 
-  // Dark state: swap
+  // Dark: swap
   &.is-dark &__icon--sun {
     opacity: 0;
     transform: rotate(90deg) scale(0.6);
@@ -64,9 +62,5 @@
   &.is-dark &__icon--moon {
     opacity: 1;
     transform: rotate(0deg) scale(1);
-  }
-
-  &:hover svg path {
-    fill: var(--vapor-gray-900);
   }
 }

--- a/components/common/theme-toggle/ThemeToggle.module.scss
+++ b/components/common/theme-toggle/ThemeToggle.module.scss
@@ -1,0 +1,72 @@
+@import '~styles/_variables.scss';
+
+.toggle {
+  position: relative;
+  width: 40px;
+  height: 40px;
+  border: none;
+  background: transparent;
+  border-radius: 10px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.18s ease, transform 0.12s ease;
+  -webkit-tap-highlight-color: transparent;
+
+  &:hover {
+    background-color: var(--vapor-gray-100);
+  }
+
+  &:active {
+    transform: scale(0.92);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--ktb-tech-blue);
+    outline-offset: 2px;
+  }
+
+  &__icon {
+    position: absolute;
+    inset: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: opacity 0.25s ease, transform 0.35s cubic-bezier(0.22, 1, 0.36, 1);
+
+    svg {
+      width: 18px;
+      height: 18px;
+    }
+
+    svg path {
+      fill: var(--vapor-gray-600);
+      transition: fill 0.2s ease;
+    }
+  }
+
+  // Default state (light): show sun, hide moon
+  &__icon--sun {
+    opacity: 1;
+    transform: rotate(0deg) scale(1);
+  }
+  &__icon--moon {
+    opacity: 0;
+    transform: rotate(-90deg) scale(0.6);
+  }
+
+  // Dark state: swap
+  &.is-dark &__icon--sun {
+    opacity: 0;
+    transform: rotate(90deg) scale(0.6);
+  }
+  &.is-dark &__icon--moon {
+    opacity: 1;
+    transform: rotate(0deg) scale(1);
+  }
+
+  &:hover svg path {
+    fill: var(--vapor-gray-900);
+  }
+}

--- a/components/common/theme-toggle/ThemeToggle.tsx
+++ b/components/common/theme-toggle/ThemeToggle.tsx
@@ -1,11 +1,32 @@
 import React, { useContext } from 'react';
 import classNames from 'classnames/bind';
 import { WindowContext } from 'context/window';
-import SunIcon from 'components/icons/SunIcon';
-import MoonIcon from 'components/icons/MoonIcon';
 import style from './ThemeToggle.module.scss';
 
 const cn = classNames.bind(style);
+
+// Inline glyphs — kept local so we control viewBox + size precisely and avoid
+// the clipping we got when the shared 24x24 MoonIcon was rendered at 18px.
+const SunGlyph = () => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden
+  >
+    <circle cx={12} cy={12} r={4} />
+    <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+  </svg>
+);
+
+const MoonGlyph = () => (
+  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+  </svg>
+);
 
 const ThemeToggle: React.FC = () => {
   const { windowTheme, handleWindowTheme } = useContext(WindowContext);
@@ -20,10 +41,10 @@ const ThemeToggle: React.FC = () => {
       title={isLight ? '다크 모드로 전환' : '라이트 모드로 전환'}
     >
       <span className={cn('toggle__icon', 'toggle__icon--sun')} aria-hidden>
-        <SunIcon />
+        <SunGlyph />
       </span>
       <span className={cn('toggle__icon', 'toggle__icon--moon')} aria-hidden>
-        <MoonIcon />
+        <MoonGlyph />
       </span>
     </button>
   );

--- a/components/common/theme-toggle/ThemeToggle.tsx
+++ b/components/common/theme-toggle/ThemeToggle.tsx
@@ -1,0 +1,32 @@
+import React, { useContext } from 'react';
+import classNames from 'classnames/bind';
+import { WindowContext } from 'context/window';
+import SunIcon from 'components/icons/SunIcon';
+import MoonIcon from 'components/icons/MoonIcon';
+import style from './ThemeToggle.module.scss';
+
+const cn = classNames.bind(style);
+
+const ThemeToggle: React.FC = () => {
+  const { windowTheme, handleWindowTheme } = useContext(WindowContext);
+  const isLight = windowTheme;
+
+  return (
+    <button
+      type="button"
+      className={cn('toggle', { 'is-dark': !isLight })}
+      onClick={() => handleWindowTheme(!isLight)}
+      aria-label={isLight ? '다크 모드로 전환' : '라이트 모드로 전환'}
+      title={isLight ? '다크 모드로 전환' : '라이트 모드로 전환'}
+    >
+      <span className={cn('toggle__icon', 'toggle__icon--sun')} aria-hidden>
+        <SunIcon />
+      </span>
+      <span className={cn('toggle__icon', 'toggle__icon--moon')} aria-hidden>
+        <MoonIcon />
+      </span>
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/components/events/ScheduledEventList.tsx
+++ b/components/events/ScheduledEventList.tsx
@@ -12,8 +12,8 @@ type Props = {
 const ScheduledEventList = ({ events, isError }: Props) => {
   return (
     <section>
-      <EventFilter />
       <SocialBanner />
+      <EventFilter />
       <ItemList events={events} isError={isError} />
     </section>
   );

--- a/components/events/ScheduledEventList.tsx
+++ b/components/events/ScheduledEventList.tsx
@@ -1,5 +1,6 @@
 import ItemList from 'components/common/item/ItemList';
 import EventFilter from 'components/features/filters/EventFilter';
+import SocialBanner from 'components/features/social-banner/SocialBanner';
 import { EventResponse } from 'model/event';
 import React from 'react';
 
@@ -12,6 +13,7 @@ const ScheduledEventList = ({ events, isError }: Props) => {
   return (
     <section>
       <EventFilter />
+      <SocialBanner />
       <ItemList events={events} isError={isError} />
     </section>
   );

--- a/components/events/calendar/CalendarView.module.scss
+++ b/components/events/calendar/CalendarView.module.scss
@@ -1,6 +1,6 @@
 .viewToggle {
   display: inline-flex;
-  background: #F0F0F5;
+  background: var(--vapor-gray-100);
   padding: 4px;
   border-radius: 10px;
 }
@@ -12,15 +12,15 @@
   border-radius: 7px;
   font-size: 13px;
   font-weight: 600;
-  color: #6C6E7E;
+  color: var(--vapor-gray-600);
   cursor: pointer;
   display: inline-flex;
   align-items: center;
   gap: 6px;
 
   &.on {
-    background: #fff;
-    color: #2B2D36;
+    background: var(--vapor-gray-000);
+    color: var(--vapor-gray-900);
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
   }
 }

--- a/components/events/calendar/CalendarView.module.scss
+++ b/components/events/calendar/CalendarView.module.scss
@@ -1,6 +1,6 @@
 .viewToggle {
   display: inline-flex;
-  background: var(--vapor-gray-100);
+  background: var(--toggle-track-bg);
   padding: 4px;
   border-radius: 10px;
 }
@@ -19,7 +19,7 @@
   gap: 6px;
 
   &.on {
-    background: var(--vapor-gray-000);
+    background: var(--toggle-active-bg);
     color: var(--vapor-gray-900);
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
   }
@@ -44,30 +44,32 @@
   font-size: 20px;
   font-weight: 700;
   letter-spacing: -0.012em;
+  color: var(--vapor-gray-900);
 }
 
 .header__navBtn {
   width: 32px;
   height: 32px;
   border-radius: 8px;
-  border: 1px solid #E1E1E8;
-  background: #fff;
+  border: 1px solid var(--vapor-gray-300);
+  background: var(--vapor-gray-000);
   cursor: pointer;
   font-size: 16px;
-  color: #6C6E7E;
-  &:hover { border-color: #CDCED6; }
+  color: var(--vapor-gray-600);
+  &:hover { border-color: var(--vapor-gray-400); }
 }
 
 .header__todayBtn {
   margin-left: 8px;
   padding: 6px 12px;
   border-radius: 8px;
-  border: 1px solid #E1E1E8;
-  background: #fff;
-  color: #2B2D36;
+  border: 1px solid var(--vapor-gray-300);
+  background: var(--vapor-gray-000);
+  color: var(--vapor-gray-900);
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
+  &:hover { border-color: var(--vapor-gray-400); }
 }
 
 .grid__weekdays {
@@ -78,27 +80,27 @@
   div {
     font-size: 12px;
     font-weight: 600;
-    color: #6C6E7E;
+    color: var(--vapor-gray-600);
     text-align: center;
     padding: 8px 0;
     min-width: 0;
   }
-  div:first-child { color: #D91C29; }
-  div:last-child  { color: #1D6CE0; }
+  div:first-child { color: var(--vapor-text-danger); }
+  div:last-child  { color: var(--vapor-text-primary); }
 }
 
 .grid {
   display: grid;
   grid-template-columns: repeat(7, minmax(0, 1fr));
   gap: 1px;
-  background: #E8E8EE;
-  border: 1px solid #E8E8EE;
+  background: var(--vapor-gray-200);
+  border: 1px solid var(--vapor-gray-200);
   border-radius: 8px;
   overflow: hidden;
 }
 
 .grid__cell {
-  background: #fff;
+  background: var(--vapor-gray-000);
   min-height: 110px;
   min-width: 0;
   padding: 8px;
@@ -108,23 +110,28 @@
   cursor: pointer;
   position: relative;
   overflow: hidden;
-  &:hover { background: #F7F7FA; }
+  color: var(--vapor-gray-900);
+  &:hover { background: var(--vapor-gray-050); }
 
-  &.outside { background: #F7F7FA; color: #8C8F9F; }
+  &.outside {
+    background: var(--vapor-gray-050);
+    color: var(--vapor-gray-500);
+  }
 }
 
 .grid__num {
   font-size: 13px;
   font-weight: 600;
   padding: 2px 4px;
+  color: var(--vapor-gray-900);
 
-  &.sun { color: #D91C29; }
-  &.sat { color: #1D6CE0; }
-  &.outside { color: #8C8F9F; }
+  &.sun { color: var(--vapor-text-danger); }
+  &.sat { color: var(--vapor-text-primary); }
+  &.outside { color: var(--vapor-gray-500); }
 }
 
 .grid__numToday {
-  background: #0043FF;
+  background: var(--ktb-tech-blue);
   color: #fff !important;
   width: 22px;
   height: 22px;
@@ -142,8 +149,18 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1.3;
+
+  // Dark mode override — the inline style sets `color: <tag hex>` and
+  // `background: rgba(<tag>, 0.08)`. Both are tuned for light bg; on a
+  // dark page they collapse to dark-on-dark and become unreadable.
+  // We force a high-contrast text + elevated surface here, but keep the
+  // left border (also inline) tinted so category color cue is preserved.
+  :global(html[data-theme='dark']) & {
+    color: var(--vapor-gray-900) !important;
+    background: var(--vapor-gray-100) !important;
+  }
 }
 .grid__chip--start { border-radius: 4px 0 0 4px; margin-right: -9px; padding-right: 12px; }
 .grid__chip--mid   { border-radius: 0; margin-left: -9px; margin-right: -9px; padding-left: 12px; padding-right: 12px; }
@@ -151,7 +168,7 @@
 
 .grid__more {
   font-size: 11px;
-  color: #6C6E7E;
+  color: var(--vapor-gray-600);
   padding: 2px 6px;
 }
 
@@ -173,12 +190,13 @@
   gap: 2px;
   cursor: pointer;
   position: relative;
+  color: var(--vapor-gray-900);
 
-  &.outside { color: #8C8F9F; }
-  &.today   { background: #0043FF; color: #fff; }
-  &.selected { outline: 2px solid #0043FF; outline-offset: -2px; }
-  &.sun:not(.today):not(.outside) { color: #D91C29; }
-  &.sat:not(.today):not(.outside) { color: #1D6CE0; }
+  &.outside { color: var(--vapor-gray-500); }
+  &.today   { background: var(--ktb-tech-blue); color: #fff; }
+  &.selected { outline: 2px solid var(--ktb-tech-blue); outline-offset: -2px; }
+  &.sun:not(.today):not(.outside) { color: var(--vapor-text-danger); }
+  &.sat:not(.today):not(.outside) { color: var(--vapor-text-primary); }
 }
 
 .dot__dots {
@@ -191,7 +209,7 @@
     border-radius: 50%;
     display: inline-block;
   }
-  i.plus { background: #8C8F9F; }
+  i.plus { background: var(--vapor-gray-500); }
 }
 
 .sheet__overlay {
@@ -205,13 +223,14 @@
 }
 
 .sheet {
-  background: #fff;
+  background: var(--vapor-gray-000);
   border-radius: 12px;
   padding: 20px;
   max-width: 480px;
   width: 90vw;
   max-height: 80vh;
   overflow-y: auto;
+  color: var(--vapor-gray-900);
 }
 
 .sheet__header {
@@ -225,6 +244,7 @@
   font-size: 16px;
   font-weight: 800;
   letter-spacing: -0.012em;
+  color: var(--vapor-gray-900);
 }
 
 .sheet__close {
@@ -232,12 +252,12 @@
   border: 0;
   font-size: 18px;
   cursor: pointer;
-  color: #6C6E7E;
+  color: var(--vapor-gray-600);
 }
 
 .sheet__empty {
   text-align: center;
-  color: #6C6E7E;
+  color: var(--vapor-gray-600);
   padding: 32px 0;
   font-size: 13px;
 }
@@ -246,15 +266,15 @@
   display: flex;
   gap: 12px;
   padding: 12px 0;
-  border-bottom: 1px solid #F0F0F5;
+  border-bottom: 1px solid var(--vapor-gray-100);
   cursor: pointer;
 
   &:last-child { border-bottom: 0; }
 
   .sheet__bar { width: 3px; flex-shrink: 0; border-radius: 2px; }
   .sheet__body {
-    .sheet__itemTitle { font-size: 14px; font-weight: 700; margin-bottom: 4px; }
-    .sheet__itemMeta  { font-size: 12px; color: #6C6E7E; }
+    .sheet__itemTitle { font-size: 14px; font-weight: 700; margin-bottom: 4px; color: var(--vapor-gray-900); }
+    .sheet__itemMeta  { font-size: 12px; color: var(--vapor-gray-600); }
   }
 }
 
@@ -270,8 +290,8 @@
 }
 
 .container {
-  background: #fff;
-  border: 1px solid #E1E1E8;
+  background: var(--vapor-gray-000);
+  border: 1px solid var(--vapor-gray-300);
   border-radius: 12px;
   padding: 24px;
   margin: 16px 0 40px;

--- a/components/features/social-banner/SocialBanner.module.scss
+++ b/components/features/social-banner/SocialBanner.module.scss
@@ -5,7 +5,10 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 12px;
-  margin: 20px 0 24px;
+  // Top margin is generous because the banner now sits between the sticky
+  // page header and the "전체 행사" filter heading — needs breathing room
+  // so it doesn't read as glued to the header.
+  margin: 40px 0 28px;
   width: 100%;
 }
 
@@ -132,7 +135,10 @@
   padding: 7px 12px;
   border-radius: 9999px;
   background: #fff;
-  color: var(--vapor-gray-900);
+  // Pill bg is always white (sits on the always-dark/gradient card surface),
+  // so the text color must be a fixed dark value — not a theme-aware token,
+  // which would invert to near-white in dark mode and disappear.
+  color: #2B2D36;
   letter-spacing: -0.005em;
   white-space: nowrap;
 
@@ -145,7 +151,7 @@
   .banner {
     grid-template-columns: 1fr;
     gap: 8px;
-    margin: 16px 0 20px;
+    margin: 28px 0 20px;
   }
 
   .card {

--- a/components/features/social-banner/SocialBanner.module.scss
+++ b/components/features/social-banner/SocialBanner.module.scss
@@ -1,0 +1,185 @@
+@import '~styles/_variables.scss';
+@import '~styles/_mixin.scss';
+
+.banner {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  margin: 20px 0 24px;
+  width: 100%;
+}
+
+.card {
+  position: relative;
+  overflow: hidden;
+  border-radius: 12px;
+  padding: 18px 20px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  min-height: 80px;
+  text-decoration: none;
+  color: #fff;
+  transition: transform 0.18s ease;
+  -webkit-tap-highlight-color: transparent;
+
+  &:hover {
+    transform: translateY(-1px);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--ktb-tech-blue);
+    outline-offset: 2px;
+  }
+
+  &--threads {
+    background: linear-gradient(135deg, #0e0e14 0%, #1c1c24 100%);
+  }
+
+  &--ig {
+    background: linear-gradient(
+      135deg,
+      #ffe08a 0%,
+      #ff6f4d 25%,
+      #e53e5e 50%,
+      #c13584 75%,
+      #5b3f9f 100%
+    );
+
+    // Subtle top-right shine over the gradient.
+    &::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(
+        circle at 100% 0%,
+        rgba(255, 255, 255, 0.18),
+        transparent 60%
+      );
+      pointer-events: none;
+    }
+  }
+}
+
+.icon {
+  width: 44px;
+  height: 44px;
+  flex-shrink: 0;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.16);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  svg {
+    width: 24px;
+    height: 24px;
+    color: #fff;
+  }
+}
+
+.body {
+  flex: 1;
+  min-width: 0;
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.label {
+  font-size: 10.5px;
+  font-weight: 600;
+  opacity: 0.78;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-bottom: 3px;
+}
+
+.copy {
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: -0.012rem;
+  line-height: 1.3;
+  margin-bottom: 3px;
+  word-break: keep-all;
+  // Cap to two lines worst case; visual contract is single-line on desktop.
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.handle {
+  font-size: 11.5px;
+  font-weight: 500;
+  opacity: 0.78;
+  font-family: 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cta {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  font-weight: 700;
+  padding: 7px 12px;
+  border-radius: 9999px;
+  background: #fff;
+  color: var(--vapor-gray-900);
+  letter-spacing: -0.005em;
+  white-space: nowrap;
+
+  .card--ig & {
+    color: #c13584;
+  }
+}
+
+@media (max-width: 768px) {
+  .banner {
+    grid-template-columns: 1fr;
+    gap: 8px;
+    margin: 16px 0 20px;
+  }
+
+  .card {
+    padding: 14px 16px;
+    min-height: 68px;
+    gap: 12px;
+    border-radius: 12px;
+  }
+
+  .icon {
+    width: 36px;
+    height: 36px;
+    border-radius: 9px;
+
+    svg {
+      width: 20px;
+      height: 20px;
+    }
+  }
+
+  .copy {
+    font-size: 14px;
+  }
+
+  .handle {
+    font-size: 11px;
+  }
+
+  .cta {
+    padding: 6px 10px;
+    font-size: 11px;
+
+    svg {
+      display: none;
+    }
+  }
+}

--- a/components/features/social-banner/SocialBanner.tsx
+++ b/components/features/social-banner/SocialBanner.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import classNames from 'classnames/bind';
+import style from './SocialBanner.module.scss';
+
+const cn = classNames.bind(style);
+
+const THREADS_URL = 'https://www.threads.com/@dev.event.official?hl=ko';
+const INSTAGRAM_URL = 'https://www.instagram.com/dev.event.official/';
+const HANDLE = '@dev.event.official';
+
+const ThreadsIcon = () => (
+  <svg
+    viewBox="0 0 192 192"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="currentColor"
+    aria-hidden
+  >
+    <path d="M141.5 86.6c-.7-.3-1.4-.7-2.1-1-1.3-23.4-14.1-36.8-35.6-37-9.7 0-17.7 4.2-22.9 11.4l11.9 8.2c3.7-5.6 9.5-6.8 14.8-6.8h.2c6.6 0 11.5 1.9 14.7 5.7 2.3 2.7 3.9 6.5 4.7 11.2-6.1-1-12.6-1.4-19.7-1-19.8 1.1-32.4 12.6-31.6 28.6.4 8.1 4.4 15 11.5 19.6 5.9 3.8 13.6 5.7 21.6 5.3 10.6-.6 18.9-4.6 24.7-11.9 4.4-5.5 7.2-12.7 8.4-21.6 5 3 8.7 7 10.7 11.7 3.5 8.1 3.7 21.5-7.2 32.4-9.6 9.6-21.1 13.7-38.5 13.8C84 156.3 70.7 150 61.9 137c-8.2-12.2-12.5-29.7-12.6-52.1.1-22.4 4.4-39.9 12.6-52 8.8-13 22.1-19.3 40.6-19.5 18.6.1 32.1 6.4 41.3 19.5 4.5 6.4 7.9 14.4 10.2 23.7l14-3.7c-2.7-11.4-7-21.3-12.8-29.5-11.7-16.6-28.9-25.1-51.1-25.2H104c-22.2.2-39 8.8-50.1 25.5-9.9 14.9-15 35.6-15.2 61.6.2 26 5.3 46.7 15.2 61.6 11.1 16.7 27.9 25.3 50.1 25.5h.1c19.7-.1 33.6-5.3 45.1-16.8 15-15 14.6-33.8 9.6-45.3-3.6-8.3-10.4-15-19.7-19.4Zm-29.7 22.8c-8.8.5-17.9-3.5-18.3-11.8-.3-6.2 4.4-13.1 18.8-13.9 1.7-.1 3.3-.1 4.9-.1 5.2 0 10.1.5 14.5 1.5-1.7 20.6-11.4 23.9-19.9 24.3Z" />
+  </svg>
+);
+
+const InstagramIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.8}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden
+  >
+    <rect x={2} y={2} width={20} height={20} rx={5} />
+    <circle cx={12} cy={12} r={4} />
+    <circle cx={17.5} cy={6.5} r={1} fill="currentColor" />
+  </svg>
+);
+
+const ArrowIcon = () => (
+  <svg
+    width={11}
+    height={11}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={3}
+    strokeLinecap="round"
+    aria-hidden
+  >
+    <path d="M5 12h14M13 5l7 7-7 7" />
+  </svg>
+);
+
+const SocialBanner: React.FC = () => {
+  return (
+    <div className={cn('banner')}>
+      <a
+        href={THREADS_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={cn('card', 'card--threads')}
+        aria-label="Threads에서 데브이벤트 팔로우"
+      >
+        <span className={cn('icon')}>
+          <ThreadsIcon />
+        </span>
+        <span className={cn('body')}>
+          <span className={cn('label')}>Threads</span>
+          <span className={cn('copy')}>새 행사 소식, 가장 먼저 받기</span>
+          <span className={cn('handle')}>{HANDLE}</span>
+        </span>
+        <span className={cn('cta')}>
+          팔로우
+          <ArrowIcon />
+        </span>
+      </a>
+
+      <a
+        href={INSTAGRAM_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={cn('card', 'card--ig')}
+        aria-label="Instagram에서 데브이벤트 팔로우"
+      >
+        <span className={cn('icon')}>
+          <InstagramIcon />
+        </span>
+        <span className={cn('body')}>
+          <span className={cn('label')}>Instagram</span>
+          <span className={cn('copy')}>행사 현장 사진 · 후기 둘러보기</span>
+          <span className={cn('handle')}>{HANDLE}</span>
+        </span>
+        <span className={cn('cta')}>
+          팔로우
+          <ArrowIcon />
+        </span>
+      </a>
+    </div>
+  );
+};
+
+export default SocialBanner;

--- a/components/features/social-banner/SocialBanner.tsx
+++ b/components/features/social-banner/SocialBanner.tsx
@@ -59,7 +59,7 @@ const SocialBanner: React.FC = () => {
         target="_blank"
         rel="noopener noreferrer"
         className={cn('card', 'card--threads')}
-        aria-label="Threads에서 데브이벤트 팔로우"
+        aria-label="Threads에서 데브이벤트 계정 보러가기"
       >
         <span className={cn('icon')}>
           <ThreadsIcon />
@@ -70,7 +70,7 @@ const SocialBanner: React.FC = () => {
           <span className={cn('handle')}>{HANDLE}</span>
         </span>
         <span className={cn('cta')}>
-          팔로우
+          보러가기
           <ArrowIcon />
         </span>
       </a>
@@ -80,18 +80,18 @@ const SocialBanner: React.FC = () => {
         target="_blank"
         rel="noopener noreferrer"
         className={cn('card', 'card--ig')}
-        aria-label="Instagram에서 데브이벤트 팔로우"
+        aria-label="Instagram에서 데브이벤트 계정 보러가기"
       >
         <span className={cn('icon')}>
           <InstagramIcon />
         </span>
         <span className={cn('body')}>
           <span className={cn('label')}>Instagram</span>
-          <span className={cn('copy')}>행사 현장 사진 · 후기 둘러보기</span>
+          <span className={cn('copy')}>익숙한 피드에서 행사 소식 받기</span>
           <span className={cn('handle')}>{HANDLE}</span>
         </span>
         <span className={cn('cta')}>
-          팔로우
+          보러가기
           <ArrowIcon />
         </span>
       </a>

--- a/components/layout/header/Header.module.scss
+++ b/components/layout/header/Header.module.scss
@@ -10,7 +10,7 @@
   z-index: 99;
   min-height: 3.5rem;
   border-bottom: 1px solid var(--vapor-gray-300);
-  background-color: hsla(0, 0%, 100%, .88);
+  background-color: var(--header-bg);
   backdrop-filter: saturate(150%) blur(32px);
 
   &__inner {

--- a/components/layout/header/Header.module.scss
+++ b/components/layout/header/Header.module.scss
@@ -66,30 +66,81 @@
     .wrapper {
       padding-left: 24px;
     }
+
+    // Login text button — align hover treatment with ThemeToggle:
+    // same border-radius + hover bg so the two header buttons read as a pair.
+    .login button {
+      border-radius: 10px;
+      transition: background-color 0.18s ease, color 0.15s ease,
+        transform 0.12s ease;
+      -webkit-tap-highlight-color: transparent;
+
+      &:hover {
+        background-color: var(--vapor-gray-100);
+        color: var(--vapor-gray-900);
+      }
+      &:active {
+        transform: scale(0.96);
+      }
+      &:focus-visible {
+        outline: 2px solid var(--ktb-tech-blue);
+        outline-offset: 2px;
+      }
+    }
   }
 }
 
 .profile {
   position: relative;
-  padding: 0px;
-  margin: 0px;
-  height: 24px;
+  padding: 0;
+  margin: 0;
+  // Match ThemeToggle's 40×40 frame so the icon button shares the same
+  // tap target and visual rhythm with the theme toggle on its left.
+  height: 40px;
+
   .profile-button {
     border: none;
     background-color: transparent;
-    width: 24px;
-    height: 24px;
-    padding: 0px;
+    width: 40px;
+    height: 40px;
+    padding: 0;
+    border-radius: 10px;
     cursor: pointer;
+    color: var(--vapor-gray-500);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: background-color 0.18s ease, color 0.15s ease,
+      transform 0.12s ease;
+    -webkit-tap-highlight-color: transparent;
 
-    svg path {
-      fill: var(--vapor-gray-500);
+    svg {
+      width: 20px;
+      height: 20px;
+      overflow: visible;
+    }
+    // Glyph is stroke-based (fill="none" + stroke="currentColor"), so we
+    // do NOT force a fill here — doing so would override the inline
+    // fill="none" via CSS specificity and render the icon as a solid blob.
+    // Color flows via the button's `color` property → currentColor → stroke.
+
+    &:hover {
+      background-color: var(--vapor-gray-100);
+      color: var(--vapor-gray-900);
+    }
+    &:active {
+      transform: scale(0.92);
+    }
+    &:focus-visible {
+      outline: 2px solid var(--ktb-tech-blue);
+      outline-offset: 2px;
     }
   }
 
   .profile-menu {
     position: absolute;
-    top: 44px;
+    // 40px button + 8px gap. Was 44px when the button was 24×24.
+    top: 48px;
     right: 0;
     left: auto;
     margin-left: 0;

--- a/components/layout/header/Header.tsx
+++ b/components/layout/header/Header.tsx
@@ -1,6 +1,7 @@
 import Logo from 'components/common/logo/Logo';
 import LoginModal from 'components/common/modal/LoginModal';
 import NoticeModal from 'components/common/modal/NoticeModal';
+import ThemeToggle from 'components/common/theme-toggle/ThemeToggle';
 import Login from 'components/features/login/Login';
 import style from 'components/layout/header/Header.module.scss';
 import Profile from 'components/layout/header/Profile';
@@ -28,6 +29,7 @@ function Header() {
           <HeaderTab />
         </nav>
         <div className={cn('header__buttons')}>
+          <ThemeToggle />
           <span className={cn('wrapper')}>
             {isLoggedIn ? (
               <div>

--- a/components/layout/header/Profile.tsx
+++ b/components/layout/header/Profile.tsx
@@ -2,13 +2,33 @@ import axios from 'axios';
 import { AuthContext } from 'context/auth';
 import { useOnClickOutside } from 'lib/hooks/useOnClickOutside';
 import * as ga from 'lib/utils/gTag';
-import ProfileIcon from 'public/icon/profile_outlined_regular.svg';
 import React, { useRef, useState } from 'react';
 import classNames from 'classnames/bind';
 import { useRouter } from 'next/router';
 import style from './Header.module.scss';
 
 const cn = classNames.bind(style);
+
+// Inline glyph — kept local for the same reason ThemeToggle inlines its
+// SunGlyph/MoonGlyph: the shared ProfileIcon SVG (`public/icon/profile_outlined_regular.svg`)
+// has a tight 0–24 viewBox where the body fills to y=22, so when scaled
+// down inside the 40×40 header button the shoulders read as "clipped"
+// against the visual baseline. This Lucide-style stroke glyph has natural
+// rounded caps and breathing room → visually pairs with SunGlyph.
+const UserGlyph = () => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden
+  >
+    <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+    <circle cx={12} cy={7} r={4} />
+  </svg>
+);
 
 const Profile = () => {
   const [profileMenuIsOpen, setProfileMenuIsOpen] = useState(false);
@@ -36,8 +56,12 @@ const Profile = () => {
 
   return (
     <div className={cn(`profile`)}>
-      <button className={cn(`profile-button`)} onClick={handleClickProfile}>
-        <ProfileIcon />
+      <button
+        className={cn(`profile-button`)}
+        onClick={handleClickProfile}
+        aria-label="프로필 메뉴 열기"
+      >
+        <UserGlyph />
       </button>
       {profileMenuIsOpen ? (
         <div className={cn('profile-menu')} ref={outsideRef}>

--- a/components/myEvent/MyEventEmpty.module.scss
+++ b/components/myEvent/MyEventEmpty.module.scss
@@ -40,10 +40,10 @@
     text-align: center;
 
     &__title {
-      color: #313234;
+      color: var(--vapor-gray-900);
       font-size: 24px;
       font-style: normal;
-      font-weight: 400;
+      font-weight: 600;
       line-height: 150%; /* 36px */
       letter-spacing: -0.48px;
       padding-bottom: 16px;
@@ -54,7 +54,7 @@
     }
 
     &__info {
-      color: #747579;
+      color: var(--vapor-gray-600);
       font-size: 16px;
       font-style: normal;
       font-weight: 500;
@@ -71,15 +71,22 @@
       padding: 4px 10px;
       gap: 10px;
       border-radius: 100px;
-      border: 1px solid var(--light-Gray2, #747579);
-      color: var(--light-Gray1, #313234);
-      background-color: white;
+      border: 1px solid var(--vapor-gray-300);
+      color: var(--vapor-gray-900);
+      background-color: var(--vapor-gray-050);
       text-align: center;
       font-size: 20px;
       font-style: normal;
       font-weight: 600;
       line-height: 100%; /* 20px */
       letter-spacing: -0.4px;
+      cursor: pointer;
+      transition: background-color 0.15s ease, border-color 0.15s ease;
+
+      &:hover {
+        background-color: var(--vapor-gray-100);
+        border-color: var(--vapor-gray-400);
+      }
     }
   }
 }

--- a/context/window.tsx
+++ b/context/window.tsx
@@ -1,4 +1,6 @@
-import React, { createContext, ReactNode, useState } from 'react';
+import React, { createContext, ReactNode, useEffect, useState } from 'react';
+
+const THEME_STORAGE_KEY = 'dev-event:theme';
 
 type ModalStateProps = {
   currentModal: number;
@@ -18,6 +20,15 @@ interface WindowContext {
   modalState: ModalStateProps;
   handleModalState: (event: ModalStateProps) => void;
 }
+
+// `windowTheme: true` = light, `false` = dark.
+// Source of truth is the <html data-theme> attribute, which the inline script
+// in _document.tsx sets BEFORE React boots (FOUC prevention). On mount we
+// sync state from the attribute and re-apply it on every toggle.
+const readInitialTheme = (): boolean => {
+  if (typeof document === 'undefined') return true;
+  return document.documentElement.getAttribute('data-theme') !== 'dark';
+};
 
 const defaultValue: WindowContext = {
   isClient: false,
@@ -47,6 +58,26 @@ const WindowProvider = ({ children }: { children: ReactNode }) => {
     defaultValue.modalState
   );
 
+  useEffect(() => {
+    setWindowTheme(readInitialTheme());
+
+    if (typeof window === 'undefined') return;
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleSystemChange = (e: MediaQueryListEvent) => {
+      // Only follow the system change when the user has not made an explicit choice.
+      let stored: string | null = null;
+      try {
+        stored = localStorage.getItem(THEME_STORAGE_KEY);
+      } catch {}
+      if (stored) return;
+      const next = e.matches ? 'dark' : 'light';
+      document.documentElement.setAttribute('data-theme', next);
+      setWindowTheme(next === 'light');
+    };
+    mq.addEventListener?.('change', handleSystemChange);
+    return () => mq.removeEventListener?.('change', handleSystemChange);
+  }, []);
+
   const handleIsClient = (event: boolean) => {
     setIsClient(event);
   };
@@ -55,7 +86,15 @@ const WindowProvider = ({ children }: { children: ReactNode }) => {
   };
 
   const handleWindowTheme = (event: boolean) => {
-    setWindowTheme(!event);
+    // `event` carries the desired NEXT theme (true = light, false = dark).
+    setWindowTheme(event);
+    if (typeof document !== 'undefined') {
+      const themeName = event ? 'light' : 'dark';
+      document.documentElement.setAttribute('data-theme', themeName);
+      try {
+        localStorage.setItem(THEME_STORAGE_KEY, themeName);
+      } catch {}
+    }
   };
 
   const handleIsNotice = (event: boolean) => {

--- a/docs/mockups/feature-mockups.html
+++ b/docs/mockups/feature-mockups.html
@@ -1,0 +1,1817 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Dev Event Web · 8 Feature Mockups</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+:root{
+  --bg:#FAFAFB;
+  --surface:#FFFFFF;
+  --surface-alt:#F4F4F7;
+  --ink:#0E0E14;
+  --ink-2:#2A2A33;
+  --muted:#6C6C76;
+  --muted-2:#9C9CA6;
+  --border:#E1E1E8;
+  --border-strong:#C8C8D0;
+  --accent:#0043FF;
+  --accent-soft:#EAF0FF;
+  --accent-deep:#001E80;
+  --success:#0FA968;
+  --warn:#FF6A00;
+  --danger:#E32C2C;
+  --r-sm:8px; --r:12px; --r-lg:24px;
+}
+
+*{box-sizing:border-box;margin:0;padding:0;}
+html{scroll-behavior:smooth;}
+body{
+  font-family:'Pretendard Variable',Pretendard,-apple-system,BlinkMacSystemFont,system-ui,sans-serif;
+  background:var(--bg);
+  color:var(--ink);
+  -webkit-font-smoothing:antialiased;
+  text-rendering:optimizeLegibility;
+  line-height:1.5;
+  font-feature-settings:"ss01","ss02","ss03";
+}
+.serif{font-family:'Instrument Serif',serif;font-style:italic;font-weight:400;}
+.mono{font-family:'JetBrains Mono',monospace;}
+
+button{font-family:inherit;cursor:pointer;border:none;background:none;color:inherit;}
+kbd{
+  font-family:'JetBrains Mono',monospace;
+  font-size:11px;
+  padding:2px 6px;
+  background:var(--surface);
+  border:1px solid var(--border);
+  border-bottom-width:2px;
+  border-radius:6px;
+  color:var(--ink-2);
+  min-width:20px;
+  display:inline-flex;
+  justify-content:center;
+}
+
+/* ============ TOP BAR ============ */
+.topbar{
+  position:sticky;top:0;z-index:50;
+  background:rgba(250,250,251,0.85);
+  backdrop-filter:blur(20px) saturate(140%);
+  -webkit-backdrop-filter:blur(20px) saturate(140%);
+  border-bottom:1px solid var(--border);
+}
+.topbar__inner{
+  max-width:1280px;margin:0 auto;
+  padding:16px 48px;
+  display:flex;align-items:center;gap:32px;
+  font-size:13px;
+}
+.topbar__logo{
+  font-weight:800;
+  letter-spacing:-0.02em;
+  font-size:15px;
+}
+.topbar__logo b{color:var(--accent);}
+.topbar__nav{display:flex;gap:24px;flex:1;}
+.topbar__nav a{
+  color:var(--muted);
+  text-decoration:none;
+  font-weight:500;
+  transition:color .2s;
+  font-size:13px;
+}
+.topbar__nav a:hover{color:var(--accent);}
+.topbar__date{
+  color:var(--muted);
+  font-family:'JetBrains Mono',monospace;
+  font-size:11px;
+  letter-spacing:0.08em;
+}
+
+/* ============ HERO ============ */
+.hero{
+  max-width:1280px;
+  margin:0 auto;
+  padding:96px 48px 128px;
+  position:relative;
+}
+.hero__eyebrow{
+  display:inline-flex;align-items:center;gap:14px;
+  font-size:12px;letter-spacing:0.18em;text-transform:uppercase;
+  color:var(--accent);font-weight:700;margin-bottom:40px;
+}
+.hero__eyebrow::before{content:"";width:40px;height:1px;background:var(--accent);}
+
+.hero h1{
+  font-size:clamp(56px,9vw,140px);
+  line-height:0.94;
+  letter-spacing:-0.045em;
+  font-weight:800;
+  margin-bottom:40px;
+}
+.hero h1 em{
+  font-family:'Instrument Serif',serif;
+  font-style:italic;
+  font-weight:400;
+  color:var(--accent);
+}
+.hero__lede{
+  max-width:680px;
+  font-size:21px;
+  color:var(--ink-2);
+  line-height:1.55;
+  margin-bottom:80px;
+  font-weight:400;
+}
+.hero__lede mark{
+  background:linear-gradient(180deg,transparent 60%,var(--accent-soft) 60%);
+  padding:0 4px;color:var(--ink);
+  font-weight:600;
+}
+
+.hero__meta{
+  display:grid;
+  grid-template-columns:repeat(4,1fr);
+  gap:48px;
+  border-top:1px solid var(--ink);
+  padding-top:32px;
+}
+.hero__meta dt{
+  font-size:11px;letter-spacing:0.14em;text-transform:uppercase;
+  color:var(--muted);margin-bottom:10px;font-weight:600;
+}
+.hero__meta dd{
+  font-size:17px;font-weight:600;color:var(--ink);
+  letter-spacing:-0.01em;
+}
+.hero__meta dd b{color:var(--accent);font-family:'JetBrains Mono',monospace;font-weight:500;font-size:14px;}
+
+/* ============ TOC ============ */
+.toc{
+  max-width:1280px;margin:0 auto;
+  padding:0 48px 64px;
+}
+.toc__inner{
+  border:1px solid var(--border);
+  border-radius:var(--r-lg);
+  padding:32px 40px;
+  background:var(--surface);
+  display:grid;
+  grid-template-columns:repeat(4,1fr);
+  gap:1px;
+  background:var(--border);
+  overflow:hidden;
+}
+.toc__item{
+  background:var(--surface);
+  padding:24px;
+  display:block;
+  text-decoration:none;
+  color:inherit;
+  transition:background .2s;
+}
+.toc__item:hover{background:var(--accent-soft);}
+.toc__item:hover .toc__num{color:var(--accent);}
+.toc__num{
+  font-family:'Instrument Serif',serif;
+  font-style:italic;
+  font-size:32px;
+  color:var(--muted-2);
+  transition:color .2s;
+  line-height:1;
+  margin-bottom:12px;
+}
+.toc__title{
+  font-size:14px;font-weight:700;
+  letter-spacing:-0.01em;
+  margin-bottom:4px;
+}
+.toc__hint{font-size:11px;color:var(--muted);letter-spacing:0.04em;}
+
+/* ============ FEATURE COMMON ============ */
+.feature{
+  max-width:1280px;
+  margin:0 auto;
+  padding:120px 48px;
+  border-top:1px solid var(--ink);
+  position:relative;
+}
+.feature__layout{
+  display:grid;
+  gap:80px;
+  align-items:start;
+}
+.feature__layout.split{grid-template-columns:5fr 7fr;}
+.feature__layout.split-rev{grid-template-columns:7fr 5fr;}
+.feature__layout.split-rev .feature__head{order:2;}
+.feature__layout.stack{grid-template-columns:1fr;}
+.feature__layout.stack .feature__head{max-width:760px;margin-bottom:24px;}
+
+.feature__num{
+  font-family:'Instrument Serif',serif;
+  font-style:italic;
+  font-size:120px;
+  line-height:1;
+  color:var(--accent);
+  margin-bottom:24px;
+  letter-spacing:-0.02em;
+}
+.feature__label{
+  font-size:11px;letter-spacing:0.18em;text-transform:uppercase;
+  color:var(--muted);font-weight:700;margin-bottom:20px;
+  display:flex;align-items:center;gap:10px;
+}
+.feature__label::before{content:"";width:24px;height:1px;background:var(--muted);}
+.feature__title{
+  font-size:clamp(36px,4vw,56px);
+  line-height:1.05;
+  letter-spacing:-0.035em;
+  font-weight:700;
+  margin-bottom:28px;
+}
+.feature__title em{
+  font-family:'Instrument Serif',serif;
+  font-style:italic;
+  font-weight:400;
+  color:var(--accent);
+}
+.feature__lede{
+  font-size:17px;
+  color:var(--ink-2);
+  line-height:1.65;
+  margin-bottom:32px;
+  max-width:540px;
+}
+.feature__bullets{list-style:none;margin-bottom:36px;counter-reset:li;}
+.feature__bullets li{
+  padding:14px 0;
+  border-top:1px solid var(--border);
+  display:grid;
+  grid-template-columns:32px 1fr;
+  gap:16px;
+  align-items:start;
+  font-size:14.5px;
+  color:var(--ink-2);
+  line-height:1.55;
+}
+.feature__bullets li::before{
+  content:counter(li,decimal-leading-zero);
+  counter-increment:li;
+  font-family:'JetBrains Mono',monospace;
+  font-size:11px;color:var(--accent);margin-top:3px;font-weight:500;
+}
+.feature__bullets li:last-child{border-bottom:1px solid var(--border);}
+
+.feature__chips{display:flex;flex-wrap:wrap;gap:8px;}
+.chip{
+  display:inline-flex;align-items:center;gap:6px;
+  padding:6px 12px;border-radius:999px;
+  background:transparent;border:1px solid var(--border-strong);
+  font-family:'JetBrains Mono',monospace;
+  font-size:10.5px;color:var(--ink-2);letter-spacing:0.02em;
+}
+.chip--ink{background:var(--ink);color:#fff;border-color:var(--ink);}
+.chip--accent{background:var(--accent-soft);color:var(--accent-deep);border-color:transparent;}
+
+/* ============ MOCKUP CANVAS ============ */
+.mockup{
+  background:linear-gradient(180deg,var(--surface-alt) 0%,#ECECF1 100%);
+  border:1px solid var(--border);
+  border-radius:var(--r-lg);
+  padding:48px;
+  position:relative;
+  overflow:hidden;
+  min-height:480px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+}
+.mockup::before{
+  content:"";
+  position:absolute;inset:0;
+  background-image:radial-gradient(circle at 1px 1px,rgba(14,14,20,0.06) 1px,transparent 0);
+  background-size:24px 24px;
+  pointer-events:none;
+  mask-image:radial-gradient(ellipse at center,#000 30%,transparent 75%);
+}
+.mockup__cap{
+  position:absolute;
+  top:20px;left:24px;
+  font-family:'JetBrains Mono',monospace;
+  font-size:10px;color:var(--muted);letter-spacing:0.1em;
+  text-transform:uppercase;
+  display:flex;align-items:center;gap:8px;
+  z-index:2;
+}
+.mockup__cap::before{
+  content:"";width:6px;height:6px;background:var(--accent);border-radius:50%;
+  box-shadow:0 0 0 3px var(--accent-soft);
+}
+.mockup__content{position:relative;z-index:1;width:100%;}
+
+/* ============================================================
+   MOCKUP 1 — BOOKMARK
+   ============================================================ */
+.mk1{display:flex;flex-direction:column;gap:24px;align-items:center;}
+.mk1__tabs{
+  display:inline-flex;gap:0;
+  background:var(--surface);border:1px solid var(--border);
+  border-radius:999px;padding:4px;
+  box-shadow:0 1px 2px rgba(14,14,20,0.04);
+}
+.mk1__tab{
+  padding:8px 18px;border-radius:999px;
+  font-size:13px;font-weight:600;color:var(--muted);
+  display:inline-flex;align-items:center;gap:8px;
+  transition:all .2s;
+}
+.mk1__tab.is-active{background:var(--ink);color:#fff;}
+.mk1__tab span{
+  font-family:'JetBrains Mono',monospace;
+  font-size:10px;font-weight:500;
+  padding:2px 6px;background:rgba(255,255,255,0.18);border-radius:999px;
+}
+.mk1__tab:not(.is-active) span{background:var(--surface-alt);color:var(--muted);}
+
+.mk1__grid{
+  display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:16px;
+  width:100%;max-width:680px;
+}
+.evcard{
+  background:var(--surface);
+  border:1px solid var(--border);
+  border-radius:var(--r);
+  overflow:hidden;
+  position:relative;
+  transition:transform .2s,box-shadow .2s;
+}
+.evcard__thumb{height:100px;position:relative;}
+.evcard__thumb.g1{background:linear-gradient(135deg,#0043FF 0%,#7B9DFF 100%);}
+.evcard__thumb.g2{background:linear-gradient(135deg,#FF6A00 0%,#FFB155 100%);}
+.evcard__thumb.g3{background:linear-gradient(135deg,#0FA968 0%,#7DDBA8 100%);}
+.evcard__thumb.g4{background:linear-gradient(135deg,#9C27B0 0%,#D580E3 100%);}
+.evcard__thumb::after{
+  content:"";position:absolute;inset:0;
+  background:radial-gradient(circle at 80% 20%,rgba(255,255,255,0.3),transparent 60%);
+}
+.evcard__bookmark{
+  position:absolute;top:8px;right:8px;
+  width:32px;height:32px;border-radius:50%;
+  background:rgba(255,255,255,0.92);
+  backdrop-filter:blur(8px);
+  display:flex;align-items:center;justify-content:center;
+  color:var(--muted);
+  transition:all .2s;
+  z-index:3;
+}
+.evcard__bookmark.is-on{background:var(--accent);color:#fff;}
+.evcard__bookmark svg{width:14px;height:14px;}
+.evcard__body{padding:14px;}
+.evcard__tag{
+  display:inline-block;
+  font-size:10px;font-weight:600;
+  color:var(--accent);
+  background:var(--accent-soft);
+  padding:3px 8px;border-radius:6px;
+  margin-bottom:8px;letter-spacing:0.02em;
+}
+.evcard__title{
+  font-size:14px;font-weight:700;
+  letter-spacing:-0.01em;
+  line-height:1.3;margin-bottom:6px;
+  color:var(--ink);
+}
+.evcard__meta{font-size:11px;color:var(--muted);}
+
+.mk1__toast{
+  display:inline-flex;align-items:center;gap:12px;
+  padding:12px 18px;
+  background:var(--ink);color:#fff;
+  border-radius:999px;
+  font-size:13px;font-weight:500;
+  box-shadow:0 8px 24px rgba(14,14,20,0.18);
+}
+.mk1__toast svg{color:var(--success);}
+.mk1__toast b{color:var(--accent-soft);font-weight:600;cursor:pointer;}
+
+/* ============================================================
+   MOCKUP 2 — CALENDAR EXPORT
+   ============================================================ */
+.mk2{width:100%;max-width:540px;margin:0 auto;}
+.mk2__card{
+  background:var(--surface);
+  border:1px solid var(--border);
+  border-radius:var(--r-lg);
+  padding:28px;
+  position:relative;
+}
+.mk2__tag{
+  display:inline-block;
+  font-size:10px;font-weight:600;letter-spacing:0.04em;
+  color:var(--accent);background:var(--accent-soft);
+  padding:4px 10px;border-radius:6px;
+  margin-bottom:14px;
+}
+.mk2__title{
+  font-size:22px;font-weight:800;letter-spacing:-0.02em;
+  margin-bottom:8px;line-height:1.25;
+}
+.mk2__meta{font-size:13px;color:var(--muted);margin-bottom:24px;}
+.mk2__actions{display:flex;gap:8px;position:relative;}
+.btn{
+  padding:10px 16px;border-radius:var(--r);
+  font-size:13px;font-weight:600;
+  display:inline-flex;align-items:center;gap:6px;
+  transition:all .15s;letter-spacing:-0.005em;
+}
+.btn--primary{background:var(--accent);color:#fff;}
+.btn--ghost{background:var(--surface);color:var(--ink);border:1px solid var(--border-strong);}
+.btn--ghost:hover{border-color:var(--ink);}
+.btn svg{width:13px;height:13px;}
+
+.mk2__dropdown{
+  position:absolute;
+  top:calc(100% + 8px);right:0;
+  width:280px;
+  background:var(--surface);
+  border:1px solid var(--border);
+  border-radius:var(--r);
+  box-shadow:0 12px 36px rgba(14,14,20,0.14),0 2px 6px rgba(14,14,20,0.04);
+  overflow:hidden;
+  z-index:5;
+  animation:dropdown-in .25s cubic-bezier(.2,.8,.2,1);
+}
+@keyframes dropdown-in{from{opacity:0;transform:translateY(-6px);}to{opacity:1;transform:translateY(0);}}
+.mk2__dropdown-head{
+  font-size:10px;letter-spacing:0.12em;text-transform:uppercase;
+  color:var(--muted);font-weight:600;
+  padding:14px 16px 8px;
+}
+.mk2__dropdown-item{
+  width:100%;
+  display:flex;align-items:center;gap:12px;
+  padding:10px 16px;
+  font-size:13.5px;font-weight:500;
+  transition:background .15s;
+  text-align:left;
+}
+.mk2__dropdown-item:hover{background:var(--surface-alt);}
+.mk2__icon{
+  width:28px;height:28px;border-radius:8px;
+  display:flex;align-items:center;justify-content:center;
+  font-size:13px;font-weight:800;color:#fff;
+  letter-spacing:-0.02em;
+  font-family:-apple-system,system-ui;
+}
+.mk2__icon--apple{background:#0E0E14;}
+.mk2__icon--google{background:#4285F4;}
+.mk2__icon--naver{background:#03C75A;}
+.mk2__icon--outlook{background:#0078D4;}
+.mk2__ext{
+  margin-left:auto;font-family:'JetBrains Mono',monospace;
+  font-size:10px;color:var(--muted);
+}
+.mk2__divider{height:1px;background:var(--border);margin:6px 0;}
+
+/* ============================================================
+   MOCKUP 3 — NOTIFICATION
+   ============================================================ */
+.mk3{width:100%;max-width:540px;display:flex;flex-direction:column;gap:20px;}
+.mk3__pop{
+  background:var(--surface);
+  border:1px solid var(--border);
+  border-radius:var(--r);
+  padding:16px;
+  display:flex;gap:14px;
+  box-shadow:0 14px 40px rgba(14,14,20,0.16),0 2px 8px rgba(14,14,20,0.06);
+  position:relative;
+}
+.mk3__pop::after{
+  content:"macOS notification";
+  position:absolute;top:-22px;right:0;
+  font-family:'JetBrains Mono',monospace;
+  font-size:9px;color:var(--muted);letter-spacing:0.08em;
+}
+.mk3__icon{
+  width:40px;height:40px;flex-shrink:0;
+  border-radius:10px;
+  background:linear-gradient(135deg,var(--accent),var(--accent-deep));
+  display:flex;align-items:center;justify-content:center;
+  color:#fff;
+}
+.mk3__body{flex:1;min-width:0;}
+.mk3__app{
+  font-size:10px;font-weight:600;color:var(--muted);
+  letter-spacing:0.02em;margin-bottom:4px;
+  display:flex;justify-content:space-between;
+}
+.mk3__app time{font-family:'JetBrains Mono',monospace;}
+.mk3__head{
+  font-size:14px;font-weight:700;letter-spacing:-0.01em;
+  line-height:1.3;margin-bottom:4px;
+}
+.mk3__text{font-size:12.5px;color:var(--muted);line-height:1.45;margin-bottom:10px;}
+.mk3__actions{display:flex;gap:6px;}
+.mk3__btn{
+  padding:6px 12px;border-radius:6px;
+  font-size:11.5px;font-weight:600;
+  background:var(--surface-alt);color:var(--ink-2);
+}
+.mk3__btn--primary{background:var(--ink);color:#fff;}
+
+.mk3__settings{
+  background:var(--surface);border:1px solid var(--border);
+  border-radius:var(--r);
+  overflow:hidden;
+}
+.mk3__set-head{
+  padding:12px 16px;
+  font-size:10px;font-weight:700;color:var(--muted);
+  letter-spacing:0.12em;text-transform:uppercase;
+  border-bottom:1px solid var(--border);
+}
+.mk3__set-row{
+  padding:16px;display:flex;align-items:center;justify-content:space-between;gap:16px;
+  border-bottom:1px solid var(--border);
+}
+.mk3__set-row:last-child{border-bottom:none;}
+.mk3__set-label{font-size:13px;font-weight:600;margin-bottom:2px;}
+.mk3__set-hint{font-size:11px;color:var(--muted);}
+.mk3__radio{
+  display:inline-flex;background:var(--surface-alt);
+  border-radius:8px;padding:3px;gap:2px;
+  border:1px solid var(--border);
+}
+.mk3__radio button{
+  padding:5px 10px;border-radius:6px;
+  font-size:11px;font-weight:600;color:var(--muted);
+}
+.mk3__radio button.is-active{background:var(--surface);color:var(--ink);box-shadow:0 1px 2px rgba(0,0,0,0.06);}
+.mk3__status{
+  display:inline-flex;align-items:center;gap:6px;
+  font-size:12px;font-weight:600;color:var(--success);
+}
+.mk3__dot{width:6px;height:6px;border-radius:50%;background:var(--success);box-shadow:0 0 0 3px rgba(15,169,104,0.15);}
+
+/* ============================================================
+   MOCKUP 4 — DARK MODE
+   ============================================================ */
+.mk4{
+  display:flex;align-items:center;gap:32px;justify-content:center;width:100%;
+}
+.phone{
+  width:200px;flex-shrink:0;
+  background:#0E0E14;
+  border-radius:32px;
+  padding:8px;
+  box-shadow:0 24px 60px rgba(14,14,20,0.18),0 4px 12px rgba(14,14,20,0.08);
+  position:relative;
+}
+.phone__notch{
+  width:60px;height:18px;
+  background:#000;
+  border-radius:0 0 14px 14px;
+  margin:0 auto 4px;
+}
+.phone__screen{
+  background:var(--surface);
+  border-radius:24px;
+  padding:16px;
+  min-height:340px;
+  overflow:hidden;
+}
+.phone__nav{
+  display:flex;justify-content:space-between;align-items:center;
+  margin-bottom:14px;
+  font-size:13px;font-weight:800;letter-spacing:-0.02em;
+}
+.phone__nav span{
+  font-size:10px;color:var(--muted);font-weight:500;
+}
+.mini-card{
+  border:1px solid var(--border);
+  border-radius:10px;
+  padding:12px;margin-bottom:8px;
+}
+.mini-card__tag{
+  font-size:8.5px;font-weight:700;
+  color:var(--accent);background:var(--accent-soft);
+  display:inline-block;padding:2px 6px;border-radius:4px;
+  margin-bottom:6px;letter-spacing:0.04em;
+}
+.mini-card h5{font-size:11.5px;font-weight:700;letter-spacing:-0.01em;margin-bottom:3px;}
+.mini-card p{font-size:9.5px;color:var(--muted);}
+.mini-card__cta{
+  font-size:10px;font-weight:600;color:var(--accent);
+  margin-top:8px;display:flex;align-items:center;gap:4px;
+}
+
+.phone--dark .phone__screen{background:#14141C;}
+.phone--dark .phone__nav{color:#F2F2F7;}
+.phone--dark .mini-card{border-color:#26262E;background:#1A1A24;}
+.phone--dark .mini-card h5{color:#F2F2F7;}
+.phone--dark .mini-card p{color:#8C8C96;}
+.phone--dark .mini-card__tag{background:rgba(92,124,255,0.15);color:#7C9AFF;}
+.phone--dark .mini-card__cta{color:#7C9AFF;}
+
+.mk4__toggle{
+  display:flex;flex-direction:column;align-items:center;gap:14px;
+}
+.toggle{
+  width:64px;height:32px;
+  background:linear-gradient(90deg,#FFC857 0%,var(--ink) 100%);
+  border-radius:999px;
+  position:relative;
+  padding:3px;
+  display:flex;align-items:center;justify-content:space-between;
+  font-size:12px;
+  box-shadow:inset 0 1px 3px rgba(0,0,0,0.2);
+}
+.toggle__sun,.toggle__moon{
+  width:26px;height:26px;
+  display:flex;align-items:center;justify-content:center;
+  z-index:1;color:rgba(255,255,255,0.7);
+}
+.toggle__knob{
+  position:absolute;top:3px;left:50%;
+  transform:translateX(-50%);
+  width:26px;height:26px;
+  background:var(--surface);
+  border-radius:50%;
+  box-shadow:0 2px 6px rgba(0,0,0,0.2);
+  z-index:2;
+}
+.mk4__code{
+  font-family:'JetBrains Mono',monospace;
+  font-size:10px;color:var(--muted);
+  background:var(--surface);
+  padding:6px 10px;border-radius:6px;
+  border:1px solid var(--border);
+  white-space:nowrap;
+}
+
+/* ============================================================
+   MOCKUP 5 — FILTER URL / PRESETS
+   ============================================================ */
+.mk5{width:100%;display:flex;flex-direction:column;gap:16px;max-width:680px;margin:0 auto;}
+.mk5__bar{
+  background:var(--surface);
+  border:1px solid var(--border);
+  border-radius:var(--r);
+  padding:14px;
+  display:flex;align-items:center;gap:8px;flex-wrap:wrap;
+}
+.fchip{
+  display:inline-flex;align-items:center;gap:6px;
+  padding:6px 10px 6px 12px;
+  background:var(--ink);color:#fff;
+  border-radius:999px;
+  font-size:12px;font-weight:600;letter-spacing:-0.01em;
+}
+.fchip svg{cursor:pointer;opacity:0.6;}
+.mk5__bar-spacer{flex:1;}
+
+.mk5__copied{
+  background:var(--surface);
+  border:1px solid var(--border);
+  border-left:3px solid var(--accent);
+  border-radius:var(--r);
+  padding:14px 18px;
+  display:flex;align-items:center;gap:12px;
+  font-size:13px;
+}
+.mk5__copied svg{color:var(--accent);flex-shrink:0;}
+.mk5__copied code{
+  margin-left:auto;
+  font-family:'JetBrains Mono',monospace;
+  font-size:11px;
+  background:var(--surface-alt);
+  padding:4px 8px;border-radius:6px;
+  color:var(--ink-2);
+  border:1px solid var(--border);
+}
+
+.mk5__panel{
+  background:var(--surface);
+  border:1px solid var(--border);
+  border-radius:var(--r);
+  overflow:hidden;
+}
+.mk5__panel-head{
+  padding:12px 16px;
+  display:flex;justify-content:space-between;align-items:center;
+  border-bottom:1px solid var(--border);
+  font-size:11px;letter-spacing:0.12em;text-transform:uppercase;
+  color:var(--muted);font-weight:700;
+}
+.mk5__panel-head span:last-child{
+  font-family:'JetBrains Mono',monospace;color:var(--ink);
+}
+.mk5__preset{
+  display:flex;align-items:center;gap:14px;
+  padding:14px 16px;
+  border-bottom:1px solid var(--border);
+  transition:background .15s;
+  cursor:pointer;
+}
+.mk5__preset:hover{background:var(--surface-alt);}
+.mk5__preset:last-child{border-bottom:none;}
+.mk5__star{
+  width:28px;height:28px;border-radius:8px;
+  background:var(--accent-soft);color:var(--accent);
+  display:flex;align-items:center;justify-content:center;
+  flex-shrink:0;
+}
+.mk5__pname{font-size:13.5px;font-weight:700;margin-bottom:2px;letter-spacing:-0.01em;}
+.mk5__phint{font-size:11px;color:var(--muted);}
+.mk5__apply{
+  margin-left:auto;
+  padding:6px 12px;
+  background:var(--surface-alt);
+  border-radius:8px;
+  font-size:11.5px;font-weight:600;color:var(--ink-2);
+}
+.mk5__preset:hover .mk5__apply{background:var(--accent);color:#fff;}
+
+/* ============================================================
+   MOCKUP 6 — COUNTDOWN
+   ============================================================ */
+.mk6{
+  width:100%;max-width:360px;margin:0 auto;
+  background:var(--surface);
+  border:1px solid var(--border);
+  border-radius:var(--r-lg);
+  padding:28px;
+  position:relative;
+  overflow:hidden;
+}
+.mk6::before{
+  content:"";position:absolute;
+  top:-40px;right:-40px;
+  width:160px;height:160px;
+  background:radial-gradient(circle,var(--accent-soft) 0%,transparent 70%);
+  pointer-events:none;
+}
+.mk6__head{
+  display:flex;justify-content:space-between;align-items:center;
+  margin-bottom:24px;position:relative;
+}
+.mk6__label{
+  font-size:11px;letter-spacing:0.12em;text-transform:uppercase;
+  color:var(--muted);font-weight:700;
+}
+.mk6__pill{
+  font-family:'JetBrains Mono',monospace;
+  font-size:11px;font-weight:500;
+  background:var(--ink);color:#fff;
+  padding:3px 9px;border-radius:999px;
+}
+.mk6__dday{
+  font-size:88px;
+  font-weight:800;
+  letter-spacing:-0.05em;
+  color:var(--accent);
+  line-height:0.95;
+  margin-bottom:16px;
+  font-family:'Pretendard Variable';
+}
+.mk6__dday small{
+  font-size:36px;font-weight:700;
+  font-family:'Instrument Serif',serif;
+  font-style:italic;
+  vertical-align:0.4em;
+  margin-right:2px;
+}
+.mk6__progress{
+  height:6px;
+  background:var(--surface-alt);
+  border-radius:999px;overflow:hidden;
+  margin-bottom:24px;position:relative;
+}
+.mk6__progress-fill{
+  height:100%;
+  background:linear-gradient(90deg,var(--accent) 0%,#7B9DFF 100%);
+  border-radius:999px;
+  position:relative;
+}
+.mk6__progress-fill::after{
+  content:"";position:absolute;right:-3px;top:-3px;
+  width:12px;height:12px;border-radius:50%;
+  background:var(--accent);
+  box-shadow:0 0 0 3px var(--accent-soft);
+}
+.mk6__title{
+  font-size:20px;font-weight:800;
+  letter-spacing:-0.02em;line-height:1.25;
+  margin-bottom:6px;
+}
+.mk6__meta{font-size:12.5px;color:var(--muted);margin-bottom:24px;line-height:1.5;}
+.mk6__next{
+  border-top:1px solid var(--border);
+  padding-top:16px;
+}
+.mk6__next-label{
+  font-size:10px;letter-spacing:0.12em;text-transform:uppercase;
+  color:var(--muted);font-weight:700;margin-bottom:12px;
+}
+.mk6__next-list{list-style:none;display:flex;flex-direction:column;gap:10px;}
+.mk6__next-list li{
+  display:flex;align-items:center;gap:10px;
+  font-size:12.5px;font-weight:500;
+}
+.mk6__next-list .mono{
+  font-size:10.5px;color:var(--accent);
+  background:var(--accent-soft);padding:2px 6px;border-radius:4px;font-weight:600;
+}
+.mk6__next-list em{margin-left:auto;font-style:normal;color:var(--muted);font-size:11px;}
+
+/* ============================================================
+   MOCKUP 7 — COMPARISON
+   ============================================================ */
+.mk7{width:100%;max-width:880px;margin:0 auto;}
+.mk7__head{
+  display:flex;justify-content:space-between;align-items:center;
+  margin-bottom:16px;
+}
+.mk7__head h3{font-size:16px;font-weight:700;letter-spacing:-0.01em;}
+.mk7__head h3 span{color:var(--muted);font-weight:500;margin-left:6px;}
+.mk7__table{
+  width:100%;
+  background:var(--surface);
+  border:1px solid var(--border);
+  border-radius:var(--r);
+  border-collapse:separate;
+  border-spacing:0;
+  overflow:hidden;
+}
+.mk7__table thead th{
+  padding:20px 18px;
+  text-align:left;
+  vertical-align:top;
+  border-bottom:1px solid var(--border);
+  background:var(--surface-alt);
+}
+.mk7__table thead th:first-child{width:100px;background:var(--surface);}
+.mk7__table tbody th{
+  padding:14px 18px;
+  text-align:left;
+  font-size:11px;font-weight:700;
+  letter-spacing:0.06em;text-transform:uppercase;
+  color:var(--muted);
+  border-bottom:1px solid var(--border);
+  background:var(--surface);
+  width:120px;
+}
+.mk7__table tbody td{
+  padding:14px 18px;
+  font-size:13.5px;
+  border-bottom:1px solid var(--border);
+  vertical-align:middle;
+  color:var(--ink-2);
+}
+.mk7__table tbody tr:last-child th,
+.mk7__table tbody tr:last-child td{border-bottom:none;}
+.mk7__table td strong,.mk7__table td b{color:var(--ink);font-weight:700;}
+
+.mk7__thumb{
+  width:64px;height:64px;
+  border-radius:10px;
+  margin-bottom:12px;
+  background:linear-gradient(135deg,var(--accent),var(--accent-deep));
+}
+.mk7__thumb.g2{background:linear-gradient(135deg,#FF6A00,#E32C2C);}
+.mk7__col-title{font-size:15px;font-weight:800;letter-spacing:-0.015em;line-height:1.25;margin-bottom:6px;}
+.mk7__col-tag{
+  display:inline-block;
+  font-size:10px;font-weight:700;letter-spacing:0.04em;
+  color:var(--accent);background:var(--accent-soft);
+  padding:2px 8px;border-radius:4px;
+}
+.pill{
+  display:inline-block;
+  padding:3px 9px;border-radius:999px;
+  font-size:11.5px;font-weight:700;
+}
+.pill--good{background:rgba(15,169,104,0.12);color:var(--success);}
+.pill--warn{background:rgba(255,106,0,0.12);color:var(--warn);}
+.mk7__highlight{
+  background:var(--accent-soft);
+  margin:-6px -10px;padding:6px 10px;border-radius:6px;
+  display:inline-block;
+}
+.mk7__warn-note{
+  display:inline-block;
+  font-size:10.5px;color:var(--warn);font-weight:600;
+  margin-left:6px;
+  background:rgba(255,106,0,0.1);
+  padding:2px 6px;border-radius:4px;
+}
+
+/* ============================================================
+   MOCKUP 8 — COMMAND PALETTE
+   ============================================================ */
+.mk8{
+  width:100%;max-width:540px;
+  margin:0 auto;
+  position:relative;
+}
+.mk8__bg{
+  position:absolute;inset:-40px;
+  background:rgba(14,14,20,0.06);
+  backdrop-filter:blur(4px);
+  border-radius:32px;
+  z-index:0;
+}
+.palette{
+  background:var(--surface);
+  border:1px solid var(--border);
+  border-radius:14px;
+  overflow:hidden;
+  box-shadow:0 24px 60px rgba(14,14,20,0.18),0 4px 12px rgba(14,14,20,0.06);
+  position:relative;
+  z-index:1;
+}
+.palette__search{
+  padding:16px 18px;
+  display:flex;align-items:center;gap:12px;
+  border-bottom:1px solid var(--border);
+}
+.palette__search svg{color:var(--muted);flex-shrink:0;}
+.palette__search input{
+  flex:1;border:none;outline:none;
+  background:transparent;
+  font:inherit;font-size:15px;font-weight:500;
+  letter-spacing:-0.01em;
+  color:var(--ink);
+  font-family:'Pretendard Variable';
+}
+.palette__search input::placeholder{color:var(--muted-2);}
+.palette__body{padding:8px 0;max-height:380px;overflow:auto;}
+.palette__section{padding:6px 0;}
+.palette__sectitle{
+  padding:6px 18px;
+  font-size:10px;font-weight:700;letter-spacing:0.14em;text-transform:uppercase;
+  color:var(--muted);
+}
+.palette__row{
+  width:100%;display:flex;align-items:center;gap:12px;
+  padding:10px 18px;
+  font-size:14px;font-weight:500;
+  text-align:left;
+  transition:background .1s;
+}
+.palette__row span{flex:1;letter-spacing:-0.005em;}
+.palette__row:hover{background:var(--surface-alt);}
+.palette__row.is-active{
+  background:var(--accent-soft);
+  color:var(--accent-deep);
+  position:relative;
+}
+.palette__row.is-active::before{
+  content:"";position:absolute;left:0;top:6px;bottom:6px;width:3px;
+  background:var(--accent);border-radius:0 3px 3px 0;
+}
+.palette__row .keys{display:inline-flex;gap:3px;}
+.palette__foot{
+  padding:10px 18px;
+  background:var(--surface-alt);
+  border-top:1px solid var(--border);
+  display:flex;gap:18px;align-items:center;
+  font-size:11px;color:var(--muted);
+}
+.palette__foot kbd{font-size:9.5px;padding:1px 5px;}
+.palette__hint{margin-left:auto;}
+
+/* ============ FOOTER ============ */
+.footer{
+  max-width:1280px;margin:0 auto;
+  padding:96px 48px 64px;
+  border-top:1px solid var(--ink);
+}
+.footer__grid{
+  display:grid;
+  grid-template-columns:2fr 1fr 1fr;
+  gap:48px;
+  margin-bottom:64px;
+}
+.footer__bigline{
+  font-size:clamp(28px,3vw,40px);
+  font-weight:600;
+  letter-spacing:-0.03em;
+  line-height:1.2;
+  max-width:540px;
+}
+.footer__bigline em{
+  font-family:'Instrument Serif',serif;
+  font-style:italic;
+  font-weight:400;
+  color:var(--accent);
+}
+.footer__col h6{
+  font-size:11px;letter-spacing:0.14em;text-transform:uppercase;
+  color:var(--muted);margin-bottom:14px;font-weight:700;
+}
+.footer__col ul{list-style:none;}
+.footer__col li{
+  padding:8px 0;font-size:13.5px;font-weight:500;
+  border-top:1px solid var(--border);
+  display:flex;justify-content:space-between;align-items:center;
+  letter-spacing:-0.005em;
+}
+.footer__col li:first-child{border-top:none;}
+.footer__col li .mono{font-size:11px;color:var(--muted);}
+.footer__bottom{
+  display:flex;justify-content:space-between;align-items:baseline;
+  font-size:11.5px;color:var(--muted);
+  font-family:'JetBrains Mono',monospace;
+  letter-spacing:0.04em;
+}
+
+/* ============ RESPONSIVE ============ */
+@media (max-width:920px){
+  .topbar__nav{display:none;}
+  .hero,.feature,.footer,.toc{padding-left:24px;padding-right:24px;}
+  .hero{padding-top:56px;padding-bottom:72px;}
+  .feature{padding-top:80px;padding-bottom:80px;}
+  .hero__meta{grid-template-columns:repeat(2,1fr);gap:24px;}
+  .toc__inner{grid-template-columns:repeat(2,1fr);}
+  .feature__layout.split,.feature__layout.split-rev{grid-template-columns:1fr;gap:48px;}
+  .feature__layout.split-rev .feature__head{order:0;}
+  .feature__num{font-size:72px;}
+  .mockup{padding:24px;min-height:auto;}
+  .mk1__grid{grid-template-columns:repeat(2,1fr);}
+  .mk4{flex-direction:column;}
+  .phone{width:170px;}
+  .mk7__table thead th{padding:12px;}
+  .mk7__table tbody th,.mk7__table tbody td{padding:10px 12px;font-size:12px;}
+  .footer__grid{grid-template-columns:1fr;gap:32px;}
+}
+</style>
+</head>
+<body>
+
+<!-- ============ TOP BAR ============ -->
+<div class="topbar">
+  <div class="topbar__inner">
+    <div class="topbar__logo">dev<b>·</b>event<b>/</b><span style="color:var(--muted);font-weight:500;">mockups</span></div>
+    <nav class="topbar__nav">
+      <a href="#f01">01 북마크</a>
+      <a href="#f02">02 캘린더</a>
+      <a href="#f03">03 알림</a>
+      <a href="#f04">04 다크모드</a>
+      <a href="#f05">05 프리셋</a>
+      <a href="#f06">06 카운트다운</a>
+      <a href="#f07">07 비교</a>
+      <a href="#f08">08 단축키</a>
+    </nav>
+    <div class="topbar__date">2026.05.15 · v0.1</div>
+  </div>
+</div>
+
+<!-- ============ HERO ============ -->
+<section class="hero">
+  <div class="hero__eyebrow">DEV EVENT WEB · FEATURE PROPOSAL</div>
+  <h1>프론트엔드만으로<br>충분히 <em>멋진</em><br>여덟 가지.</h1>
+  <p class="hero__lede">
+    백엔드 변경 없이 <mark>localStorage · 브라우저 API · 클라이언트 가공</mark>만으로
+    완성할 수 있는 기능 제안서. 각 항목은 1~3일 안에 마감 가능한 단위로 쪼개졌고,
+    KTB 디자인 시스템(Pretendard · Tech Blue · 12/24px radius)을 그대로 따릅니다.
+  </p>
+  <dl class="hero__meta">
+    <div><dt>스택</dt><dd>Next.js 12 <b>· React 17</b></dd></div>
+    <div><dt>저장소</dt><dd>localStorage <b>· URL</b></dd></div>
+    <div><dt>API 변경</dt><dd>없음 <b>· zero</b></dd></div>
+    <div><dt>예상 공수</dt><dd>1~3일 × 8 <b>· 약 2주</b></dd></div>
+  </dl>
+</section>
+
+<!-- ============ TOC ============ -->
+<section class="toc">
+  <div class="toc__inner">
+    <a class="toc__item" href="#f01"><div class="toc__num">01</div><div class="toc__title">관심 행사 북마크</div><div class="toc__hint">localStorage · 1.5d</div></a>
+    <a class="toc__item" href="#f02"><div class="toc__num">02</div><div class="toc__title">캘린더 내보내기</div><div class="toc__hint">.ics · 1d</div></a>
+    <a class="toc__item" href="#f03"><div class="toc__num">03</div><div class="toc__title">시작 전 알림</div><div class="toc__hint">Notification · 2d</div></a>
+    <a class="toc__item" href="#f04"><div class="toc__num">04</div><div class="toc__title">다크모드</div><div class="toc__hint">CSS Variables · 2d</div></a>
+    <a class="toc__item" href="#f05"><div class="toc__num">05</div><div class="toc__title">필터 URL · 프리셋</div><div class="toc__hint">URLSearchParams · 1.5d</div></a>
+    <a class="toc__item" href="#f06"><div class="toc__num">06</div><div class="toc__title">다가오는 행사 위젯</div><div class="toc__hint">Date arithmetic · 0.5d</div></a>
+    <a class="toc__item" href="#f07"><div class="toc__num">07</div><div class="toc__title">행사 비교 모드</div><div class="toc__hint">Client state · 1.5d</div></a>
+    <a class="toc__item" href="#f08"><div class="toc__num">08</div><div class="toc__title">키보드 단축키 + ⌘K</div><div class="toc__hint">KeyboardEvent · 2d</div></a>
+  </div>
+</section>
+
+<!-- ============================================================
+     FEATURE 01 — BOOKMARK
+     ============================================================ -->
+<section class="feature" id="f01">
+  <div class="feature__layout split">
+    <div class="feature__head">
+      <div class="feature__num">01</div>
+      <div class="feature__label">Bookmark · localStorage</div>
+      <h2 class="feature__title">관심 행사를 <em>별표</em>로 묶어두기</h2>
+      <p class="feature__lede">
+        로그인 없이도 동작하는 클라이언트 사이드 북마크. 카드 우상단의 별 아이콘으로
+        토글하고, <code class="mono" style="font-size:13px;background:var(--surface-alt);padding:2px 6px;border-radius:4px;">/events/bookmarks</code>
+        라우트에서 모아 봅니다.
+      </p>
+      <ol class="feature__bullets">
+        <li><code class="mono" style="font-size:12px;">EventContext</code>에 <code class="mono" style="font-size:12px;">bookmarkedIds: Set&lt;number&gt;</code> 추가, localStorage에 mirror.</li>
+        <li>카드/상세/캘린더 셀에서 동일한 토글 인터랙션 — 별 채움 + 살짝 튀어오르는 spring 모션.</li>
+        <li>토스트로 즉시 피드백, "실행 취소"로 5초간 되돌릴 수 있음.</li>
+        <li>나중에 백엔드 동기화가 필요해지면 동일한 인터페이스 뒤에 API만 끼우면 됨.</li>
+      </ol>
+      <div class="feature__chips">
+        <span class="chip chip--ink">1.5 days</span>
+        <span class="chip">localStorage</span>
+        <span class="chip">no API change</span>
+        <span class="chip chip--accent">High impact</span>
+      </div>
+    </div>
+
+    <div class="mockup">
+      <span class="mockup__cap">/events/bookmarks</span>
+      <div class="mockup__content">
+        <div class="mk1">
+          <div class="mk1__tabs">
+            <button class="mk1__tab">전체 <span>124</span></button>
+            <button class="mk1__tab is-active">북마크 <span>12</span></button>
+            <button class="mk1__tab">지난 행사 <span>89</span></button>
+          </div>
+
+          <div class="mk1__grid">
+            <article class="evcard">
+              <div class="evcard__thumb g1"></div>
+              <button class="evcard__bookmark is-on" aria-label="북마크됨">
+                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 17.3l-6.2 3.7 1.6-7-5.4-4.7 7.1-.6L12 2l2.9 6.7 7.1.6-5.4 4.7 1.6 7z"/></svg>
+              </button>
+              <div class="evcard__body">
+                <div class="evcard__tag">컨퍼런스</div>
+                <div class="evcard__title">FEConf Korea 2026</div>
+                <div class="evcard__meta">5월 18일 · 코엑스</div>
+              </div>
+            </article>
+
+            <article class="evcard">
+              <div class="evcard__thumb g2"></div>
+              <button class="evcard__bookmark is-on" aria-label="북마크됨">
+                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 17.3l-6.2 3.7 1.6-7-5.4-4.7 7.1-.6L12 2l2.9 6.7 7.1.6-5.4 4.7 1.6 7z"/></svg>
+              </button>
+              <div class="evcard__body">
+                <div class="evcard__tag">웨비나</div>
+                <div class="evcard__title">Next.js 16 Deep Dive</div>
+                <div class="evcard__meta">5월 20일 · 온라인</div>
+              </div>
+            </article>
+
+            <article class="evcard">
+              <div class="evcard__thumb g3"></div>
+              <button class="evcard__bookmark is-on" aria-label="북마크됨">
+                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 17.3l-6.2 3.7 1.6-7-5.4-4.7 7.1-.6L12 2l2.9 6.7 7.1.6-5.4 4.7 1.6 7z"/></svg>
+              </button>
+              <div class="evcard__body">
+                <div class="evcard__tag">해커톤</div>
+                <div class="evcard__title">서울 디지털 해커톤</div>
+                <div class="evcard__meta">5월 25일 · 동대문</div>
+              </div>
+            </article>
+          </div>
+
+          <div class="mk1__toast">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg>
+            <span>북마크에 저장했어요</span>
+            <b>실행 취소</b>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     FEATURE 02 — CALENDAR EXPORT
+     ============================================================ -->
+<section class="feature" id="f02">
+  <div class="feature__layout split-rev">
+    <div class="feature__head">
+      <div class="feature__num">02</div>
+      <div class="feature__label">Calendar Export · .ics</div>
+      <h2 class="feature__title">내 캘린더에<br><em>한 번에</em> 꽂아두기</h2>
+      <p class="feature__lede">
+        행사 상세에서 클릭 한 번으로 Apple · Google · Naver · Outlook 어디든 추가.
+        <code class="mono" style="font-size:13px;background:var(--surface-alt);padding:2px 6px;border-radius:4px;">.ics</code> 파일은
+        클라이언트에서 30줄 정도의 RFC 5545 포맷터로 직접 생성합니다.
+      </p>
+      <ol class="feature__bullets">
+        <li>모델의 <code class="mono" style="font-size:12px;">use_start_date_time_yn === 'N'</code> 이면 자동으로 <b>all-day</b> 이벤트로 처리.</li>
+        <li>Google Calendar는 <code class="mono" style="font-size:12px;">calendar.google.com/render?action=TEMPLATE</code> 쿼리 조립만으로 새 탭.</li>
+        <li>다중일 행사(<code class="mono" style="font-size:12px;">end_date_time</code> 까지)와 알람(<code class="mono" style="font-size:12px;">VALARM</code>) 포함.</li>
+        <li>외부 라이브러리 없이 25KB → 0KB. 번들 영향 zero.</li>
+      </ol>
+      <div class="feature__chips">
+        <span class="chip chip--ink">1 day</span>
+        <span class="chip">RFC 5545</span>
+        <span class="chip">no deps</span>
+        <span class="chip chip--accent">High intent</span>
+      </div>
+    </div>
+
+    <div class="mockup">
+      <span class="mockup__cap">events/[id]</span>
+      <div class="mockup__content">
+        <div class="mk2">
+          <div class="mk2__card">
+            <span class="mk2__tag">컨퍼런스 · 클라우드</span>
+            <h3 class="mk2__title">AWS Summit Seoul 2026</h3>
+            <div class="mk2__meta">5월 18일 (월) · 09:00 ~ 18:00 · 코엑스 그랜드볼룸</div>
+            <div class="mk2__actions">
+              <button class="btn btn--primary">
+                신청 사이트로
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17L17 7"/><path d="M7 7h10v10"/></svg>
+              </button>
+              <button class="btn btn--ghost">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/><line x1="12" y1="14" x2="12" y2="18"/><line x1="10" y1="16" x2="14" y2="16"/></svg>
+                내 캘린더에 추가
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="margin-left:2px;"><polyline points="6 9 12 15 18 9"/></svg>
+              </button>
+
+              <div class="mk2__dropdown">
+                <div class="mk2__dropdown-head">캘린더 선택</div>
+                <button class="mk2__dropdown-item">
+                  <span class="mk2__icon mk2__icon--apple"></span>
+                  Apple 캘린더
+                  <span class="mk2__ext">.ics</span>
+                </button>
+                <button class="mk2__dropdown-item">
+                  <span class="mk2__icon mk2__icon--google">G</span>
+                  Google 캘린더
+                  <svg class="mk2__ext" style="width:11px;height:11px;color:var(--muted);" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+                </button>
+                <button class="mk2__dropdown-item">
+                  <span class="mk2__icon mk2__icon--naver">N</span>
+                  네이버 캘린더
+                  <svg class="mk2__ext" style="width:11px;height:11px;color:var(--muted);" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+                </button>
+                <div class="mk2__divider"></div>
+                <button class="mk2__dropdown-item">
+                  <span class="mk2__icon mk2__icon--outlook">O</span>
+                  Outlook
+                  <span class="mk2__ext">.ics</span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     FEATURE 03 — NOTIFICATION
+     ============================================================ -->
+<section class="feature" id="f03">
+  <div class="feature__layout split">
+    <div class="feature__head">
+      <div class="feature__num">03</div>
+      <div class="feature__label">Notification · Service Worker</div>
+      <h2 class="feature__title">놓치지 않게,<br><em>30분 전</em>에 톡.</h2>
+      <p class="feature__lede">
+        북마크한 행사 시작 N분 전에 브라우저 알림. 푸시 서버 없이
+        <code class="mono" style="font-size:13px;background:var(--surface-alt);padding:2px 6px;border-radius:4px;">setTimeout</code> +
+        Service Worker의 <code class="mono" style="font-size:13px;background:var(--surface-alt);padding:2px 6px;border-radius:4px;">showNotification</code> 으로 충분합니다.
+      </p>
+      <ol class="feature__bullets">
+        <li>최초 북마크 시 권한 요청 → 거절해도 앱은 정상 동작 (graceful degradation).</li>
+        <li>알림 시점은 글로벌 설정 1개 · 5분/30분/1시간/1일 전.</li>
+        <li>SW가 깨어 있을 때 fire, 안 깨어 있어도 다음 방문에 만회 알림.</li>
+        <li>같이 작업하면 PWA 매니페스트도 자연스럽게 추가 — "홈 화면에 설치"까지 한 번에.</li>
+      </ol>
+      <div class="feature__chips">
+        <span class="chip chip--ink">2 days</span>
+        <span class="chip">Notification API</span>
+        <span class="chip">Service Worker</span>
+        <span class="chip chip--accent">Sticky</span>
+      </div>
+    </div>
+
+    <div class="mockup">
+      <span class="mockup__cap">notification + settings</span>
+      <div class="mockup__content">
+        <div class="mk3">
+          <div class="mk3__pop">
+            <div class="mk3__icon">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 8a6 6 0 0112 0c0 7 3 9 3 9H3s3-2 3-9"/><path d="M10.3 21a1.94 1.94 0 003.4 0"/></svg>
+            </div>
+            <div class="mk3__body">
+              <div class="mk3__app"><span>Dev Event Web · dev-event.vercel.app</span><time>지금</time></div>
+              <div class="mk3__head">30분 후 시작 — FEConf Korea 2026</div>
+              <p class="mk3__text">14:00 · 코엑스 그랜드볼룸 · 6,400 / 8,000명 참여 중</p>
+              <div class="mk3__actions">
+                <button class="mk3__btn mk3__btn--primary">자세히 보기</button>
+                <button class="mk3__btn">닫기</button>
+              </div>
+            </div>
+          </div>
+
+          <div class="mk3__settings">
+            <div class="mk3__set-head">알림 설정</div>
+            <div class="mk3__set-row">
+              <div>
+                <div class="mk3__set-label">알림 시점</div>
+                <div class="mk3__set-hint">북마크한 모든 행사에 적용돼요</div>
+              </div>
+              <div class="mk3__radio">
+                <button>5분</button>
+                <button class="is-active">30분</button>
+                <button>1시간</button>
+                <button>1일</button>
+              </div>
+            </div>
+            <div class="mk3__set-row">
+              <div>
+                <div class="mk3__set-label">브라우저 권한</div>
+                <div class="mk3__set-hint">알림을 받으려면 권한이 필요해요</div>
+              </div>
+              <div class="mk3__status">
+                <span class="mk3__dot"></span>
+                허용됨
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     FEATURE 04 — DARK MODE
+     ============================================================ -->
+<section class="feature" id="f04">
+  <div class="feature__layout stack">
+    <div class="feature__head">
+      <div class="feature__num">04</div>
+      <div class="feature__label">Dark Mode · CSS Variables</div>
+      <h2 class="feature__title">밤에도 <em>덜 눈부신</em> 행사 탐색.</h2>
+      <p class="feature__lede" style="max-width:720px;">
+        프로젝트의 <code class="mono" style="font-size:13px;background:var(--surface-alt);padding:2px 6px;border-radius:4px;">WindowContext.windowTheme</code>은
+        이미 정의돼 있지만 실제 토글 UI와 SCSS 분기가 비어 있어요. 한 번에 라이트/다크 토큰을 정리하고
+        <code class="mono" style="font-size:13px;background:var(--surface-alt);padding:2px 6px;border-radius:4px;">prefers-color-scheme</code> 까지 잇기.
+      </p>
+      <ol class="feature__bullets" style="max-width:720px;">
+        <li><code class="mono" style="font-size:12px;">styles/_variables.scss</code>에 시멘틱 토큰 2벌(<code class="mono" style="font-size:12px;">--ink</code>, <code class="mono" style="font-size:12px;">--surface</code> …) 정의.</li>
+        <li>KTB Tech Blue를 라이트/다크 모두에서 충분한 대비로 — 다크에선 살짝 밝힌 <code class="mono" style="font-size:12px;">#5C7CFF</code> 톤.</li>
+        <li>시스템 설정 자동 추종 + 수동 토글 + localStorage에 사용자 선택 저장.</li>
+        <li>썸네일 이미지는 그대로 두되 카드/보더에 다크 보정만.</li>
+      </ol>
+      <div class="feature__chips">
+        <span class="chip chip--ink">2 days</span>
+        <span class="chip">CSS Variables</span>
+        <span class="chip">prefers-color-scheme</span>
+        <span class="chip chip--accent">Hygiene</span>
+      </div>
+    </div>
+
+    <div class="mockup" style="padding-top:64px;padding-bottom:64px;">
+      <span class="mockup__cap">light / dark · side by side</span>
+      <div class="mockup__content">
+        <div class="mk4">
+
+          <div class="phone phone--light">
+            <div class="phone__notch"></div>
+            <div class="phone__screen">
+              <div class="phone__nav">Dev Event <span>5/15</span></div>
+              <div class="mini-card">
+                <div class="mini-card__tag">컨퍼런스</div>
+                <h5>FEConf Korea 2026</h5>
+                <p>5월 18일 · 코엑스 그랜드볼룸</p>
+              </div>
+              <div class="mini-card">
+                <div class="mini-card__tag">웨비나</div>
+                <h5>Next.js 16 Deep Dive</h5>
+                <p>5월 20일 · 온라인</p>
+                <div class="mini-card__cta">자세히 →</div>
+              </div>
+              <div class="mini-card">
+                <div class="mini-card__tag">해커톤</div>
+                <h5>서울 디지털 해커톤</h5>
+                <p>5월 25일 · 동대문</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="mk4__toggle">
+            <div class="toggle">
+              <div class="toggle__sun">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+              </div>
+              <div class="toggle__moon">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>
+              </div>
+              <div class="toggle__knob"></div>
+            </div>
+            <div class="mk4__code">prefers-color-scheme</div>
+          </div>
+
+          <div class="phone phone--dark">
+            <div class="phone__notch"></div>
+            <div class="phone__screen">
+              <div class="phone__nav">Dev Event <span>5/15</span></div>
+              <div class="mini-card">
+                <div class="mini-card__tag">컨퍼런스</div>
+                <h5>FEConf Korea 2026</h5>
+                <p>5월 18일 · 코엑스 그랜드볼룸</p>
+              </div>
+              <div class="mini-card">
+                <div class="mini-card__tag">웨비나</div>
+                <h5>Next.js 16 Deep Dive</h5>
+                <p>5월 20일 · 온라인</p>
+                <div class="mini-card__cta">자세히 →</div>
+              </div>
+              <div class="mini-card">
+                <div class="mini-card__tag">해커톤</div>
+                <h5>서울 디지털 해커톤</h5>
+                <p>5월 25일 · 동대문</p>
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     FEATURE 05 — FILTER URL / PRESET
+     ============================================================ -->
+<section class="feature" id="f05">
+  <div class="feature__layout split-rev">
+    <div class="feature__head">
+      <div class="feature__num">05</div>
+      <div class="feature__label">Filter URL · Presets</div>
+      <h2 class="feature__title">필터 조합을<br><em>링크</em>로 공유.</h2>
+      <p class="feature__lede">
+        지금 EventContext 상태는 URL에 반영되지 않아요. 필터를
+        <code class="mono" style="font-size:13px;background:var(--surface-alt);padding:2px 6px;border-radius:4px;">URLSearchParams</code> 로 직렬화하면
+        "프론트엔드 + 서울 + 무료" 같은 조합을 한 줄 링크로 동료에게.
+      </p>
+      <ol class="feature__bullets">
+        <li>현재 EventContext의 모든 필드(<code class="mono" style="font-size:12px;">jobGroupList, eventType, location, coast, search, date</code>)를 쿼리스트링에.</li>
+        <li>"링크 복사" 버튼 한 번이면 끝 — clipboard API.</li>
+        <li>자주 쓰는 조합은 별표로 localStorage에 저장 — 사이드바 드롭다운에서 한 번에 적용.</li>
+        <li>캘린더 뷰가 이미 <code class="mono" style="font-size:12px;">?view=calendar</code> 패턴을 쓰고 있어 자연스럽게 확장 가능.</li>
+      </ol>
+      <div class="feature__chips">
+        <span class="chip chip--ink">1.5 days</span>
+        <span class="chip">URLSearchParams</span>
+        <span class="chip">localStorage</span>
+        <span class="chip chip--accent">Shareable</span>
+      </div>
+    </div>
+
+    <div class="mockup">
+      <span class="mockup__cap">/events?jobs=fe&loc=seoul&cost=free</span>
+      <div class="mockup__content">
+        <div class="mk5">
+          <div class="mk5__bar">
+            <span class="fchip">프론트엔드
+              <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><path d="M18 6L6 18M6 6l12 12"/></svg>
+            </span>
+            <span class="fchip">서울
+              <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><path d="M18 6L6 18M6 6l12 12"/></svg>
+            </span>
+            <span class="fchip">무료
+              <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><path d="M18 6L6 18M6 6l12 12"/></svg>
+            </span>
+            <span class="fchip">컨퍼런스
+              <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><path d="M18 6L6 18M6 6l12 12"/></svg>
+            </span>
+            <div class="mk5__bar-spacer"></div>
+            <button class="btn btn--ghost" style="padding:7px 12px;font-size:12px;">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15 9 22 9 17 14 19 21 12 17 5 21 7 14 2 9 9 9"/></svg>
+              프리셋 저장
+            </button>
+            <button class="btn btn--primary" style="padding:7px 12px;font-size:12px;">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"/></svg>
+              링크 복사
+            </button>
+          </div>
+
+          <div class="mk5__copied">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg>
+            <span>이 필터 조합이 URL로 복사됐어요</span>
+            <code>?jobs=fe&loc=seoul&cost=free</code>
+          </div>
+
+          <div class="mk5__panel">
+            <div class="mk5__panel-head">
+              <span>내 프리셋</span>
+              <span>5</span>
+            </div>
+            <div class="mk5__preset">
+              <div class="mk5__star">★</div>
+              <div>
+                <div class="mk5__pname">취준생용 무료 컨퍼런스</div>
+                <div class="mk5__phint">프론트엔드 · 서울 · 무료 · 컨퍼런스</div>
+              </div>
+              <button class="mk5__apply">적용</button>
+            </div>
+            <div class="mk5__preset">
+              <div class="mk5__star">★</div>
+              <div>
+                <div class="mk5__pname">부산 주말 행사</div>
+                <div class="mk5__phint">부산 · 주말 · 전체 직군</div>
+              </div>
+              <button class="mk5__apply">적용</button>
+            </div>
+            <div class="mk5__preset">
+              <div class="mk5__star">★</div>
+              <div>
+                <div class="mk5__pname">백엔드 + 데브옵스</div>
+                <div class="mk5__phint">백엔드 · 데브옵스 · 온라인 포함</div>
+              </div>
+              <button class="mk5__apply">적용</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     FEATURE 06 — COUNTDOWN
+     ============================================================ -->
+<section class="feature" id="f06">
+  <div class="feature__layout split">
+    <div class="feature__head">
+      <div class="feature__num">06</div>
+      <div class="feature__label">Countdown · Date Math</div>
+      <h2 class="feature__title">가장 가까운 행사,<br><em>늘 시야에</em>.</h2>
+      <p class="feature__lede">
+        북마크된 행사 중 가장 가까운 것을 사이드/홈 위젯에 고정.
+        D-Day 카운트와 진행도(북마크 시점 → 행사 시작) 바, 그리고 이번 주 일정 미리보기.
+      </p>
+      <ol class="feature__bullets">
+        <li>이미 받아둔 데이터에서 클라이언트 가공만 — 신규 페치 없음.</li>
+        <li>당일엔 "D-Day" → 시작 시간 30분 단위 카운트다운으로 자동 전환.</li>
+        <li>모바일에선 접힘, 데스크탑에선 좌측 sticky 패널로.</li>
+        <li>"이번 주 다른 행사" 영역으로 1분 안에 다음 일정도 훑게.</li>
+      </ol>
+      <div class="feature__chips">
+        <span class="chip chip--ink">0.5 day</span>
+        <span class="chip">no API</span>
+        <span class="chip chip--accent">Anchor moment</span>
+      </div>
+    </div>
+
+    <div class="mockup">
+      <span class="mockup__cap">sidebar widget</span>
+      <div class="mockup__content">
+        <div class="mk6">
+          <div class="mk6__head">
+            <div class="mk6__label">다가오는 관심 행사</div>
+            <div class="mk6__pill">3 / 12</div>
+          </div>
+
+          <div class="mk6__dday"><small>D−</small>3</div>
+
+          <div class="mk6__progress">
+            <div class="mk6__progress-fill" style="width:72%"></div>
+          </div>
+
+          <div class="mk6__title">FEConf Korea 2026</div>
+          <div class="mk6__meta">5월 18일 (월) · 10:00 ~ 18:00<br>코엑스 그랜드볼룸</div>
+
+          <div class="mk6__next">
+            <div class="mk6__next-label">이번 주 다른 행사</div>
+            <ul class="mk6__next-list">
+              <li><span class="mono">D−5</span> Next.js 16 한국 밋업 <em>온라인</em></li>
+              <li><span class="mono">D−7</span> 카카오테크 부트캠프 OT <em>판교</em></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     FEATURE 07 — COMPARISON
+     ============================================================ -->
+<section class="feature" id="f07">
+  <div class="feature__layout stack">
+    <div class="feature__head">
+      <div class="feature__num">07</div>
+      <div class="feature__label">Compare · Client State</div>
+      <h2 class="feature__title">"둘 중 어디 갈까"를 <em>5초 만에</em>.</h2>
+      <p class="feature__lede" style="max-width:720px;">
+        카드에서 체크박스로 2~3개 선택 → 하단에 비교 트레이 → 클릭하면 모달.
+        날짜 · 장소 · 비용 · 주제 · 정원 · 마감을 나란히. 차이 나는 셀은 KTB Blue 하이라이트.
+      </p>
+      <ol class="feature__bullets" style="max-width:720px;">
+        <li>선택은 sessionStorage에 잠시 보관 → 새로고침해도 유지.</li>
+        <li>차이 감지 로직은 단순 row-wise diff — 같으면 묶고, 다르면 강조.</li>
+        <li>마감 임박(<code class="mono" style="font-size:12px;">D−1, D−2</code>)이나 무료 같은 의사결정 단서는 별도 배지.</li>
+        <li>모바일에선 카드 스와이프 비교로 자연스럽게.</li>
+      </ol>
+      <div class="feature__chips">
+        <span class="chip chip--ink">1.5 days</span>
+        <span class="chip">sessionStorage</span>
+        <span class="chip chip--accent">Decision aid</span>
+      </div>
+    </div>
+
+    <div class="mockup">
+      <span class="mockup__cap">compare modal · 2 events</span>
+      <div class="mockup__content">
+        <div class="mk7">
+          <div class="mk7__head">
+            <h3>2개 행사 비교<span>차이 나는 항목은 강조 표시</span></h3>
+            <button class="btn btn--ghost" style="padding:7px 12px;font-size:12px;">+ 행사 추가</button>
+          </div>
+          <table class="mk7__table">
+            <thead>
+              <tr>
+                <th></th>
+                <th>
+                  <div class="mk7__thumb"></div>
+                  <div class="mk7__col-title">AWS Summit Seoul 2026</div>
+                  <span class="mk7__col-tag">컨퍼런스</span>
+                </th>
+                <th>
+                  <div class="mk7__thumb g2"></div>
+                  <div class="mk7__col-title">Google I/O Extended</div>
+                  <span class="mk7__col-tag">밋업</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th>날짜</th>
+                <td><strong>5월 18일 (월)</strong> · D−3</td>
+                <td>5월 20일 (수) · D−5</td>
+              </tr>
+              <tr>
+                <th>장소</th>
+                <td>코엑스 그랜드볼룸</td>
+                <td>구글 코리아 (강남)</td>
+              </tr>
+              <tr>
+                <th>비용</th>
+                <td><span class="pill pill--good">무료</span></td>
+                <td><b>₩30,000</b></td>
+              </tr>
+              <tr>
+                <th>주제</th>
+                <td>클라우드 · AI · 보안</td>
+                <td>Android · Web · AI</td>
+              </tr>
+              <tr>
+                <th>정원</th>
+                <td>8,000명</td>
+                <td><b>150명</b> <span class="mk7__warn-note">조기 마감 가능</span></td>
+              </tr>
+              <tr>
+                <th>신청 마감</th>
+                <td>5월 17일 23:59</td>
+                <td><span class="mk7__highlight"><b>5월 14일 18:00 · D−1</b></span></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     FEATURE 08 — COMMAND PALETTE
+     ============================================================ -->
+<section class="feature" id="f08">
+  <div class="feature__layout stack">
+    <div class="feature__head">
+      <div class="feature__num">08</div>
+      <div class="feature__label">Keyboard · ⌘K Palette</div>
+      <h2 class="feature__title">개발자 사이트답게,<br>모든 게 <em>키보드로</em>.</h2>
+      <p class="feature__lede" style="max-width:720px;">
+        어디서든 <kbd>⌘</kbd><kbd>K</kbd> 로 명령 팔레트. 검색 · 뷰 전환 · 필터 초기화 · 다음 행사 점프까지
+        손이 마우스로 옮겨갈 일을 줄이기. 개발자 행사 사이트가 이걸 안 하는 건 좀 직무유기죠.
+      </p>
+      <ol class="feature__bullets" style="max-width:720px;">
+        <li>단일 글로벌 KeyboardEvent listener — 입력창 포커스 시엔 자동 무시.</li>
+        <li>화살표로 이동, Enter로 실행, ESC로 닫기 — Linear/Raycast 패턴 그대로.</li>
+        <li>최근 명령은 상단에 — sessionStorage 기반 MRU 캐시.</li>
+        <li>접근성: 모달 진입 시 focus trap, 닫을 때 트리거 요소로 복귀.</li>
+      </ol>
+      <div class="feature__chips">
+        <span class="chip chip--ink">2 days</span>
+        <span class="chip">KeyboardEvent</span>
+        <span class="chip">a11y · focus trap</span>
+        <span class="chip chip--accent">Power user</span>
+      </div>
+    </div>
+
+    <div class="mockup" style="padding:64px 48px;">
+      <span class="mockup__cap">⌘K · anywhere</span>
+      <div class="mockup__content">
+        <div class="mk8">
+          <div class="mk8__bg"></div>
+          <div class="palette">
+            <div class="palette__search">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+              <input value="필터" placeholder="검색하거나 명령 입력…" readonly>
+              <kbd>ESC</kbd>
+            </div>
+            <div class="palette__body">
+              <div class="palette__section">
+                <div class="palette__sectitle">필터</div>
+                <button class="palette__row is-active">
+                  <span>검색창 포커스</span>
+                  <div class="keys"><kbd>/</kbd></div>
+                </button>
+                <button class="palette__row">
+                  <span>필터 초기화</span>
+                  <div class="keys"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>K</kbd></div>
+                </button>
+              </div>
+              <div class="palette__section">
+                <div class="palette__sectitle">뷰</div>
+                <button class="palette__row">
+                  <span>캘린더 뷰로 전환</span>
+                  <div class="keys"><kbd>C</kbd></div>
+                </button>
+                <button class="palette__row">
+                  <span>리스트 뷰로 전환</span>
+                  <div class="keys"><kbd>L</kbd></div>
+                </button>
+                <button class="palette__row">
+                  <span>이번 달로 이동</span>
+                  <div class="keys"><kbd>T</kbd></div>
+                </button>
+              </div>
+              <div class="palette__section">
+                <div class="palette__sectitle">탐색</div>
+                <button class="palette__row">
+                  <span>북마크 목록 열기</span>
+                  <div class="keys"><kbd>⌘</kbd><kbd>B</kbd></div>
+                </button>
+                <button class="palette__row">
+                  <span>다음 행사로</span>
+                  <div class="keys"><kbd>J</kbd></div>
+                </button>
+                <button class="palette__row">
+                  <span>이전 행사로</span>
+                  <div class="keys"><kbd>K</kbd></div>
+                </button>
+              </div>
+            </div>
+            <div class="palette__foot">
+              <span><kbd>↑</kbd><kbd>↓</kbd> 이동</span>
+              <span><kbd>↵</kbd> 선택</span>
+              <span class="palette__hint">어디서든 <kbd>⌘</kbd><kbd>K</kbd> 로 열기</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============ FOOTER ============ -->
+<footer class="footer">
+  <div class="footer__grid">
+    <div class="footer__bigline">
+      <em>다음 단계</em>는<br>
+      이 중 어느 두 개를 한 묶음으로 골라 brainstorming → spec → plan 으로 이어가는 것.
+    </div>
+    <div class="footer__col">
+      <h6>추천 출발점</h6>
+      <ul>
+        <li>01 북마크<span class="mono">1.5d</span></li>
+        <li>02 캘린더 내보내기<span class="mono">1d</span></li>
+        <li>06 카운트다운 위젯<span class="mono">0.5d</span></li>
+      </ul>
+    </div>
+    <div class="footer__col">
+      <h6>한 묶음 제안</h6>
+      <ul>
+        <li>01 + 02 + 06<span class="mono">~3d</span></li>
+        <li>05 + 08<span class="mono">~3.5d</span></li>
+        <li>03 + PWA<span class="mono">~3d</span></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer__bottom">
+    <span>DEV·EVENT / FEATURE MOCKUPS · v0.1</span>
+    <span>2026.05.15 · Pretendard + Instrument Serif + JetBrains Mono</span>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/docs/mockups/social-banner-final.html
+++ b/docs/mockups/social-banner-final.html
@@ -1,0 +1,747 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Dev Event Web · Social Banner — Final (Variant A)</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+:root{
+  --gray-000:#ffffff;
+  --gray-050:#F7F7FA;
+  --gray-100:#F0F0F5;
+  --gray-200:#E8E8EE;
+  --gray-300:#E1E1E8;
+  --gray-400:#CDCED6;
+  --gray-500:#8C8F9F;
+  --gray-600:#6C6E7E;
+  --gray-700:#525463;
+  --gray-800:#3E404C;
+  --gray-900:#2B2D36;
+  --gray-950:#252730;
+  --ktb-blue:#0043ff;
+  --ktb-navy:#000040;
+
+  --threads-ink:#0E0E14;
+  --threads-ink-2:#1C1C24;
+  --ig-grad:linear-gradient(135deg,#FFE08A 0%,#FF6F4D 25%,#E53E5E 50%,#C13584 75%,#5B3F9F 100%);
+
+  --r-200:6px;
+  --r-400:12px;
+  --r-600:24px;
+}
+
+*{box-sizing:border-box;margin:0;padding:0;}
+html{scroll-behavior:smooth;}
+body{
+  font-family:'Pretendard Variable',Pretendard,-apple-system,BlinkMacSystemFont,system-ui,sans-serif;
+  background:var(--gray-050);
+  color:var(--gray-900);
+  -webkit-font-smoothing:antialiased;
+  word-break:keep-all;
+  line-height:1.5;
+}
+.serif{font-family:'Instrument Serif',serif;font-style:italic;font-weight:400;}
+.mono{font-family:'JetBrains Mono',monospace;}
+button{font:inherit;background:none;border:none;cursor:pointer;color:inherit;}
+a{color:inherit;text-decoration:none;}
+
+/* ============ TOP BAR ============ */
+.topbar{
+  position:sticky;top:0;z-index:50;
+  background:hsla(0,0%,100%,.88);
+  backdrop-filter:blur(20px) saturate(150%);
+  border-bottom:1px solid var(--gray-300);
+}
+.topbar__inner{
+  max-width:1280px;margin:0 auto;
+  padding:14px 48px;
+  display:flex;align-items:center;gap:24px;
+  font-size:13px;
+}
+.topbar__logo{font-weight:800;letter-spacing:-0.02em;font-size:15px;}
+.topbar__logo b{color:var(--ktb-blue);}
+.topbar__nav{display:flex;gap:24px;flex:1;}
+.topbar__nav a{color:var(--gray-600);font-weight:500;font-size:13px;}
+.topbar__nav a:hover{color:var(--ktb-blue);}
+.topbar__date{
+  color:var(--gray-600);font-family:'JetBrains Mono',monospace;
+  font-size:11px;letter-spacing:0.06em;
+}
+
+/* ============ HERO ============ */
+.hero{
+  max-width:1280px;margin:0 auto;
+  padding:64px 48px 48px;
+}
+.hero__eyebrow{
+  display:inline-flex;align-items:center;gap:12px;
+  font-size:11px;letter-spacing:0.18em;text-transform:uppercase;
+  color:var(--ktb-blue);font-weight:700;margin-bottom:28px;
+}
+.hero__eyebrow::before{content:"";width:36px;height:1px;background:var(--ktb-blue);}
+.hero h1{
+  font-size:clamp(36px,5.2vw,72px);
+  line-height:1.0;
+  letter-spacing:-0.035em;
+  font-weight:800;
+  margin-bottom:24px;
+}
+.hero h1 em{
+  font-family:'Instrument Serif',serif;
+  font-style:italic;font-weight:400;
+  color:var(--ktb-blue);
+}
+.hero__lede{
+  max-width:680px;font-size:17px;color:var(--gray-700);
+  line-height:1.6;
+}
+.hero__lede mark{
+  background:linear-gradient(180deg,transparent 60%,rgba(0,67,255,0.1) 60%);
+  padding:0 4px;color:var(--gray-900);font-weight:600;
+}
+
+/* ============ FRAME WRAPPER ============ */
+.section{
+  max-width:1280px;margin:0 auto;
+  padding:64px 48px;
+  border-top:1px solid var(--gray-900);
+}
+.section__head{margin-bottom:32px;}
+.section__label{
+  font-size:11px;letter-spacing:0.18em;text-transform:uppercase;
+  color:var(--gray-600);font-weight:700;margin-bottom:12px;
+  display:flex;align-items:center;gap:10px;
+}
+.section__label::before{content:"";width:24px;height:1px;background:var(--gray-600);}
+.section__title{
+  font-size:32px;font-weight:700;letter-spacing:-0.025em;
+  margin-bottom:10px;
+}
+.section__title em{font-family:'Instrument Serif',serif;font-style:italic;font-weight:400;color:var(--ktb-blue);}
+.section__desc{font-size:15px;color:var(--gray-700);max-width:680px;line-height:1.6;}
+.section__desc code{
+  font-family:'JetBrains Mono',monospace;
+  background:var(--gray-100);padding:2px 6px;border-radius:4px;font-size:13px;
+}
+
+.frame{
+  background:var(--gray-050);
+  border:1px solid var(--gray-300);
+  border-radius:var(--r-600);
+  padding:32px;
+  position:relative;
+  overflow:hidden;
+}
+.frame::before{
+  content:"";position:absolute;inset:0;
+  background-image:radial-gradient(circle at 1px 1px,rgba(14,14,20,0.04) 1px,transparent 0);
+  background-size:24px 24px;
+  pointer-events:none;
+  mask-image:radial-gradient(ellipse at center,#000 30%,transparent 80%);
+}
+.frame__cap{
+  position:absolute;top:14px;left:20px;
+  font-family:'JetBrains Mono',monospace;
+  font-size:10px;color:var(--gray-600);letter-spacing:0.1em;
+  text-transform:uppercase;
+  display:inline-flex;align-items:center;gap:8px;
+  z-index:2;
+}
+.frame__cap::before{
+  content:"";width:6px;height:6px;background:var(--ktb-blue);border-radius:50%;
+  box-shadow:0 0 0 3px rgba(0,67,255,0.14);
+}
+.frame__inner{position:relative;z-index:1;padding-top:24px;}
+
+/* ============ SOCIAL BANNER (the actual component) ============ */
+.sb{
+  display:grid;
+  grid-template-columns:1fr 1fr;
+  gap:12px;
+  width:100%;
+}
+.sb__card{
+  position:relative;overflow:hidden;
+  border-radius:var(--r-400);
+  padding:18px 20px;
+  display:flex;align-items:center;gap:16px;
+  transition:transform .18s ease;
+  cursor:pointer;
+  min-height:80px;
+}
+.sb__card:hover{transform:translateY(-1px);}
+.sb__card:focus-visible{outline:2px solid var(--ktb-blue);outline-offset:2px;}
+
+.sb__card--threads{
+  background:linear-gradient(135deg,var(--threads-ink) 0%,var(--threads-ink-2) 100%);
+  color:#fff;
+}
+.sb__card--ig{
+  background:var(--ig-grad);
+  color:#fff;
+}
+.sb__card--ig::after{
+  content:"";position:absolute;inset:0;
+  background:radial-gradient(circle at 100% 0%,rgba(255,255,255,0.18),transparent 60%);
+  pointer-events:none;
+}
+
+.sb__icon{
+  width:44px;height:44px;
+  background:rgba(255,255,255,0.16);
+  border-radius:10px;
+  display:flex;align-items:center;justify-content:center;
+  flex-shrink:0;
+  backdrop-filter:blur(8px);
+}
+.sb__icon svg{width:24px;height:24px;color:#fff;}
+.sb__body{flex:1;min-width:0;position:relative;z-index:1;}
+.sb__label{
+  font-size:10.5px;font-weight:600;
+  opacity:0.78;letter-spacing:0.06em;text-transform:uppercase;
+  margin-bottom:3px;
+}
+.sb__copy{
+  font-size:15px;font-weight:700;
+  letter-spacing:-0.012rem;line-height:1.3;
+  margin-bottom:3px;
+}
+.sb__handle{
+  font-size:11.5px;font-weight:500;opacity:0.78;
+  font-family:'JetBrains Mono',monospace;
+}
+.sb__cta{
+  font-size:12px;font-weight:700;
+  padding:7px 12px;border-radius:9999px;
+  background:#fff;color:var(--gray-900);
+  flex-shrink:0;
+  display:inline-flex;align-items:center;gap:4px;
+}
+.sb__card--ig .sb__cta{color:#C13584;}
+
+/* RESPONSIVE BREAK — exact rule */
+@media (max-width:768px){
+  .sb{
+    grid-template-columns:1fr;
+    gap:8px;
+  }
+  .sb__card{
+    padding:14px 16px;
+    min-height:68px;
+    gap:12px;
+  }
+  .sb__icon{width:36px;height:36px;border-radius:9px;}
+  .sb__icon svg{width:20px;height:20px;}
+  .sb__copy{font-size:14px;}
+  .sb__handle{font-size:11px;}
+  .sb__cta{padding:6px 10px;font-size:11px;}
+}
+
+/* Phone preview always uses mobile layout (mockup is rendered at desktop
+   viewport, so media queries above don't fire inside the phone frame). */
+.phone .sb{
+  grid-template-columns:1fr;
+  gap:8px;
+}
+.phone .sb__card{
+  padding:12px 14px;
+  min-height:60px;
+  gap:11px;
+}
+.phone .sb__icon{width:34px;height:34px;border-radius:8px;}
+.phone .sb__icon svg{width:18px;height:18px;}
+.phone .sb__label{font-size:9.5px;margin-bottom:2px;}
+.phone .sb__copy{font-size:12.5px;margin-bottom:2px;}
+.phone .sb__handle{font-size:10px;}
+.phone .sb__cta{padding:5px 9px;font-size:10.5px;}
+.phone .sb__cta svg{display:none;}
+
+/* ============ PAGE MOCKUP (/events) ============ */
+.page{
+  background:var(--gray-000);
+  border:1px solid var(--gray-300);
+  border-radius:var(--r-600);
+  padding:32px;
+  margin:0 auto;
+}
+.page__title{
+  font-size:28px;font-weight:700;
+  letter-spacing:-0.012rem;
+  margin-bottom:6px;color:var(--gray-900);
+}
+.page__count{
+  font-size:14px;color:var(--gray-600);font-weight:500;
+  margin-bottom:24px;
+}
+.page__filter{
+  display:flex;gap:8px;margin-bottom:24px;flex-wrap:wrap;
+}
+.page__chip{
+  padding:7px 14px;border:1px solid var(--gray-300);
+  border-radius:9999px;background:var(--gray-000);
+  font-size:13px;font-weight:500;color:var(--gray-700);
+}
+.page__chip.is-on{background:var(--gray-900);color:#fff;border-color:var(--gray-900);}
+.page__grid{
+  display:grid;
+  grid-template-columns:repeat(auto-fill,minmax(220px,1fr));
+  gap:16px;margin-top:24px;
+}
+.mini-card{background:transparent;}
+.mini-card__thumb{
+  width:100%;aspect-ratio:5/3;border-radius:var(--r-400);
+  background:var(--gray-100);position:relative;overflow:hidden;
+  margin-bottom:12px;
+}
+.mini-card__thumb.g1{background:linear-gradient(135deg,#0043ff 0%,#7B9DFF 100%);}
+.mini-card__thumb.g2{background:linear-gradient(135deg,#08785E 0%,#7DDBA8 100%);}
+.mini-card__thumb.g3{background:linear-gradient(135deg,#FF6F4D 0%,#FFB155 100%);}
+.mini-card__thumb.g4{background:linear-gradient(135deg,#C13584 0%,#F57DF0 100%);}
+.mini-card__badge{
+  position:absolute;top:12px;left:12px;
+  font-size:10.5px;font-weight:600;
+  background:rgba(255,255,255,0.96);
+  color:var(--gray-900);
+  padding:3px 8px;border-radius:9999px;
+}
+.mini-card__name{
+  font-size:14px;font-weight:700;
+  letter-spacing:-0.012rem;
+  white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
+  margin-bottom:4px;
+}
+.mini-card__period{
+  font-size:11.5px;color:var(--gray-600);
+  display:flex;align-items:center;gap:4px;
+}
+
+/* ============ MOBILE PHONE PREVIEW ============ */
+.mobile-row{
+  display:flex;gap:48px;align-items:flex-start;flex-wrap:wrap;
+}
+.mobile-col{flex:1;min-width:280px;}
+.phone{
+  width:320px;flex-shrink:0;
+  background:#0E0E14;
+  border-radius:36px;
+  padding:8px;
+  box-shadow:0 24px 56px rgba(14,14,20,0.18),0 4px 12px rgba(14,14,20,0.08);
+}
+.phone__notch{
+  width:100px;height:20px;background:#000;
+  border-radius:0 0 14px 14px;margin:0 auto 4px;
+}
+.phone__screen{
+  background:var(--gray-000);
+  border-radius:28px;
+  padding:18px;min-height:560px;
+  overflow:hidden;
+}
+.phone__nav{
+  display:flex;justify-content:space-between;align-items:center;
+  margin-bottom:16px;
+  font-size:15px;font-weight:800;letter-spacing:-0.02em;
+}
+.phone__nav small{font-size:11px;color:var(--gray-600);font-weight:500;}
+.phone__title{
+  font-size:20px;font-weight:700;
+  letter-spacing:-0.012rem;
+  margin:8px 0 6px;
+}
+.phone__count{font-size:12px;color:var(--gray-600);margin-bottom:14px;}
+.phone__filter{
+  display:flex;gap:6px;margin-bottom:14px;overflow:hidden;
+}
+.phone__filter span{
+  font-size:11px;padding:5px 10px;border-radius:9999px;
+  border:1px solid var(--gray-300);color:var(--gray-700);font-weight:500;
+  white-space:nowrap;
+}
+.phone__filter span.is-on{background:var(--gray-900);color:#fff;border-color:var(--gray-900);}
+.phone__card{
+  margin-top:14px;display:flex;flex-direction:column;
+}
+.phone__card-thumb{
+  width:100%;aspect-ratio:5/3;
+  border-radius:10px;margin-bottom:10px;
+  background:linear-gradient(135deg,#0043ff,#7B9DFF);
+}
+.phone__card-thumb.g2{background:linear-gradient(135deg,#08785E,#7DDBA8);}
+.phone__card-name{font-size:13.5px;font-weight:700;letter-spacing:-0.012rem;margin-bottom:3px;}
+.phone__card-meta{font-size:10.5px;color:var(--gray-600);}
+
+/* ============ ARROW DIAGRAM ============ */
+.arrow{
+  display:inline-flex;align-items:center;gap:8px;
+  font-family:'JetBrains Mono',monospace;
+  font-size:11px;color:var(--gray-600);
+  letter-spacing:0.04em;
+  margin:24px 0;padding:14px 18px;
+  background:var(--gray-100);border-radius:var(--r-400);
+}
+.arrow b{color:var(--ktb-blue);}
+
+/* ============ SPEC LIST ============ */
+.spec{
+  background:var(--gray-000);
+  border:1px solid var(--gray-300);
+  border-radius:var(--r-400);
+  overflow:hidden;
+}
+.spec__row{
+  display:grid;grid-template-columns:160px 1fr;
+  border-bottom:1px solid var(--gray-300);
+}
+.spec__row:last-child{border-bottom:none;}
+.spec__key{
+  padding:14px 18px;
+  font-size:11px;letter-spacing:0.1em;text-transform:uppercase;
+  color:var(--gray-600);font-weight:700;
+  background:var(--gray-050);
+}
+.spec__val{
+  padding:14px 18px;
+  font-size:13.5px;color:var(--gray-900);
+}
+.spec__val code{
+  font-family:'JetBrains Mono',monospace;
+  background:var(--gray-100);padding:2px 6px;border-radius:4px;font-size:12px;
+  color:var(--gray-800);
+}
+
+/* ============ FOOTER ============ */
+.footer{
+  max-width:1280px;margin:0 auto;
+  padding:64px 48px 56px;
+  border-top:1px solid var(--gray-900);
+}
+.footer__line{
+  font-size:clamp(20px,2.2vw,28px);
+  font-weight:600;letter-spacing:-0.02em;line-height:1.3;
+  max-width:640px;margin-bottom:36px;
+}
+.footer__line em{font-family:'Instrument Serif',serif;font-style:italic;font-weight:400;color:var(--ktb-blue);}
+.footer__bottom{
+  display:flex;justify-content:space-between;
+  font-size:11px;color:var(--gray-600);
+  font-family:'JetBrains Mono',monospace;letter-spacing:0.04em;
+}
+
+@media (max-width:780px){
+  .topbar__nav{display:none;}
+  .hero,.section,.footer{padding-left:24px;padding-right:24px;}
+  .hero{padding-top:40px;padding-bottom:36px;}
+  .section{padding-top:48px;padding-bottom:48px;}
+  .frame{padding:20px;}
+  .page{padding:20px;}
+  .mobile-row{gap:24px;}
+}
+</style>
+</head>
+<body>
+
+<!-- ============ TOP BAR ============ -->
+<div class="topbar">
+  <div class="topbar__inner">
+    <div class="topbar__logo">dev<b>·</b>event<b>/</b><span style="color:var(--gray-600);font-weight:500;">social-banner · final</span></div>
+    <nav class="topbar__nav">
+      <a href="#pc">PC 한 줄</a>
+      <a href="#mobile">모바일 stack</a>
+      <a href="#spec">스펙</a>
+    </nav>
+    <div class="topbar__date">2026.05.15 · variant A · locked</div>
+  </div>
+</div>
+
+<!-- ============ HERO ============ -->
+<section class="hero">
+  <div class="hero__eyebrow">DEV EVENT · /events · variant A · FINAL</div>
+  <h1>PC는 <em>한 줄로</em>,<br>모바일은 <em>위아래로</em>.</h1>
+  <p class="hero__lede">
+    선택하신 <mark>Variant A · Split Card</mark>를 그대로 구현 형태로 변환.
+    데스크탑(<code class="mono" style="font-size:13px;background:var(--gray-100);padding:2px 6px;border-radius:4px;">≥ 769px</code>)에선 Threads · Instagram을 1:1 그리드로 나란히 배치, 모바일(<code class="mono" style="font-size:13px;background:var(--gray-100);padding:2px 6px;border-radius:4px;">≤ 768px</code>)에선 1열로 위아래 stack.
+  </p>
+  <div class="arrow">
+    <span>BREAKPOINT</span>
+    <span style="color:var(--gray-400);">→</span>
+    <span><b>≥ 769px</b> · <code class="mono" style="background:transparent;">grid-template-columns: 1fr 1fr</code></span>
+    <span style="color:var(--gray-400);">/</span>
+    <span><b>≤ 768px</b> · <code class="mono" style="background:transparent;">grid-template-columns: 1fr</code></span>
+  </div>
+</section>
+
+<!-- ============================================================
+     PC — SIDE BY SIDE
+     ============================================================ -->
+<section class="section" id="pc">
+  <div class="section__head">
+    <div class="section__label">PC · 데스크탑 (≥ 769px)</div>
+    <h2 class="section__title">한 줄에 <em>나란히</em> 두 장.</h2>
+    <p class="section__desc">
+      필터 칩 줄 바로 아래, 첫 행사 카드 위에 들어갑니다. 1:1 그리드 + 12px 간격.
+      카드 자체 높이는 80px 고정 — 아래 행사 카드의 시각 무게를 누르지 않습니다.
+    </p>
+  </div>
+
+  <div class="frame">
+    <span class="frame__cap">/events · 1104px laptop · ≥ 769px</span>
+    <div class="frame__inner">
+      <div class="page">
+        <h2 class="page__title">개발자 행사</h2>
+        <div class="page__count">총 124개의 행사가 등록되어 있어요</div>
+        <div class="page__filter">
+          <span class="page__chip is-on">전체</span>
+          <span class="page__chip">컨퍼런스</span>
+          <span class="page__chip">웨비나</span>
+          <span class="page__chip">해커톤</span>
+          <span class="page__chip">밋업</span>
+          <span class="page__chip">네트워킹</span>
+        </div>
+
+        <!-- ★ THE BANNER — side by side on PC -->
+        <div class="sb">
+          <a class="sb__card sb__card--threads" href="#" aria-label="Threads에서 데브이벤트 팔로우">
+            <span class="sb__icon" aria-hidden>
+              <svg viewBox="0 0 192 192" fill="currentColor"><path d="M141.5 86.6c-.7-.3-1.4-.7-2.1-1-1.3-23.4-14.1-36.8-35.6-37-9.7 0-17.7 4.2-22.9 11.4l11.9 8.2c3.7-5.6 9.5-6.8 14.8-6.8h.2c6.6 0 11.5 1.9 14.7 5.7 2.3 2.7 3.9 6.5 4.7 11.2-6.1-1-12.6-1.4-19.7-1-19.8 1.1-32.4 12.6-31.6 28.6.4 8.1 4.4 15 11.5 19.6 5.9 3.8 13.6 5.7 21.6 5.3 10.6-.6 18.9-4.6 24.7-11.9 4.4-5.5 7.2-12.7 8.4-21.6 5 3 8.7 7 10.7 11.7 3.5 8.1 3.7 21.5-7.2 32.4-9.6 9.6-21.1 13.7-38.5 13.8C84 156.3 70.7 150 61.9 137c-8.2-12.2-12.5-29.7-12.6-52.1.1-22.4 4.4-39.9 12.6-52 8.8-13 22.1-19.3 40.6-19.5 18.6.1 32.1 6.4 41.3 19.5 4.5 6.4 7.9 14.4 10.2 23.7l14-3.7c-2.7-11.4-7-21.3-12.8-29.5-11.7-16.6-28.9-25.1-51.1-25.2H104c-22.2.2-39 8.8-50.1 25.5-9.9 14.9-15 35.6-15.2 61.6.2 26 5.3 46.7 15.2 61.6 11.1 16.7 27.9 25.3 50.1 25.5h.1c19.7-.1 33.6-5.3 45.1-16.8 15-15 14.6-33.8 9.6-45.3-3.6-8.3-10.4-15-19.7-19.4Zm-29.7 22.8c-8.8.5-17.9-3.5-18.3-11.8-.3-6.2 4.4-13.1 18.8-13.9 1.7-.1 3.3-.1 4.9-.1 5.2 0 10.1.5 14.5 1.5-1.7 20.6-11.4 23.9-19.9 24.3Z"/></svg>
+            </span>
+            <div class="sb__body">
+              <div class="sb__label">Threads</div>
+              <div class="sb__copy">새 행사 소식, 가장 먼저 받기</div>
+              <div class="sb__handle">@dev_event_kr</div>
+            </div>
+            <span class="sb__cta">팔로우
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+            </span>
+          </a>
+
+          <a class="sb__card sb__card--ig" href="#" aria-label="Instagram에서 데브이벤트 팔로우">
+            <span class="sb__icon" aria-hidden>
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="2" y="2" width="20" height="20" rx="5"/>
+                <circle cx="12" cy="12" r="4"/>
+                <circle cx="17.5" cy="6.5" r="1" fill="currentColor"/>
+              </svg>
+            </span>
+            <div class="sb__body">
+              <div class="sb__label">Instagram</div>
+              <div class="sb__copy">행사 현장 사진 · 후기 둘러보기</div>
+              <div class="sb__handle">@dev_event_kr</div>
+            </div>
+            <span class="sb__cta">팔로우
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+            </span>
+          </a>
+        </div>
+        <!-- /banner -->
+
+        <div class="page__grid">
+          <article class="mini-card">
+            <div class="mini-card__thumb g1"><div class="mini-card__badge">진행중</div></div>
+            <div class="mini-card__name">FEConf Korea 2026</div>
+            <div class="mini-card__period">5월 18일 · 코엑스</div>
+          </article>
+          <article class="mini-card">
+            <div class="mini-card__thumb g2"><div class="mini-card__badge">D-5</div></div>
+            <div class="mini-card__name">AWS Summit Seoul 2026</div>
+            <div class="mini-card__period">5월 20일 · 코엑스</div>
+          </article>
+          <article class="mini-card">
+            <div class="mini-card__thumb g3"><div class="mini-card__badge">D-7</div></div>
+            <div class="mini-card__name">서울 디지털 해커톤</div>
+            <div class="mini-card__period">5월 25일 · 동대문</div>
+          </article>
+          <article class="mini-card">
+            <div class="mini-card__thumb g4"><div class="mini-card__badge">D-12</div></div>
+            <div class="mini-card__name">PyCon KR 2026</div>
+            <div class="mini-card__period">5월 30일 · 코엑스</div>
+          </article>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     MOBILE — STACK
+     ============================================================ -->
+<section class="section" id="mobile">
+  <div class="section__head">
+    <div class="section__label">모바일 (≤ 768px)</div>
+    <h2 class="section__title">화면이 좁아지면 <em>위아래로</em>.</h2>
+    <p class="section__desc">
+      한 줄에 두 장을 욱여넣으면 글자 잘림 · 터치 영역 좁아짐. 768px 이하에선 자연스럽게 1열 stack으로 전환.
+      카드 padding도 약간 줄여 (18·20 → 14·16) 모바일 밀도 맞춤.
+    </p>
+  </div>
+
+  <div class="frame">
+    <span class="frame__cap">/events · 375px iPhone · ≤ 768px</span>
+    <div class="frame__inner">
+      <div class="mobile-row">
+        <div class="phone">
+          <div class="phone__notch"></div>
+          <div class="phone__screen">
+            <div class="phone__nav">Dev Event <small>5/15</small></div>
+            <div class="phone__title">개발자 행사</div>
+            <div class="phone__count">총 124개</div>
+            <div class="phone__filter">
+              <span class="is-on">전체</span>
+              <span>컨퍼런스</span>
+              <span>웨비나</span>
+              <span>해커톤</span>
+            </div>
+
+            <!-- ★ THE BANNER — stacked on mobile (same component, different breakpoint) -->
+            <div class="sb">
+              <a class="sb__card sb__card--threads" href="#">
+                <span class="sb__icon"><svg viewBox="0 0 192 192" fill="currentColor"><path d="M141.5 86.6c-.7-.3-1.4-.7-2.1-1-1.3-23.4-14.1-36.8-35.6-37-9.7 0-17.7 4.2-22.9 11.4l11.9 8.2c3.7-5.6 9.5-6.8 14.8-6.8h.2c6.6 0 11.5 1.9 14.7 5.7 2.3 2.7 3.9 6.5 4.7 11.2-6.1-1-12.6-1.4-19.7-1-19.8 1.1-32.4 12.6-31.6 28.6.4 8.1 4.4 15 11.5 19.6 5.9 3.8 13.6 5.7 21.6 5.3 10.6-.6 18.9-4.6 24.7-11.9 4.4-5.5 7.2-12.7 8.4-21.6 5 3 8.7 7 10.7 11.7 3.5 8.1 3.7 21.5-7.2 32.4-9.6 9.6-21.1 13.7-38.5 13.8C84 156.3 70.7 150 61.9 137c-8.2-12.2-12.5-29.7-12.6-52.1.1-22.4 4.4-39.9 12.6-52 8.8-13 22.1-19.3 40.6-19.5 18.6.1 32.1 6.4 41.3 19.5 4.5 6.4 7.9 14.4 10.2 23.7l14-3.7c-2.7-11.4-7-21.3-12.8-29.5-11.7-16.6-28.9-25.1-51.1-25.2H104c-22.2.2-39 8.8-50.1 25.5-9.9 14.9-15 35.6-15.2 61.6.2 26 5.3 46.7 15.2 61.6 11.1 16.7 27.9 25.3 50.1 25.5h.1c19.7-.1 33.6-5.3 45.1-16.8 15-15 14.6-33.8 9.6-45.3-3.6-8.3-10.4-15-19.7-19.4Zm-29.7 22.8c-8.8.5-17.9-3.5-18.3-11.8-.3-6.2 4.4-13.1 18.8-13.9 1.7-.1 3.3-.1 4.9-.1 5.2 0 10.1.5 14.5 1.5-1.7 20.6-11.4 23.9-19.9 24.3Z"/></svg></span>
+                <div class="sb__body">
+                  <div class="sb__label">Threads</div>
+                  <div class="sb__copy">새 소식 받기</div>
+                  <div class="sb__handle">@dev_event_kr</div>
+                </div>
+                <span class="sb__cta">팔로우</span>
+              </a>
+              <a class="sb__card sb__card--ig" href="#">
+                <span class="sb__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5"/><circle cx="12" cy="12" r="4"/><circle cx="17.5" cy="6.5" r="1" fill="currentColor"/></svg></span>
+                <div class="sb__body">
+                  <div class="sb__label">Instagram</div>
+                  <div class="sb__copy">현장 사진 · 후기</div>
+                  <div class="sb__handle">@dev_event_kr</div>
+                </div>
+                <span class="sb__cta">팔로우</span>
+              </a>
+            </div>
+            <!-- /banner -->
+
+            <div class="phone__card">
+              <div class="phone__card-thumb"></div>
+              <div class="phone__card-name">FEConf Korea 2026</div>
+              <div class="phone__card-meta">5월 18일 · 코엑스</div>
+            </div>
+            <div class="phone__card">
+              <div class="phone__card-thumb g2"></div>
+              <div class="phone__card-name">AWS Summit Seoul 2026</div>
+              <div class="phone__card-meta">5월 20일 · 코엑스</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="mobile-col">
+          <h4 style="font-size:11px;letter-spacing:0.14em;text-transform:uppercase;color:var(--gray-600);font-weight:700;margin-bottom:14px;">반응형 규칙</h4>
+          <ul style="list-style:none;font-size:13.5px;color:var(--gray-800);line-height:1.7;">
+            <li style="border-top:1px solid var(--gray-300);padding:12px 0;">PC · <code class="mono" style="font-size:12px;background:var(--gray-100);padding:2px 6px;border-radius:4px;">grid-template-columns: 1fr 1fr</code> · gap 12px</li>
+            <li style="border-top:1px solid var(--gray-300);padding:12px 0;">모바일 · <code class="mono" style="font-size:12px;background:var(--gray-100);padding:2px 6px;border-radius:4px;">grid-template-columns: 1fr</code> · gap 8px</li>
+            <li style="border-top:1px solid var(--gray-300);padding:12px 0;">카드 padding · 18·20 → 14·16</li>
+            <li style="border-top:1px solid var(--gray-300);padding:12px 0;">아이콘 크기 · 44px → 36px</li>
+            <li style="border-top:1px solid var(--gray-300);padding:12px 0;">CTA · "팔로우" 텍스트만 (화살표 생략)</li>
+            <li style="border-top:1px solid var(--gray-300);border-bottom:1px solid var(--gray-300);padding:12px 0;">@handle · 동일하게 유지 (한 줄 ellipsis로)</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     FULL SPEC
+     ============================================================ -->
+<section class="section" id="spec">
+  <div class="section__head">
+    <div class="section__label">Spec sheet · 구현 계약서</div>
+    <h2 class="section__title">실제 컴포넌트 <em>스펙</em>.</h2>
+    <p class="section__desc">
+      <code>components/features/social-banner/SocialBanner.tsx</code> + <code>SocialBanner.module.scss</code> 2개 파일로 만들고,
+      <code>pages/events.tsx</code>의 필터 칩 줄 아래 단 한 줄로 import.
+    </p>
+  </div>
+
+  <div class="spec">
+    <div class="spec__row">
+      <div class="spec__key">파일</div>
+      <div class="spec__val">
+        <code>components/features/social-banner/SocialBanner.tsx</code><br>
+        <code>components/features/social-banner/SocialBanner.module.scss</code>
+      </div>
+    </div>
+    <div class="spec__row">
+      <div class="spec__key">노출 위치</div>
+      <div class="spec__val">
+        <code>/events</code> 페이지 · <code>ScheduledEventList</code> 컴포넌트 위 (필터 영역 직후)
+      </div>
+    </div>
+    <div class="spec__row">
+      <div class="spec__key">PC (≥ 769px)</div>
+      <div class="spec__val">
+        <code>display: grid; grid-template-columns: 1fr 1fr; gap: 12px;</code><br>
+        카드 높이 80px · padding 18px 20px · 아이콘 44×44px
+      </div>
+    </div>
+    <div class="spec__row">
+      <div class="spec__key">모바일 (≤ 768px)</div>
+      <div class="spec__val">
+        <code>grid-template-columns: 1fr; gap: 8px;</code><br>
+        카드 높이 68px · padding 14px 16px · 아이콘 36×36px · CTA 화살표 생략
+      </div>
+    </div>
+    <div class="spec__row">
+      <div class="spec__key">Threads 카드</div>
+      <div class="spec__val">
+        bg <code>linear-gradient(135deg, #0E0E14 0%, #1C1C24 100%)</code> · 텍스트 #fff · CTA pill <code>bg:#fff; color:var(--gray-900);</code>
+      </div>
+    </div>
+    <div class="spec__row">
+      <div class="spec__key">Instagram 카드</div>
+      <div class="spec__val">
+        bg <code>linear-gradient(135deg, #FFE08A, #FF6F4D, #E53E5E, #C13584, #5B3F9F)</code> · 우상단 highlight overlay · CTA pill <code>color:#C13584;</code>
+      </div>
+    </div>
+    <div class="spec__row">
+      <div class="spec__key">Radius</div>
+      <div class="spec__val"><code>var(--border-radius-400)</code> = 12px · DESIGN.md §5</div>
+    </div>
+    <div class="spec__row">
+      <div class="spec__key">Border / Shadow</div>
+      <div class="spec__val">없음 — DESIGN.md §6 flat 원칙 준수</div>
+    </div>
+    <div class="spec__row">
+      <div class="spec__key">Hover</div>
+      <div class="spec__val"><code>transform: translateY(-1px); transition: transform 0.18s ease;</code> — 그림자 추가 금지</div>
+    </div>
+    <div class="spec__row">
+      <div class="spec__key">A11y</div>
+      <div class="spec__val">
+        각 카드는 <code>&lt;a&gt;</code> · <code>aria-label</code> 명시 · 외부 링크는 <code>target="_blank" rel="noopener noreferrer"</code> · focus-visible 시 KTB Blue 2px outline
+      </div>
+    </div>
+    <div class="spec__row">
+      <div class="spec__key">링크 (구현 시 필요)</div>
+      <div class="spec__val">
+        <code>https://www.threads.net/@&lt;handle&gt;</code> · <code>https://www.instagram.com/&lt;handle&gt;</code> — 실제 핸들 확인 후 주입
+      </div>
+    </div>
+    <div class="spec__row">
+      <div class="spec__key">예상 공수</div>
+      <div class="spec__val">0.5 day · 외부 API · 백엔드 변경 없음</div>
+    </div>
+  </div>
+</section>
+
+<!-- ============ FOOTER ============ -->
+<footer class="footer">
+  <div class="footer__line">
+    이 mockup 그대로 구현으로 옮기면 됩니다.<br>
+    <em>실제 SNS 핸들 URL</em>만 알려주시면 바로 들어가요.
+  </div>
+  <div class="footer__bottom">
+    <span>DEV·EVENT / SOCIAL BANNER · variant A · final</span>
+    <span>2026.05.15 · breakpoint 768px</span>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/docs/mockups/social-banner-mockup.html
+++ b/docs/mockups/social-banner-mockup.html
@@ -1,0 +1,1100 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Dev Event Web · Social Banner Mockup</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+:root{
+  /* Mapped 1:1 to project DESIGN.md tokens */
+  --gray-000:#ffffff;
+  --gray-050:#F7F7FA;       /* background-alternative */
+  --gray-100:#F0F0F5;
+  --gray-200:#E8E8EE;
+  --gray-300:#E1E1E8;       /* border-color */
+  --gray-400:#CDCED6;       /* border-hover */
+  --gray-500:#8C8F9F;
+  --gray-600:#6C6E7E;       /* text-hint */
+  --gray-700:#525463;
+  --gray-800:#3E404C;       /* text-secondary */
+  --gray-900:#2B2D36;       /* text-normal */
+  --gray-950:#252730;
+  --ktb-blue:#0043ff;
+  --ktb-navy:#000040;
+  --ktb-navy-hover:#0238D1;
+  --ktb-sky:#78CDFF;
+
+  --ig-grad:linear-gradient(135deg,#FFE08A 0%,#FF6F4D 25%,#E53E5E 50%,#C13584 75%,#5B3F9F 100%);
+  --threads-ink:#0E0E14;
+
+  --r-200:6px;   /* badge */
+  --r-400:12px;  /* standard */
+  --r-600:24px;  /* elevated */
+}
+
+*{box-sizing:border-box;margin:0;padding:0;}
+html{scroll-behavior:smooth;}
+body{
+  font-family:'Pretendard Variable',Pretendard,-apple-system,BlinkMacSystemFont,system-ui,sans-serif;
+  background:var(--gray-050);
+  color:var(--gray-900);
+  -webkit-font-smoothing:antialiased;
+  word-break:keep-all;
+  line-height:1.5;
+}
+.serif{font-family:'Instrument Serif',serif;font-style:italic;font-weight:400;}
+.mono{font-family:'JetBrains Mono',monospace;}
+button{font:inherit;background:none;border:none;cursor:pointer;color:inherit;}
+a{color:inherit;text-decoration:none;}
+
+/* ============ TOP BAR ============ */
+.topbar{
+  position:sticky;top:0;z-index:50;
+  background:hsla(0,0%,100%,.88);
+  backdrop-filter:blur(20px) saturate(150%);
+  border-bottom:1px solid var(--gray-300);
+}
+.topbar__inner{
+  max-width:1104px;margin:0 auto;
+  padding:14px 48px;
+  display:flex;align-items:center;gap:24px;
+  font-size:13px;
+}
+.topbar__logo{font-weight:800;letter-spacing:-0.02em;font-size:15px;}
+.topbar__logo b{color:var(--ktb-blue);}
+.topbar__nav{display:flex;gap:24px;flex:1;}
+.topbar__nav a{color:var(--gray-600);font-weight:500;font-size:13px;transition:color .15s;}
+.topbar__nav a:hover{color:var(--ktb-blue);}
+.topbar__date{
+  color:var(--gray-600);font-family:'JetBrains Mono',monospace;
+  font-size:11px;letter-spacing:0.06em;
+}
+
+/* ============ HERO ============ */
+.hero{
+  max-width:1104px;margin:0 auto;
+  padding:80px 48px 64px;
+}
+.hero__eyebrow{
+  display:inline-flex;align-items:center;gap:12px;
+  font-size:11px;letter-spacing:0.18em;text-transform:uppercase;
+  color:var(--ktb-blue);font-weight:700;margin-bottom:32px;
+}
+.hero__eyebrow::before{content:"";width:36px;height:1px;background:var(--ktb-blue);}
+.hero h1{
+  font-size:clamp(40px,6.5vw,84px);
+  line-height:0.98;
+  letter-spacing:-0.035em;
+  font-weight:800;
+  margin-bottom:28px;
+}
+.hero h1 em{
+  font-family:'Instrument Serif',serif;
+  font-style:italic;font-weight:400;
+  color:var(--ktb-blue);
+}
+.hero__lede{
+  max-width:640px;font-size:18px;color:var(--gray-700);
+  line-height:1.6;
+}
+.hero__lede mark{
+  background:linear-gradient(180deg,transparent 60%,rgba(0,67,255,0.08) 60%);
+  padding:0 4px;color:var(--gray-900);font-weight:600;
+}
+.hero__meta{
+  margin-top:48px;
+  display:grid;grid-template-columns:repeat(4,1fr);gap:32px;
+  border-top:1px solid var(--gray-900);padding-top:24px;
+}
+.hero__meta dt{
+  font-size:10.5px;letter-spacing:0.14em;text-transform:uppercase;
+  color:var(--gray-600);margin-bottom:8px;font-weight:600;
+}
+.hero__meta dd{font-size:15px;font-weight:600;letter-spacing:-0.01em;}
+.hero__meta dd b{
+  font-family:'JetBrains Mono',monospace;
+  font-weight:500;color:var(--ktb-blue);font-size:12px;
+  display:block;margin-top:2px;
+}
+
+/* ============ FEATURE COMMON ============ */
+.feature{
+  max-width:1104px;margin:0 auto;
+  padding:96px 48px;
+  border-top:1px solid var(--gray-900);
+}
+.feature__head{margin-bottom:48px;max-width:720px;}
+.feature__num{
+  font-family:'Instrument Serif',serif;
+  font-style:italic;
+  font-size:96px;line-height:1;color:var(--ktb-blue);
+  margin-bottom:20px;letter-spacing:-0.02em;
+}
+.feature__label{
+  font-size:11px;letter-spacing:0.18em;text-transform:uppercase;
+  color:var(--gray-600);font-weight:700;margin-bottom:16px;
+  display:flex;align-items:center;gap:10px;
+}
+.feature__label::before{content:"";width:24px;height:1px;background:var(--gray-600);}
+.feature__title{
+  font-size:clamp(32px,3.6vw,48px);
+  line-height:1.1;letter-spacing:-0.03em;font-weight:700;
+  margin-bottom:20px;
+}
+.feature__title em{
+  font-family:'Instrument Serif',serif;
+  font-style:italic;font-weight:400;color:var(--ktb-blue);
+}
+.feature__lede{
+  font-size:16px;color:var(--gray-700);line-height:1.65;
+}
+.feature__chips{display:flex;flex-wrap:wrap;gap:8px;margin-top:20px;}
+.chip{
+  display:inline-flex;align-items:center;gap:6px;
+  padding:6px 12px;border-radius:9999px;
+  border:1px solid var(--gray-400);
+  font-family:'JetBrains Mono',monospace;
+  font-size:10.5px;color:var(--gray-800);letter-spacing:0.02em;
+}
+.chip--ink{background:var(--gray-900);color:#fff;border-color:var(--gray-900);}
+.chip--accent{background:rgba(0,67,255,0.08);color:var(--ktb-blue);border-color:transparent;font-weight:600;}
+.chip--good{background:rgba(8,120,94,0.1);color:#08785E;border-color:transparent;font-weight:600;}
+.chip--soft{background:var(--gray-100);color:var(--gray-700);border-color:transparent;}
+
+/* ============ MOCKUP CANVAS ============ */
+.canvas{
+  background:var(--gray-050);
+  border:1px solid var(--gray-300);
+  border-radius:var(--r-600);
+  padding:48px;
+  position:relative;
+  overflow:hidden;
+}
+.canvas::before{
+  content:"";position:absolute;inset:0;
+  background-image:radial-gradient(circle at 1px 1px,rgba(14,14,20,0.05) 1px,transparent 0);
+  background-size:24px 24px;
+  pointer-events:none;
+  mask-image:radial-gradient(ellipse at center,#000 30%,transparent 80%);
+}
+.canvas__cap{
+  position:absolute;top:18px;left:24px;
+  font-family:'JetBrains Mono',monospace;
+  font-size:10px;color:var(--gray-600);letter-spacing:0.1em;
+  text-transform:uppercase;
+  display:flex;align-items:center;gap:8px;
+  z-index:2;
+}
+.canvas__cap::before{
+  content:"";width:6px;height:6px;background:var(--ktb-blue);border-radius:50%;
+  box-shadow:0 0 0 3px rgba(0,67,255,0.12);
+}
+.canvas__inner{position:relative;z-index:1;}
+
+/* /events page chrome simulation */
+.page{
+  background:var(--gray-000);
+  border:1px solid var(--gray-300);
+  border-radius:var(--r-600);
+  padding:24px;
+  max-width:880px;margin:0 auto;
+}
+.page__title{
+  font-size:24px;font-weight:700;
+  letter-spacing:-0.012rem;
+  margin-bottom:6px;color:var(--gray-900);
+}
+.page__count{
+  font-size:13px;color:var(--gray-600);font-weight:500;
+  margin-bottom:20px;
+}
+.page__filter{
+  display:flex;gap:8px;margin-bottom:20px;flex-wrap:wrap;
+}
+.page__chip{
+  padding:6px 12px;border:1px solid var(--gray-300);
+  border-radius:9999px;background:var(--gray-000);
+  font-size:13px;font-weight:500;color:var(--gray-700);
+}
+.page__chip.is-on{background:var(--gray-900);color:#fff;border-color:var(--gray-900);}
+.page__grid{
+  display:grid;grid-template-columns:repeat(3,1fr);gap:16px;margin-top:20px;
+}
+.mini-card{
+  background:transparent;
+}
+.mini-card__thumb{
+  width:100%;aspect-ratio:5/3;border-radius:var(--r-400);
+  background:var(--gray-100);position:relative;overflow:hidden;
+  margin-bottom:12px;
+}
+.mini-card__thumb.g1{background:linear-gradient(135deg,#0043ff 0%,#7B9DFF 100%);}
+.mini-card__thumb.g2{background:linear-gradient(135deg,#08785E 0%,#7DDBA8 100%);}
+.mini-card__thumb.g3{background:linear-gradient(135deg,#FF6F4D 0%,#FFB155 100%);}
+.mini-card__badge{
+  position:absolute;top:12px;left:12px;
+  font-size:10.5px;font-weight:600;
+  background:rgba(255,255,255,0.96);
+  color:var(--gray-900);
+  padding:3px 8px;border-radius:9999px;
+}
+.mini-card__name{
+  font-size:13.5px;font-weight:700;
+  letter-spacing:-0.012rem;
+  white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
+  margin-bottom:4px;
+}
+.mini-card__period{
+  font-size:11px;color:var(--gray-600);
+  display:flex;align-items:center;gap:4px;
+}
+
+/* ============ LOGOS ============ */
+.logo-ig{
+  display:inline-flex;align-items:center;justify-content:center;
+  background:var(--ig-grad);
+  border-radius:8px;
+  color:#fff;
+}
+.logo-threads{
+  display:inline-flex;align-items:center;justify-content:center;
+  background:var(--threads-ink);
+  border-radius:8px;
+  color:#fff;
+}
+
+/* ============================================================
+   VARIANT A — Split Card (RECOMMENDED placement: above event list)
+   ============================================================ */
+.va{
+  display:grid;grid-template-columns:1fr 1fr;gap:12px;
+  margin-bottom:24px;
+}
+.va__card{
+  position:relative;overflow:hidden;
+  border-radius:var(--r-400);
+  padding:18px 20px;
+  display:flex;align-items:center;gap:16px;
+  transition:transform .18s ease;
+  cursor:pointer;
+}
+.va__card:hover{transform:translateY(-1px);}
+
+.va__card--threads{
+  background:linear-gradient(135deg,#0E0E14 0%,#1C1C24 100%);
+  color:#fff;
+}
+.va__card--ig{
+  background:var(--ig-grad);
+  color:#fff;
+}
+.va__card--ig::after{
+  content:"";position:absolute;inset:0;
+  background:radial-gradient(circle at 100% 0%,rgba(255,255,255,0.18),transparent 60%);
+  pointer-events:none;
+}
+.va__icon{
+  width:44px;height:44px;
+  background:rgba(255,255,255,0.14);
+  border-radius:10px;
+  display:flex;align-items:center;justify-content:center;
+  flex-shrink:0;backdrop-filter:blur(8px);
+}
+.va__icon svg{width:24px;height:24px;color:#fff;}
+.va__body{flex:1;min-width:0;position:relative;z-index:1;}
+.va__label{
+  font-size:10.5px;font-weight:600;
+  opacity:0.78;letter-spacing:0.06em;text-transform:uppercase;
+  margin-bottom:2px;
+}
+.va__copy{
+  font-size:15px;font-weight:700;
+  letter-spacing:-0.012rem;line-height:1.3;
+  margin-bottom:2px;
+}
+.va__handle{
+  font-size:11.5px;font-weight:500;opacity:0.78;
+  font-family:'JetBrains Mono',monospace;
+}
+.va__cta{
+  font-size:12px;font-weight:700;
+  padding:7px 12px;border-radius:9999px;
+  background:#fff;color:var(--gray-900);
+  flex-shrink:0;
+  display:inline-flex;align-items:center;gap:4px;
+}
+.va__card--ig .va__cta{color:#C13584;}
+
+/* ============================================================
+   VARIANT B — Slim Strip (placement: inline, narrow)
+   ============================================================ */
+.vb{
+  display:flex;align-items:center;gap:14px;
+  background:var(--gray-000);
+  border:1px solid var(--gray-300);
+  border-radius:var(--r-400);
+  padding:14px 20px;
+  margin-bottom:24px;
+}
+.vb__icons{display:flex;gap:6px;}
+.vb__icon-pill{
+  width:32px;height:32px;border-radius:8px;
+  display:flex;align-items:center;justify-content:center;
+}
+.vb__icon-pill svg{width:18px;height:18px;color:#fff;}
+.vb__copy{
+  flex:1;font-size:13.5px;font-weight:600;
+  letter-spacing:-0.005em;color:var(--gray-900);
+}
+.vb__copy span{color:var(--gray-600);font-weight:500;margin-left:4px;}
+.vb__actions{display:flex;gap:6px;}
+.vb__btn{
+  padding:7px 12px;
+  border-radius:9999px;
+  font-size:12px;font-weight:700;
+  display:inline-flex;align-items:center;gap:4px;
+  border:1px solid var(--gray-300);
+  background:var(--gray-000);
+  color:var(--gray-900);
+  transition:border-color .15s,background .15s;
+}
+.vb__btn:hover{border-color:var(--gray-900);}
+.vb__btn--threads:hover{background:#0E0E14;color:#fff;border-color:#0E0E14;}
+.vb__btn--ig:hover{background:var(--ig-grad);color:#fff;border-color:transparent;}
+.vb__close{
+  width:28px;height:28px;border-radius:50%;
+  display:flex;align-items:center;justify-content:center;
+  color:var(--gray-500);
+}
+.vb__close:hover{background:var(--gray-100);color:var(--gray-900);}
+
+/* ============================================================
+   VARIANT C — Hero Gradient Card (placement: replaces existing top banner)
+   ============================================================ */
+.vc{
+  position:relative;overflow:hidden;
+  border-radius:var(--r-600);
+  padding:32px 36px;
+  background:linear-gradient(135deg,#0E0E14 0%,#1C1C24 45%,#3A1E62 100%);
+  color:#fff;
+  margin-bottom:24px;
+  display:flex;align-items:center;gap:32px;
+}
+.vc::before{
+  content:"";position:absolute;
+  inset:auto -100px -120px auto;
+  width:340px;height:340px;
+  background:var(--ig-grad);
+  border-radius:50%;
+  filter:blur(70px);opacity:0.55;
+  pointer-events:none;
+}
+.vc::after{
+  content:"";position:absolute;
+  inset:-120px auto auto -80px;
+  width:240px;height:240px;
+  background:radial-gradient(circle,rgba(0,67,255,0.55),transparent 70%);
+  border-radius:50%;
+  filter:blur(50px);
+  pointer-events:none;
+}
+.vc__body{position:relative;z-index:1;flex:1;}
+.vc__eyebrow{
+  display:inline-flex;align-items:center;gap:8px;
+  font-size:11px;font-weight:700;letter-spacing:0.12em;text-transform:uppercase;
+  color:#fff;opacity:0.78;margin-bottom:14px;
+}
+.vc__eyebrow::before{
+  content:"";width:6px;height:6px;border-radius:50%;
+  background:var(--ktb-sky);
+  box-shadow:0 0 0 3px rgba(120,205,255,0.22);
+  animation:pulse-sky 2s infinite;
+}
+@keyframes pulse-sky{
+  0%,100%{box-shadow:0 0 0 3px rgba(120,205,255,0.22);}
+  50%{box-shadow:0 0 0 6px rgba(120,205,255,0);}
+}
+.vc__title{
+  font-size:26px;font-weight:800;
+  letter-spacing:-0.022em;line-height:1.2;
+  margin-bottom:8px;
+}
+.vc__title em{
+  font-family:'Instrument Serif',serif;
+  font-style:italic;font-weight:400;
+  background:var(--ig-grad);
+  -webkit-background-clip:text;background-clip:text;
+  color:transparent;
+}
+.vc__text{
+  font-size:13.5px;color:rgba(255,255,255,0.78);
+  margin-bottom:18px;max-width:440px;line-height:1.55;
+}
+.vc__buttons{display:flex;gap:8px;flex-wrap:wrap;position:relative;z-index:1;}
+.vc__btn{
+  padding:9px 16px;border-radius:9999px;
+  font-size:13px;font-weight:700;
+  display:inline-flex;align-items:center;gap:8px;
+  transition:transform .15s ease;
+}
+.vc__btn:hover{transform:translateY(-1px);}
+.vc__btn svg{width:16px;height:16px;}
+.vc__btn--threads{background:#fff;color:#0E0E14;}
+.vc__btn--ig{
+  background:var(--ig-grad);
+  color:#fff;
+}
+.vc__handle-mono{
+  font-family:'JetBrains Mono',monospace;font-size:11.5px;
+  opacity:0.7;
+}
+
+/* ============ DEVICE PREVIEW (mobile mini) ============ */
+.mobile-stack{
+  display:flex;gap:32px;align-items:flex-start;
+  margin-top:32px;flex-wrap:wrap;
+}
+.phone{
+  width:280px;flex-shrink:0;
+  background:#0E0E14;
+  border-radius:32px;
+  padding:8px;
+  box-shadow:0 20px 48px rgba(14,14,20,0.18),0 4px 12px rgba(14,14,20,0.08);
+}
+.phone__notch{
+  width:90px;height:18px;background:#000;
+  border-radius:0 0 14px 14px;margin:0 auto 4px;
+}
+.phone__screen{
+  background:var(--gray-000);
+  border-radius:24px;
+  padding:14px;min-height:480px;
+  overflow:hidden;
+}
+.phone__nav{
+  display:flex;justify-content:space-between;align-items:center;
+  margin-bottom:14px;
+  font-size:14px;font-weight:800;letter-spacing:-0.02em;
+}
+.phone__nav small{font-size:10px;color:var(--gray-600);font-weight:500;}
+.phone__title{
+  font-size:16px;font-weight:700;
+  letter-spacing:-0.012rem;
+  margin:8px 0 4px;
+}
+.phone__count{font-size:11px;color:var(--gray-600);margin-bottom:12px;}
+.phone__card{
+  margin-top:10px;display:flex;flex-direction:column;gap:8px;
+}
+.phone__card-thumb{
+  width:100%;aspect-ratio:5/3;
+  border-radius:10px;
+  background:linear-gradient(135deg,#0043ff,#7B9DFF);
+}
+.phone__card-thumb.g2{background:linear-gradient(135deg,#FF6F4D,#FFB155);}
+.phone__card-name{font-size:12.5px;font-weight:700;letter-spacing:-0.012rem;}
+.phone__card-meta{font-size:10px;color:var(--gray-600);}
+
+/* phone-scoped banners */
+.phone .va{margin-bottom:14px;gap:8px;}
+.phone .va__card{padding:11px 12px;gap:9px;border-radius:10px;}
+.phone .va__icon{width:32px;height:32px;border-radius:8px;}
+.phone .va__icon svg{width:18px;height:18px;}
+.phone .va__label{font-size:8.5px;margin-bottom:1px;}
+.phone .va__copy{font-size:11.5px;}
+.phone .va__handle{display:none;}
+.phone .va__cta{display:none;}
+
+.phone .vb{padding:9px 12px;gap:8px;border-radius:10px;margin-bottom:14px;}
+.phone .vb__icon-pill{width:24px;height:24px;border-radius:6px;}
+.phone .vb__icon-pill svg{width:14px;height:14px;}
+.phone .vb__copy{font-size:11px;}
+.phone .vb__copy span{display:none;}
+.phone .vb__actions{display:none;}
+.phone .vb__close{width:18px;height:18px;}
+.phone .vb__close svg{width:10px;height:10px;}
+
+.phone .vc{padding:16px 16px;border-radius:14px;margin-bottom:14px;}
+.phone .vc__title{font-size:14.5px;margin-bottom:4px;}
+.phone .vc__text{font-size:10.5px;margin-bottom:10px;}
+.phone .vc__buttons{gap:6px;}
+.phone .vc__btn{padding:6px 10px;font-size:10.5px;}
+.phone .vc__btn svg{width:11px;height:11px;}
+.phone .vc__eyebrow{font-size:8.5px;margin-bottom:8px;}
+
+/* ============ COMPARE TABLE ============ */
+.compare{
+  margin-top:80px;
+  border:1px solid var(--gray-300);
+  background:var(--gray-000);
+  border-radius:var(--r-400);
+  overflow:hidden;
+}
+.compare table{width:100%;border-collapse:collapse;}
+.compare th,.compare td{
+  padding:14px 18px;text-align:left;vertical-align:top;
+  border-bottom:1px solid var(--gray-300);font-size:13.5px;
+}
+.compare thead th{
+  background:var(--gray-050);
+  font-size:11px;letter-spacing:0.12em;text-transform:uppercase;
+  font-weight:700;color:var(--gray-700);
+}
+.compare tbody th{
+  font-weight:600;color:var(--gray-600);width:160px;background:var(--gray-000);
+  font-size:11.5px;letter-spacing:0.08em;text-transform:uppercase;
+}
+.compare tbody tr:last-child th,.compare tbody tr:last-child td{border-bottom:none;}
+.compare strong{font-weight:700;color:var(--ktb-blue);}
+.compare .pros{color:#08785E;font-weight:600;}
+.compare .cons{color:#B45209;font-weight:600;}
+
+/* ============ FOOTER ============ */
+.footer{
+  max-width:1104px;margin:0 auto;
+  padding:80px 48px 56px;
+  border-top:1px solid var(--gray-900);
+}
+.footer__bigline{
+  font-size:clamp(24px,2.6vw,36px);
+  font-weight:600;letter-spacing:-0.025em;
+  line-height:1.25;max-width:640px;
+  margin-bottom:48px;
+}
+.footer__bigline em{
+  font-family:'Instrument Serif',serif;
+  font-style:italic;font-weight:400;color:var(--ktb-blue);
+}
+.footer__bottom{
+  display:flex;justify-content:space-between;
+  font-size:11px;color:var(--gray-600);
+  font-family:'JetBrains Mono',monospace;letter-spacing:0.04em;
+}
+
+/* ============ RESPONSIVE ============ */
+@media (max-width:780px){
+  .topbar__nav{display:none;}
+  .hero,.feature,.footer{padding-left:24px;padding-right:24px;}
+  .hero{padding-top:48px;padding-bottom:48px;}
+  .feature{padding:72px 24px;}
+  .hero__meta{grid-template-columns:repeat(2,1fr);gap:20px;}
+  .canvas{padding:24px;}
+  .va{grid-template-columns:1fr;}
+  .vc{flex-direction:column;align-items:flex-start;padding:24px;}
+  .page__grid{grid-template-columns:1fr 1fr;}
+}
+</style>
+</head>
+<body>
+
+<!-- ============ TOP BAR ============ -->
+<div class="topbar">
+  <div class="topbar__inner">
+    <div class="topbar__logo">dev<b>·</b>event<b>/</b><span style="color:var(--gray-600);font-weight:500;">social-banner</span></div>
+    <nav class="topbar__nav">
+      <a href="#va">A · Split Card</a>
+      <a href="#vb">B · Slim Strip</a>
+      <a href="#vc">C · Hero Gradient</a>
+      <a href="#compare">비교</a>
+    </nav>
+    <div class="topbar__date">2026.05.15 · proposal</div>
+  </div>
+</div>
+
+<!-- ============ HERO ============ -->
+<section class="hero">
+  <div class="hero__eyebrow">DEV EVENT · /events SOCIAL BANNER</div>
+  <h1>새 행사 소식,<br><em>먼저</em> 받아보세요.</h1>
+  <p class="hero__lede">
+    <mark>Threads · Instagram</mark> 공식 계정으로 가는 진입점을 <code class="mono" style="font-size:14px;background:var(--gray-100);padding:2px 6px;border-radius:4px;">/events</code> 페이지에 자연스럽게 끼워 넣는 세 가지 배치 안.
+    DESIGN.md 토큰을 모두 따르면서, 인스타 그라데이션은 §2 KTB Gradient Accents 규칙(<i>display-only</i>)을 인용 — 일반 카드 텍스트에는 적용 안 함.
+  </p>
+  <dl class="hero__meta">
+    <div><dt>토큰</dt><dd>DESIGN.md §2 · §4 <b>준수</b></dd></div>
+    <div><dt>그라데이션</dt><dd>display-only <b>§2 exception</b></dd></div>
+    <div><dt>위치</dt><dd>/events · 상단/중간 <b>placement TBD</b></dd></div>
+    <div><dt>예상 공수</dt><dd>0.5 ~ 1 day <b>frontend only</b></dd></div>
+  </dl>
+</section>
+
+<!-- ============================================================
+     VARIANT A — SPLIT CARD
+     ============================================================ -->
+<section class="feature" id="va">
+  <div class="feature__head">
+    <div class="feature__num">A</div>
+    <div class="feature__label">Recommended · split card · above list</div>
+    <h2 class="feature__title"><em>두 장</em> 나란히, 균형감 있게.</h2>
+    <p class="feature__lede">
+      Threads는 잉크 블랙, Instagram은 공식 그라데이션. 각 카드가 자체 브랜드 컬러를 가져
+      "공식 채널이구나"가 한눈에 읽힙니다. KTB의 카드 형태(12px radius, no shadow)를 그대로 따르되 그라데이션은 표면 색으로만 한정해 §2 규칙을 침범하지 않습니다.
+    </p>
+    <div class="feature__chips">
+      <span class="chip chip--ink">권장</span>
+      <span class="chip chip--accent">High visibility</span>
+      <span class="chip chip--soft">12px radius · no shadow</span>
+      <span class="chip chip--good">Pros: 2채널 동등 노출</span>
+    </div>
+  </div>
+
+  <div class="canvas">
+    <span class="canvas__cap">/events · 상단 (필터칩 아래 / 리스트 위)</span>
+    <div class="canvas__inner">
+      <div class="page">
+        <h2 class="page__title">개발자 행사</h2>
+        <div class="page__count">총 124개의 행사가 등록되어 있어요</div>
+        <div class="page__filter">
+          <span class="page__chip is-on">전체</span>
+          <span class="page__chip">컨퍼런스</span>
+          <span class="page__chip">웨비나</span>
+          <span class="page__chip">해커톤</span>
+          <span class="page__chip">밋업</span>
+        </div>
+
+        <!-- VARIANT A inline -->
+        <div class="va">
+          <a class="va__card va__card--threads" href="#">
+            <span class="va__icon" aria-hidden>
+              <!-- Threads logo -->
+              <svg viewBox="0 0 192 192" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                <path d="M141.5 86.6c-.7-.3-1.4-.7-2.1-1-1.3-23.4-14.1-36.8-35.6-37-9.7 0-17.7 4.2-22.9 11.4l11.9 8.2c3.7-5.6 9.5-6.8 14.8-6.8h.2c6.6 0 11.5 1.9 14.7 5.7 2.3 2.7 3.9 6.5 4.7 11.2-6.1-1-12.6-1.4-19.7-1-19.8 1.1-32.4 12.6-31.6 28.6.4 8.1 4.4 15 11.5 19.6 5.9 3.8 13.6 5.7 21.6 5.3 10.6-.6 18.9-4.6 24.7-11.9 4.4-5.5 7.2-12.7 8.4-21.6 5 3 8.7 7 10.7 11.7 3.5 8.1 3.7 21.5-7.2 32.4-9.6 9.6-21.1 13.7-38.5 13.8C84 156.3 70.7 150 61.9 137c-8.2-12.2-12.5-29.7-12.6-52.1.1-22.4 4.4-39.9 12.6-52 8.8-13 22.1-19.3 40.6-19.5 18.6.1 32.1 6.4 41.3 19.5 4.5 6.4 7.9 14.4 10.2 23.7l14-3.7c-2.7-11.4-7-21.3-12.8-29.5-11.7-16.6-28.9-25.1-51.1-25.2H104c-22.2.2-39 8.8-50.1 25.5-9.9 14.9-15 35.6-15.2 61.6.2 26 5.3 46.7 15.2 61.6 11.1 16.7 27.9 25.3 50.1 25.5h.1c19.7-.1 33.6-5.3 45.1-16.8 15-15 14.6-33.8 9.6-45.3-3.6-8.3-10.4-15-19.7-19.4Zm-29.7 22.8c-8.8.5-17.9-3.5-18.3-11.8-.3-6.2 4.4-13.1 18.8-13.9 1.7-.1 3.3-.1 4.9-.1 5.2 0 10.1.5 14.5 1.5-1.7 20.6-11.4 23.9-19.9 24.3Z"/>
+              </svg>
+            </span>
+            <div class="va__body">
+              <div class="va__label">Threads</div>
+              <div class="va__copy">새 행사 소식, 가장 먼저 받기</div>
+              <div class="va__handle">@dev_event_kr</div>
+            </div>
+            <span class="va__cta">팔로우
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+            </span>
+          </a>
+
+          <a class="va__card va__card--ig" href="#">
+            <span class="va__icon" aria-hidden>
+              <!-- Instagram glyph -->
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="2" y="2" width="20" height="20" rx="5"/>
+                <circle cx="12" cy="12" r="4"/>
+                <circle cx="17.5" cy="6.5" r="1" fill="currentColor"/>
+              </svg>
+            </span>
+            <div class="va__body">
+              <div class="va__label">Instagram</div>
+              <div class="va__copy">행사 현장 사진 · 후기 둘러보기</div>
+              <div class="va__handle">@dev_event_kr</div>
+            </div>
+            <span class="va__cta">팔로우
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+            </span>
+          </a>
+        </div>
+
+        <div class="page__grid">
+          <article class="mini-card">
+            <div class="mini-card__thumb g1">
+              <div class="mini-card__badge">진행중</div>
+            </div>
+            <div class="mini-card__name">FEConf Korea 2026</div>
+            <div class="mini-card__period">5월 18일 · 코엑스</div>
+          </article>
+          <article class="mini-card">
+            <div class="mini-card__thumb g2">
+              <div class="mini-card__badge">D-5</div>
+            </div>
+            <div class="mini-card__name">AWS Summit Seoul 2026</div>
+            <div class="mini-card__period">5월 20일 · 코엑스</div>
+          </article>
+          <article class="mini-card">
+            <div class="mini-card__thumb g3">
+              <div class="mini-card__badge">D-7</div>
+            </div>
+            <div class="mini-card__name">서울 디지털 해커톤</div>
+            <div class="mini-card__period">5월 25일 · 동대문</div>
+          </article>
+        </div>
+      </div>
+
+      <div class="mobile-stack">
+        <div class="phone">
+          <div class="phone__notch"></div>
+          <div class="phone__screen">
+            <div class="phone__nav">Dev Event <small>5/15</small></div>
+            <div class="phone__title">개발자 행사</div>
+            <div class="phone__count">총 124개</div>
+
+            <div class="va">
+              <a class="va__card va__card--threads" href="#">
+                <span class="va__icon"><svg viewBox="0 0 192 192" fill="currentColor"><path d="M141.5 86.6c-.7-.3-1.4-.7-2.1-1-1.3-23.4-14.1-36.8-35.6-37-9.7 0-17.7 4.2-22.9 11.4l11.9 8.2c3.7-5.6 9.5-6.8 14.8-6.8h.2c6.6 0 11.5 1.9 14.7 5.7 2.3 2.7 3.9 6.5 4.7 11.2-6.1-1-12.6-1.4-19.7-1-19.8 1.1-32.4 12.6-31.6 28.6.4 8.1 4.4 15 11.5 19.6 5.9 3.8 13.6 5.7 21.6 5.3 10.6-.6 18.9-4.6 24.7-11.9 4.4-5.5 7.2-12.7 8.4-21.6 5 3 8.7 7 10.7 11.7 3.5 8.1 3.7 21.5-7.2 32.4-9.6 9.6-21.1 13.7-38.5 13.8C84 156.3 70.7 150 61.9 137c-8.2-12.2-12.5-29.7-12.6-52.1.1-22.4 4.4-39.9 12.6-52 8.8-13 22.1-19.3 40.6-19.5 18.6.1 32.1 6.4 41.3 19.5 4.5 6.4 7.9 14.4 10.2 23.7l14-3.7c-2.7-11.4-7-21.3-12.8-29.5-11.7-16.6-28.9-25.1-51.1-25.2H104c-22.2.2-39 8.8-50.1 25.5-9.9 14.9-15 35.6-15.2 61.6.2 26 5.3 46.7 15.2 61.6 11.1 16.7 27.9 25.3 50.1 25.5h.1c19.7-.1 33.6-5.3 45.1-16.8 15-15 14.6-33.8 9.6-45.3-3.6-8.3-10.4-15-19.7-19.4Zm-29.7 22.8c-8.8.5-17.9-3.5-18.3-11.8-.3-6.2 4.4-13.1 18.8-13.9 1.7-.1 3.3-.1 4.9-.1 5.2 0 10.1.5 14.5 1.5-1.7 20.6-11.4 23.9-19.9 24.3Z"/></svg></span>
+                <div class="va__body">
+                  <div class="va__label">Threads</div>
+                  <div class="va__copy">새 소식 받기</div>
+                </div>
+              </a>
+              <a class="va__card va__card--ig" href="#">
+                <span class="va__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5"/><circle cx="12" cy="12" r="4"/><circle cx="17.5" cy="6.5" r="1" fill="currentColor"/></svg></span>
+                <div class="va__body">
+                  <div class="va__label">Instagram</div>
+                  <div class="va__copy">행사 현장 후기</div>
+                </div>
+              </a>
+            </div>
+
+            <div class="phone__card">
+              <div class="phone__card-thumb"></div>
+              <div class="phone__card-name">FEConf Korea 2026</div>
+              <div class="phone__card-meta">5월 18일 · 코엑스</div>
+            </div>
+            <div class="phone__card">
+              <div class="phone__card-thumb g2"></div>
+              <div class="phone__card-name">AWS Summit Seoul 2026</div>
+              <div class="phone__card-meta">5월 20일 · 코엑스</div>
+            </div>
+          </div>
+        </div>
+
+        <div style="flex:1;min-width:260px;">
+          <h4 style="font-size:12px;letter-spacing:0.14em;text-transform:uppercase;color:var(--gray-600);font-weight:700;margin-bottom:14px;">스펙</h4>
+          <ul style="list-style:none;font-size:13.5px;color:var(--gray-800);line-height:1.7;">
+            <li style="border-top:1px solid var(--gray-300);padding:10px 0;"><b>위치</b> — 필터 칩 줄 바로 아래, 첫 행사 카드 위</li>
+            <li style="border-top:1px solid var(--gray-300);padding:10px 0;"><b>그리드</b> — 데스크탑 1:1 / 모바일 stack (1열)</li>
+            <li style="border-top:1px solid var(--gray-300);padding:10px 0;"><b>높이</b> — 80px desktop / 64px mobile</li>
+            <li style="border-top:1px solid var(--gray-300);padding:10px 0;"><b>Radius</b> — <code class="mono">--border-radius-400</code> (12px)</li>
+            <li style="border-top:1px solid var(--gray-300);padding:10px 0;"><b>Threads</b> — bg `#0E0E14 → #1C1C24`</li>
+            <li style="border-top:1px solid var(--gray-300);padding:10px 0;"><b>Instagram</b> — official gradient (display-only 예외)</li>
+            <li style="border-top:1px solid var(--gray-300);border-bottom:1px solid var(--gray-300);padding:10px 0;"><b>Hover</b> — translateY(-1px), no shadow</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     VARIANT B — SLIM STRIP
+     ============================================================ -->
+<section class="feature" id="vb">
+  <div class="feature__head">
+    <div class="feature__num">B</div>
+    <div class="feature__label">Subtle · slim strip · dismissible</div>
+    <h2 class="feature__title">조용히 한 줄로<br><em>덜 방해하게</em>.</h2>
+    <p class="feature__lede">
+      행사 카드의 시각적 무게를 그대로 두고 싶을 때. 단정한 1px 보더 + 작은 아이콘 페어 + 텍스트 한 줄로 끝.
+      X 버튼으로 닫을 수 있고(localStorage 기억), 닫혀도 Footer에서는 항상 찾을 수 있게 합니다.
+    </p>
+    <div class="feature__chips">
+      <span class="chip chip--soft">Minimal noise</span>
+      <span class="chip chip--good">Pros: 콘텐츠 우선</span>
+      <span class="chip">dismissible · localStorage</span>
+    </div>
+  </div>
+
+  <div class="canvas">
+    <span class="canvas__cap">/events · 상단 (헤더 바로 아래)</span>
+    <div class="canvas__inner">
+      <div class="page">
+
+        <div class="vb">
+          <div class="vb__icons">
+            <span class="vb__icon-pill" style="background:#0E0E14;">
+              <svg viewBox="0 0 192 192" fill="currentColor"><path d="M141.5 86.6c-.7-.3-1.4-.7-2.1-1-1.3-23.4-14.1-36.8-35.6-37-9.7 0-17.7 4.2-22.9 11.4l11.9 8.2c3.7-5.6 9.5-6.8 14.8-6.8h.2c6.6 0 11.5 1.9 14.7 5.7 2.3 2.7 3.9 6.5 4.7 11.2-6.1-1-12.6-1.4-19.7-1-19.8 1.1-32.4 12.6-31.6 28.6.4 8.1 4.4 15 11.5 19.6 5.9 3.8 13.6 5.7 21.6 5.3 10.6-.6 18.9-4.6 24.7-11.9 4.4-5.5 7.2-12.7 8.4-21.6 5 3 8.7 7 10.7 11.7 3.5 8.1 3.7 21.5-7.2 32.4-9.6 9.6-21.1 13.7-38.5 13.8C84 156.3 70.7 150 61.9 137c-8.2-12.2-12.5-29.7-12.6-52.1.1-22.4 4.4-39.9 12.6-52 8.8-13 22.1-19.3 40.6-19.5 18.6.1 32.1 6.4 41.3 19.5 4.5 6.4 7.9 14.4 10.2 23.7l14-3.7c-2.7-11.4-7-21.3-12.8-29.5-11.7-16.6-28.9-25.1-51.1-25.2H104c-22.2.2-39 8.8-50.1 25.5-9.9 14.9-15 35.6-15.2 61.6.2 26 5.3 46.7 15.2 61.6 11.1 16.7 27.9 25.3 50.1 25.5h.1c19.7-.1 33.6-5.3 45.1-16.8 15-15 14.6-33.8 9.6-45.3-3.6-8.3-10.4-15-19.7-19.4Zm-29.7 22.8c-8.8.5-17.9-3.5-18.3-11.8-.3-6.2 4.4-13.1 18.8-13.9 1.7-.1 3.3-.1 4.9-.1 5.2 0 10.1.5 14.5 1.5-1.7 20.6-11.4 23.9-19.9 24.3Z"/></svg>
+            </span>
+            <span class="vb__icon-pill" style="background:var(--ig-grad);">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5"/><circle cx="12" cy="12" r="4"/><circle cx="17.5" cy="6.5" r="1" fill="currentColor"/></svg>
+            </span>
+          </div>
+          <div class="vb__copy">데브이벤트 소식, SNS에서 먼저 받아보세요<span>· 새 행사가 올라오면 가장 먼저 알려드려요</span></div>
+          <div class="vb__actions">
+            <a class="vb__btn vb__btn--threads" href="#">Threads 팔로우</a>
+            <a class="vb__btn vb__btn--ig" href="#">Instagram 팔로우</a>
+          </div>
+          <button class="vb__close" aria-label="배너 닫기">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M18 6L6 18M6 6l12 12"/></svg>
+          </button>
+        </div>
+
+        <h2 class="page__title">개발자 행사</h2>
+        <div class="page__count">총 124개의 행사가 등록되어 있어요</div>
+        <div class="page__filter">
+          <span class="page__chip is-on">전체</span>
+          <span class="page__chip">컨퍼런스</span>
+          <span class="page__chip">웨비나</span>
+          <span class="page__chip">해커톤</span>
+          <span class="page__chip">밋업</span>
+        </div>
+        <div class="page__grid">
+          <article class="mini-card">
+            <div class="mini-card__thumb g1"><div class="mini-card__badge">진행중</div></div>
+            <div class="mini-card__name">FEConf Korea 2026</div>
+            <div class="mini-card__period">5월 18일 · 코엑스</div>
+          </article>
+          <article class="mini-card">
+            <div class="mini-card__thumb g2"><div class="mini-card__badge">D-5</div></div>
+            <div class="mini-card__name">AWS Summit Seoul 2026</div>
+            <div class="mini-card__period">5월 20일 · 코엑스</div>
+          </article>
+          <article class="mini-card">
+            <div class="mini-card__thumb g3"><div class="mini-card__badge">D-7</div></div>
+            <div class="mini-card__name">서울 디지털 해커톤</div>
+            <div class="mini-card__period">5월 25일 · 동대문</div>
+          </article>
+        </div>
+      </div>
+
+      <div class="mobile-stack">
+        <div class="phone">
+          <div class="phone__notch"></div>
+          <div class="phone__screen">
+            <div class="phone__nav">Dev Event <small>5/15</small></div>
+
+            <div class="vb">
+              <div class="vb__icons">
+                <span class="vb__icon-pill" style="background:#0E0E14;">
+                  <svg viewBox="0 0 192 192" fill="currentColor"><path d="M141.5 86.6c-.7-.3-1.4-.7-2.1-1-1.3-23.4-14.1-36.8-35.6-37-9.7 0-17.7 4.2-22.9 11.4l11.9 8.2c3.7-5.6 9.5-6.8 14.8-6.8h.2c6.6 0 11.5 1.9 14.7 5.7 2.3 2.7 3.9 6.5 4.7 11.2-6.1-1-12.6-1.4-19.7-1-19.8 1.1-32.4 12.6-31.6 28.6.4 8.1 4.4 15 11.5 19.6 5.9 3.8 13.6 5.7 21.6 5.3 10.6-.6 18.9-4.6 24.7-11.9 4.4-5.5 7.2-12.7 8.4-21.6 5 3 8.7 7 10.7 11.7 3.5 8.1 3.7 21.5-7.2 32.4-9.6 9.6-21.1 13.7-38.5 13.8C84 156.3 70.7 150 61.9 137c-8.2-12.2-12.5-29.7-12.6-52.1.1-22.4 4.4-39.9 12.6-52 8.8-13 22.1-19.3 40.6-19.5 18.6.1 32.1 6.4 41.3 19.5 4.5 6.4 7.9 14.4 10.2 23.7l14-3.7c-2.7-11.4-7-21.3-12.8-29.5-11.7-16.6-28.9-25.1-51.1-25.2H104c-22.2.2-39 8.8-50.1 25.5-9.9 14.9-15 35.6-15.2 61.6.2 26 5.3 46.7 15.2 61.6 11.1 16.7 27.9 25.3 50.1 25.5h.1c19.7-.1 33.6-5.3 45.1-16.8 15-15 14.6-33.8 9.6-45.3-3.6-8.3-10.4-15-19.7-19.4Zm-29.7 22.8c-8.8.5-17.9-3.5-18.3-11.8-.3-6.2 4.4-13.1 18.8-13.9 1.7-.1 3.3-.1 4.9-.1 5.2 0 10.1.5 14.5 1.5-1.7 20.6-11.4 23.9-19.9 24.3Z"/></svg>
+                </span>
+                <span class="vb__icon-pill" style="background:var(--ig-grad);">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5"/><circle cx="12" cy="12" r="4"/><circle cx="17.5" cy="6.5" r="1" fill="currentColor"/></svg>
+                </span>
+              </div>
+              <div class="vb__copy">SNS 팔로우</div>
+              <button class="vb__close">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M18 6L6 18M6 6l12 12"/></svg>
+              </button>
+            </div>
+
+            <div class="phone__title">개발자 행사</div>
+            <div class="phone__count">총 124개</div>
+
+            <div class="phone__card">
+              <div class="phone__card-thumb"></div>
+              <div class="phone__card-name">FEConf Korea 2026</div>
+              <div class="phone__card-meta">5월 18일 · 코엑스</div>
+            </div>
+            <div class="phone__card">
+              <div class="phone__card-thumb g2"></div>
+              <div class="phone__card-name">AWS Summit Seoul 2026</div>
+              <div class="phone__card-meta">5월 20일 · 코엑스</div>
+            </div>
+          </div>
+        </div>
+
+        <div style="flex:1;min-width:260px;">
+          <h4 style="font-size:12px;letter-spacing:0.14em;text-transform:uppercase;color:var(--gray-600);font-weight:700;margin-bottom:14px;">스펙</h4>
+          <ul style="list-style:none;font-size:13.5px;color:var(--gray-800);line-height:1.7;">
+            <li style="border-top:1px solid var(--gray-300);padding:10px 0;"><b>위치</b> — 헤더 바로 아래, 필터 위</li>
+            <li style="border-top:1px solid var(--gray-300);padding:10px 0;"><b>높이</b> — 56px desktop / 44px mobile</li>
+            <li style="border-top:1px solid var(--gray-300);padding:10px 0;"><b>표면</b> — `--gray-000` bg + 1px `--gray-300` border</li>
+            <li style="border-top:1px solid var(--gray-300);padding:10px 0;"><b>아이콘</b> — 32px 페어 (Threads 잉크 / IG 그라데이션)</li>
+            <li style="border-top:1px solid var(--gray-300);padding:10px 0;"><b>닫기</b> — X 버튼, localStorage <code class="mono">'dev-event:social-banner:dismissed'</code></li>
+            <li style="border-top:1px solid var(--gray-300);border-bottom:1px solid var(--gray-300);padding:10px 0;"><b>Hover</b> — 버튼 hover 시 각 채널 색으로 채워짐</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     VARIANT C — HERO GRADIENT
+     ============================================================ -->
+<section class="feature" id="vc">
+  <div class="feature__head">
+    <div class="feature__num">C</div>
+    <div class="feature__label">Brand-forward · hero gradient · marketing</div>
+    <h2 class="feature__title">기존 영상 배너 <em>대체</em>안.</h2>
+    <p class="feature__lede">
+      현재 <code class="mono" style="font-size:14px;background:var(--gray-100);padding:2px 6px;border-radius:4px;">/events</code> 상단에 있는 영상 배너 자리를 SNS 마케팅 슬롯으로 활용하는 안.
+      깊은 잉크 + IG 그라데이션 블러 오브 + 살짝 도는 pulse-sky → DESIGN.md §6 "pulse keyframe은 라이브/긴급에만" 규칙을 인용한 단일 모션.
+    </p>
+    <div class="feature__chips">
+      <span class="chip chip--accent">Maximum visibility</span>
+      <span class="chip">replaces /events hero</span>
+      <span class="chip chip--soft">24px radius · gradient orb</span>
+      <span class="chip" style="background:rgba(180,82,9,0.1);color:#B45209;border-color:transparent;font-weight:600;">Cons: 페이지 톤 무거워짐</span>
+    </div>
+  </div>
+
+  <div class="canvas">
+    <span class="canvas__cap">/events · 페이지 최상단 (영상 배너 자리)</span>
+    <div class="canvas__inner">
+      <div class="page">
+
+        <div class="vc">
+          <div class="vc__body">
+            <div class="vc__eyebrow">SOCIAL · 데브이벤트 공식 채널</div>
+            <h3 class="vc__title">새 행사는 <em>SNS에서</em><br>가장 먼저 알려드려요.</h3>
+            <p class="vc__text">컨퍼런스 · 해커톤 · 웨비나 · 밋업. 매주 새로 올라오는 행사 소식과 현장 후기를 Threads와 Instagram에서 받아보세요.</p>
+            <div class="vc__buttons">
+              <a class="vc__btn vc__btn--threads" href="#">
+                <svg viewBox="0 0 192 192" fill="currentColor"><path d="M141.5 86.6c-.7-.3-1.4-.7-2.1-1-1.3-23.4-14.1-36.8-35.6-37-9.7 0-17.7 4.2-22.9 11.4l11.9 8.2c3.7-5.6 9.5-6.8 14.8-6.8h.2c6.6 0 11.5 1.9 14.7 5.7 2.3 2.7 3.9 6.5 4.7 11.2-6.1-1-12.6-1.4-19.7-1-19.8 1.1-32.4 12.6-31.6 28.6.4 8.1 4.4 15 11.5 19.6 5.9 3.8 13.6 5.7 21.6 5.3 10.6-.6 18.9-4.6 24.7-11.9 4.4-5.5 7.2-12.7 8.4-21.6 5 3 8.7 7 10.7 11.7 3.5 8.1 3.7 21.5-7.2 32.4-9.6 9.6-21.1 13.7-38.5 13.8C84 156.3 70.7 150 61.9 137c-8.2-12.2-12.5-29.7-12.6-52.1.1-22.4 4.4-39.9 12.6-52 8.8-13 22.1-19.3 40.6-19.5 18.6.1 32.1 6.4 41.3 19.5 4.5 6.4 7.9 14.4 10.2 23.7l14-3.7c-2.7-11.4-7-21.3-12.8-29.5-11.7-16.6-28.9-25.1-51.1-25.2H104c-22.2.2-39 8.8-50.1 25.5-9.9 14.9-15 35.6-15.2 61.6.2 26 5.3 46.7 15.2 61.6 11.1 16.7 27.9 25.3 50.1 25.5h.1c19.7-.1 33.6-5.3 45.1-16.8 15-15 14.6-33.8 9.6-45.3-3.6-8.3-10.4-15-19.7-19.4Zm-29.7 22.8c-8.8.5-17.9-3.5-18.3-11.8-.3-6.2 4.4-13.1 18.8-13.9 1.7-.1 3.3-.1 4.9-.1 5.2 0 10.1.5 14.5 1.5-1.7 20.6-11.4 23.9-19.9 24.3Z"/></svg>
+                Threads에서 보기
+              </a>
+              <a class="vc__btn vc__btn--ig" href="#">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5"/><circle cx="12" cy="12" r="4"/><circle cx="17.5" cy="6.5" r="1" fill="currentColor"/></svg>
+                Instagram에서 보기
+              </a>
+            </div>
+          </div>
+        </div>
+
+        <h2 class="page__title">개발자 행사</h2>
+        <div class="page__count">총 124개의 행사가 등록되어 있어요</div>
+        <div class="page__grid">
+          <article class="mini-card">
+            <div class="mini-card__thumb g1"><div class="mini-card__badge">진행중</div></div>
+            <div class="mini-card__name">FEConf Korea 2026</div>
+            <div class="mini-card__period">5월 18일 · 코엑스</div>
+          </article>
+          <article class="mini-card">
+            <div class="mini-card__thumb g2"><div class="mini-card__badge">D-5</div></div>
+            <div class="mini-card__name">AWS Summit Seoul 2026</div>
+            <div class="mini-card__period">5월 20일 · 코엑스</div>
+          </article>
+          <article class="mini-card">
+            <div class="mini-card__thumb g3"><div class="mini-card__badge">D-7</div></div>
+            <div class="mini-card__name">서울 디지털 해커톤</div>
+            <div class="mini-card__period">5월 25일 · 동대문</div>
+          </article>
+        </div>
+      </div>
+
+      <div class="mobile-stack">
+        <div class="phone">
+          <div class="phone__notch"></div>
+          <div class="phone__screen">
+            <div class="phone__nav">Dev Event <small>5/15</small></div>
+
+            <div class="vc">
+              <div class="vc__body">
+                <div class="vc__eyebrow">SOCIAL</div>
+                <h3 class="vc__title">새 행사 소식, SNS에서</h3>
+                <p class="vc__text">매주 새 행사 + 현장 후기.</p>
+                <div class="vc__buttons">
+                  <a class="vc__btn vc__btn--threads" href="#">
+                    <svg viewBox="0 0 192 192" fill="currentColor"><path d="M141.5 86.6c-.7-.3-1.4-.7-2.1-1-1.3-23.4-14.1-36.8-35.6-37-9.7 0-17.7 4.2-22.9 11.4l11.9 8.2c3.7-5.6 9.5-6.8 14.8-6.8h.2c6.6 0 11.5 1.9 14.7 5.7 2.3 2.7 3.9 6.5 4.7 11.2-6.1-1-12.6-1.4-19.7-1-19.8 1.1-32.4 12.6-31.6 28.6.4 8.1 4.4 15 11.5 19.6 5.9 3.8 13.6 5.7 21.6 5.3 10.6-.6 18.9-4.6 24.7-11.9 4.4-5.5 7.2-12.7 8.4-21.6 5 3 8.7 7 10.7 11.7 3.5 8.1 3.7 21.5-7.2 32.4-9.6 9.6-21.1 13.7-38.5 13.8C84 156.3 70.7 150 61.9 137c-8.2-12.2-12.5-29.7-12.6-52.1.1-22.4 4.4-39.9 12.6-52 8.8-13 22.1-19.3 40.6-19.5 18.6.1 32.1 6.4 41.3 19.5 4.5 6.4 7.9 14.4 10.2 23.7l14-3.7c-2.7-11.4-7-21.3-12.8-29.5-11.7-16.6-28.9-25.1-51.1-25.2H104c-22.2.2-39 8.8-50.1 25.5-9.9 14.9-15 35.6-15.2 61.6.2 26 5.3 46.7 15.2 61.6 11.1 16.7 27.9 25.3 50.1 25.5h.1c19.7-.1 33.6-5.3 45.1-16.8 15-15 14.6-33.8 9.6-45.3-3.6-8.3-10.4-15-19.7-19.4Zm-29.7 22.8c-8.8.5-17.9-3.5-18.3-11.8-.3-6.2 4.4-13.1 18.8-13.9 1.7-.1 3.3-.1 4.9-.1 5.2 0 10.1.5 14.5 1.5-1.7 20.6-11.4 23.9-19.9 24.3Z"/></svg>
+                    Threads
+                  </a>
+                  <a class="vc__btn vc__btn--ig" href="#">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5"/><circle cx="12" cy="12" r="4"/><circle cx="17.5" cy="6.5" r="1" fill="currentColor"/></svg>
+                    Instagram
+                  </a>
+                </div>
+              </div>
+            </div>
+
+            <div class="phone__title">개발자 행사</div>
+            <div class="phone__card">
+              <div class="phone__card-thumb"></div>
+              <div class="phone__card-name">FEConf Korea 2026</div>
+              <div class="phone__card-meta">5월 18일 · 코엑스</div>
+            </div>
+          </div>
+        </div>
+
+        <div style="flex:1;min-width:260px;">
+          <h4 style="font-size:12px;letter-spacing:0.14em;text-transform:uppercase;color:var(--gray-600);font-weight:700;margin-bottom:14px;">스펙</h4>
+          <ul style="list-style:none;font-size:13.5px;color:var(--gray-800);line-height:1.7;">
+            <li style="border-top:1px solid var(--gray-300);padding:10px 0;"><b>위치</b> — /events 최상단 (영상 배너 자리)</li>
+            <li style="border-top:1px solid var(--gray-300);padding:10px 0;"><b>높이</b> — 200px desktop / 240px mobile</li>
+            <li style="border-top:1px solid var(--gray-300);padding:10px 0;"><b>Radius</b> — <code class="mono">--border-radius-600</code> (24px)</li>
+            <li style="border-top:1px solid var(--gray-300);padding:10px 0;"><b>표면</b> — 잉크 그라데이션 + IG 그라데이션 블러 오브 + KTB Blue 오브</li>
+            <li style="border-top:1px solid var(--gray-300);padding:10px 0;"><b>모션</b> — <code class="mono">@keyframes pulse-sky</code> on eyebrow dot (§6)</li>
+            <li style="border-top:1px solid var(--gray-300);padding:10px 0;"><b>타이포 그라데이션</b> — `em` 부분만 IG 그라데이션 텍스트 (§2 예외)</li>
+            <li style="border-top:1px solid var(--gray-300);border-bottom:1px solid var(--gray-300);padding:10px 0;"><b>리스크</b> — 기존 영상 배너 제거 필요. 마케팅 의사결정 동반.</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============ COMPARE ============ -->
+<section class="feature" id="compare">
+  <div class="feature__head">
+    <div class="feature__num">⇌</div>
+    <div class="feature__label">Compare · 의사결정 표</div>
+    <h2 class="feature__title">셋 중 <em>어떤 결</em>로 갈까요?</h2>
+  </div>
+
+  <div class="compare">
+    <table>
+      <thead>
+        <tr>
+          <th></th>
+          <th>A · Split Card</th>
+          <th>B · Slim Strip</th>
+          <th>C · Hero Gradient</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th>가시성</th>
+          <td><strong>중상</strong></td>
+          <td>낮음</td>
+          <td><strong>최상</strong></td>
+        </tr>
+        <tr>
+          <th>콘텐츠 방해</th>
+          <td>적음</td>
+          <td class="pros">거의 없음</td>
+          <td class="cons">큼</td>
+        </tr>
+        <tr>
+          <th>구현 공수</th>
+          <td>0.5d</td>
+          <td class="pros">0.3d</td>
+          <td>1d</td>
+        </tr>
+        <tr>
+          <th>위치</th>
+          <td>필터 칩 아래</td>
+          <td>헤더 바로 아래</td>
+          <td>페이지 최상단</td>
+        </tr>
+        <tr>
+          <th>닫기 가능</th>
+          <td>—</td>
+          <td class="pros">localStorage</td>
+          <td>—</td>
+        </tr>
+        <tr>
+          <th>DESIGN.md 충실도</th>
+          <td class="pros">완벽 · 12px radius · flat</td>
+          <td class="pros">완벽 · 표준 카드</td>
+          <td>§2 예외 인용 · 24px radius</td>
+        </tr>
+        <tr>
+          <th>2채널 균형</th>
+          <td class="pros">동등 노출</td>
+          <td>동등 노출</td>
+          <td>버튼 동등</td>
+        </tr>
+        <tr>
+          <th>한 줄 요약</th>
+          <td><strong>균형감 있는 정공법</strong></td>
+          <td>조용한 한 줄 · 닫기 가능</td>
+          <td>강한 인상 · 영상 배너 대체</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<!-- ============ FOOTER ============ -->
+<footer class="footer">
+  <div class="footer__bigline">
+    어느 결로 갈지 정해주시면,<br>
+    그 방향으로 <em>한 묶음</em>으로 구현하겠습니다.
+  </div>
+  <div class="footer__bottom">
+    <span>DEV·EVENT / SOCIAL BANNER · v0.1</span>
+    <span>2026.05.15 · DESIGN.md §2 · §4 · §6 conformant</span>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/lib/utils/__tests__/calendar.test.ts
+++ b/lib/utils/__tests__/calendar.test.ts
@@ -1,0 +1,165 @@
+import {
+  buildIcsForEvent,
+  buildGoogleCalendarUrl,
+  isAllDayEvent,
+} from '../calendar';
+import { Event } from 'model/event';
+
+const makeEvent = (overrides: Partial<Event> = {}): Event => ({
+  id: '123',
+  title: 'FEConf Korea 2026',
+  description: '프론트엔드 컨퍼런스',
+  organizer: '코엑스 그랜드볼룸',
+  event_link: 'https://example.com',
+  cover_image_link: '',
+  display_sequence: 1,
+  event_time_type: 'DATE',
+  start_day_week: 'MON' as never,
+  start_date_time: '2026-05-18T01:00:00.000Z',
+  end_day_week: 'MON' as never,
+  end_date_time: '2026-05-18T09:00:00.000Z',
+  tags: [],
+  create_date_time: '2026-01-01T00:00:00.000Z',
+  use_start_date_time_yn: 'Y',
+  use_end_date_time_yn: 'Y',
+  ...overrides,
+});
+
+describe('isAllDayEvent', () => {
+  it('treats use_start_date_time_yn === "N" as all-day', () => {
+    expect(
+      isAllDayEvent({
+        use_start_date_time_yn: 'N',
+        use_end_date_time_yn: 'Y',
+      })
+    ).toBe(true);
+  });
+
+  it('treats use_end_date_time_yn === "N" as all-day', () => {
+    expect(
+      isAllDayEvent({
+        use_start_date_time_yn: 'Y',
+        use_end_date_time_yn: 'N',
+      })
+    ).toBe(true);
+  });
+
+  it('returns false when both Y', () => {
+    expect(
+      isAllDayEvent({
+        use_start_date_time_yn: 'Y',
+        use_end_date_time_yn: 'Y',
+      })
+    ).toBe(false);
+  });
+});
+
+describe('buildIcsForEvent', () => {
+  it('includes VCALENDAR/VEVENT envelopes', () => {
+    const ics = buildIcsForEvent(makeEvent());
+    expect(ics).toContain('BEGIN:VCALENDAR');
+    expect(ics).toContain('END:VCALENDAR');
+    expect(ics).toContain('BEGIN:VEVENT');
+    expect(ics).toContain('END:VEVENT');
+  });
+
+  it('uses DTSTART/DTEND with UTC time for timed events', () => {
+    const ics = buildIcsForEvent(makeEvent());
+    expect(ics).toMatch(/DTSTART:\d{8}T\d{6}Z/);
+    expect(ics).toMatch(/DTEND:\d{8}T\d{6}Z/);
+  });
+
+  it('uses DATE form for all-day events and adds 1 local day to DTEND', () => {
+    // Use TZ-naive date strings so getFullYear/Month/Date resolve to 5/18 in any locale.
+    const ics = buildIcsForEvent(
+      makeEvent({
+        start_date_time: '2026-05-18T00:00:00',
+        end_date_time: '2026-05-18T23:59:59',
+        use_start_date_time_yn: 'N',
+        use_end_date_time_yn: 'N',
+      })
+    );
+    expect(ics).toContain('DTSTART;VALUE=DATE:20260518');
+    expect(ics).toContain('DTEND;VALUE=DATE:20260519');
+  });
+
+  it('escapes commas, semicolons, and backslashes in summary/description', () => {
+    const ics = buildIcsForEvent(
+      makeEvent({
+        title: 'A, B; C\\D',
+        description: 'line1\nline2',
+      })
+    );
+    expect(ics).toContain('SUMMARY:A\\, B\\; C\\\\D');
+    expect(ics).toContain('line1\\nline2');
+  });
+
+  it('embeds a 30-minute VALARM', () => {
+    const ics = buildIcsForEvent(makeEvent());
+    expect(ics).toContain('BEGIN:VALARM');
+    expect(ics).toContain('TRIGGER:-PT30M');
+    expect(ics).toContain('END:VALARM');
+  });
+
+  it('embeds baseUrl link when given', () => {
+    const ics = buildIcsForEvent(makeEvent(), 'https://dev-event.vercel.app');
+    expect(ics).toContain('URL:https://dev-event.vercel.app/event/detail/123');
+  });
+
+  it('uses CRLF line endings per RFC 5545', () => {
+    const ics = buildIcsForEvent(makeEvent());
+    expect(ics).toMatch(/\r\n/);
+  });
+});
+
+describe('buildGoogleCalendarUrl', () => {
+  it('returns a calendar.google.com TEMPLATE URL', () => {
+    const url = buildGoogleCalendarUrl(makeEvent());
+    expect(url).toMatch(
+      /^https:\/\/calendar\.google\.com\/calendar\/render\?/
+    );
+    expect(url).toContain('action=TEMPLATE');
+  });
+
+  it('encodes the title in text param', () => {
+    const url = buildGoogleCalendarUrl(
+      makeEvent({ title: 'FEConf 2026' })
+    );
+    // URLSearchParams form-encodes spaces as '+'.
+    expect(url).toContain('text=FEConf+2026');
+  });
+
+  it('uses UTC datetime range for timed events', () => {
+    const url = buildGoogleCalendarUrl(makeEvent());
+    expect(url).toMatch(/dates=\d{8}T\d{6}Z%2F\d{8}T\d{6}Z/);
+  });
+
+  it('uses date-only range with exclusive end for all-day events', () => {
+    const url = buildGoogleCalendarUrl(
+      makeEvent({
+        start_date_time: '2026-05-18T00:00:00',
+        end_date_time: '2026-05-18T23:59:59',
+        use_start_date_time_yn: 'N',
+        use_end_date_time_yn: 'N',
+      })
+    );
+    expect(url).toContain('dates=20260518%2F20260519');
+  });
+
+  it('passes organizer as location', () => {
+    const url = buildGoogleCalendarUrl(
+      makeEvent({ organizer: '코엑스' })
+    );
+    expect(decodeURIComponent(url)).toContain('location=코엑스');
+  });
+
+  it('uses UTC datetime for timed events regardless of host TZ', () => {
+    const url = buildGoogleCalendarUrl(
+      makeEvent({
+        start_date_time: '2026-05-18T01:00:00.000Z',
+        end_date_time: '2026-05-18T09:00:00.000Z',
+      })
+    );
+    expect(url).toContain('dates=20260518T010000Z%2F20260518T090000Z');
+  });
+});

--- a/lib/utils/calendar.ts
+++ b/lib/utils/calendar.ts
@@ -1,0 +1,137 @@
+import { Event } from 'model/event';
+
+export type CalendarTarget = 'google' | 'apple' | 'outlook';
+
+const pad = (n: number) => String(n).padStart(2, '0');
+
+const toIcsUtc = (input: string | Date): string => {
+  const d = typeof input === 'string' ? new Date(input) : input;
+  return (
+    d.getUTCFullYear().toString() +
+    pad(d.getUTCMonth() + 1) +
+    pad(d.getUTCDate()) +
+    'T' +
+    pad(d.getUTCHours()) +
+    pad(d.getUTCMinutes()) +
+    pad(d.getUTCSeconds()) +
+    'Z'
+  );
+};
+
+const toIcsDate = (input: string | Date): string => {
+  const d = typeof input === 'string' ? new Date(input) : input;
+  return (
+    d.getFullYear().toString() + pad(d.getMonth() + 1) + pad(d.getDate())
+  );
+};
+
+// DST/TZ-safe single day increment using local date components.
+const nextLocalDay = (d: Date): Date =>
+  new Date(d.getFullYear(), d.getMonth(), d.getDate() + 1);
+
+const escapeText = (text: string): string =>
+  text
+    .replace(/\\/g, '\\\\')
+    .replace(/;/g, '\\;')
+    .replace(/,/g, '\\,')
+    .replace(/\r?\n/g, '\\n');
+
+export const isAllDayEvent = (
+  event: Pick<Event, 'use_start_date_time_yn' | 'use_end_date_time_yn'>
+): boolean =>
+  event.use_start_date_time_yn === 'N' || event.use_end_date_time_yn === 'N';
+
+const buildDetails = (event: Event, baseUrl: string): string => {
+  const link = baseUrl ? `${baseUrl}/event/detail/${event.id}` : '';
+  const desc = event.description ? event.description.slice(0, 500) : '';
+  return [desc, link ? `자세히 보기: ${link}` : ''].filter(Boolean).join('\n\n');
+};
+
+export const buildIcsForEvent = (event: Event, baseUrl = ''): string => {
+  const start = new Date(event.start_date_time);
+  const end = new Date(event.end_date_time);
+  const allDay = isAllDayEvent(event);
+  const now = new Date();
+  const uid = `dev-event-${event.id}@dev-event.vercel.app`;
+  const link = baseUrl ? `${baseUrl}/event/detail/${event.id}` : '';
+
+  const dtStart = allDay
+    ? `DTSTART;VALUE=DATE:${toIcsDate(start)}`
+    : `DTSTART:${toIcsUtc(start)}`;
+  const dtEnd = allDay
+    ? `DTEND;VALUE=DATE:${toIcsDate(nextLocalDay(end))}`
+    : `DTEND:${toIcsUtc(end)}`;
+
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//Dev Event Web//KO//EN',
+    'CALSCALE:GREGORIAN',
+    'METHOD:PUBLISH',
+    'BEGIN:VEVENT',
+    `UID:${uid}`,
+    `DTSTAMP:${toIcsUtc(now)}`,
+    dtStart,
+    dtEnd,
+    `SUMMARY:${escapeText(event.title)}`,
+    `DESCRIPTION:${escapeText(buildDetails(event, baseUrl))}`,
+    event.organizer ? `LOCATION:${escapeText(event.organizer)}` : '',
+    link ? `URL:${link}` : '',
+    'BEGIN:VALARM',
+    'TRIGGER:-PT30M',
+    'ACTION:DISPLAY',
+    `DESCRIPTION:${escapeText(event.title)} 시작 30분 전`,
+    'END:VALARM',
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ].filter(Boolean);
+
+  return lines.join('\r\n');
+};
+
+export const buildGoogleCalendarUrl = (event: Event, baseUrl = ''): string => {
+  const start = new Date(event.start_date_time);
+  const end = new Date(event.end_date_time);
+  const allDay = isAllDayEvent(event);
+
+  const dates = allDay
+    ? `${toIcsDate(start)}/${toIcsDate(nextLocalDay(end))}`
+    : `${toIcsUtc(start)}/${toIcsUtc(end)}`;
+
+  const params = new URLSearchParams({
+    action: 'TEMPLATE',
+    text: event.title,
+    dates,
+    details: buildDetails(event, baseUrl),
+    location: event.organizer || '',
+  });
+
+  return `https://calendar.google.com/calendar/render?${params.toString()}`;
+};
+
+export const downloadIcsForEvent = (event: Event, baseUrl = ''): void => {
+  const ics = buildIcsForEvent(event, baseUrl);
+  const blob = new Blob([ics], { type: 'text/calendar;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `dev-event-${event.id}.ics`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+};
+
+export const openInCalendar = (
+  target: CalendarTarget,
+  event: Event,
+  baseUrl = ''
+): void => {
+  if (target === 'google') {
+    window.open(buildGoogleCalendarUrl(event, baseUrl), '_blank', 'noopener');
+    return;
+  }
+  downloadIcsForEvent(event, baseUrl);
+};

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
+    "@vercel/analytics": "^2.0.1",
     "axios": "^0.26.1",
     "classnames": "^2.3.1",
     "cookie": "^0.5.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -25,7 +25,6 @@ export default function MyApp({ Component, pageProps }: AppPropsWithLayout) {
 
   useEffect(() => {
     Modal.setAppElement('#__next');
-    document.documentElement.setAttribute('data-theme', 'light');
     const handleRouteChange = (url: URL) => {
       gtag.pageview(url);
     };

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -10,6 +10,7 @@ import { EventProvider } from 'context/event';
 import { WindowProvider } from 'context/window';
 import { ToastProvider } from 'context/toast';
 import Modal from 'react-modal';
+import { Analytics } from '@vercel/analytics/react';
 
 type NextPageWithLayout = NextPage & {
   getLayout?: (page: ReactElement) => ReactNode;
@@ -50,6 +51,7 @@ export default function MyApp({ Component, pageProps }: AppPropsWithLayout) {
           </EventProvider>
         </WindowProvider>
       </AuthProvider>
+      <Analytics />
     </>
   );
 }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -22,6 +22,12 @@ class MyDocument extends Document {
     return (
       <Html>
         <Head>
+          {/* FOUC prevention: resolve theme before React boots */}
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `(function(){try{var s=localStorage.getItem('dev-event:theme');var t=s||(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');document.documentElement.setAttribute('data-theme',t);}catch(e){document.documentElement.setAttribute('data-theme','light');}})();`,
+            }}
+          />
           <meta property="og:type" content="website" />
           <meta property="og:site_name" content="Dev Event" />
           <meta

--- a/pages/event/detail/[eventId].tsx
+++ b/pages/event/detail/[eventId].tsx
@@ -7,6 +7,7 @@ import { marked } from 'marked';
 import Layout from 'components/layout';
 import ShareIcon from 'components/icons/ShareIcon';
 import BookmarkIcon from 'components/icons/BookmarkIcon';
+import CalendarExportButton from 'components/common/calendar-export/CalendarExportButton';
 import DdayTag from 'components/common/tag/DdayTag';
 import FilterTag from 'components/common/tag/FilterTag';
 import LoginModal from 'components/common/modal/LoginModal';
@@ -217,11 +218,12 @@ const EventDetail: React.FC<EventDetailProps> = ({ eventData }) => {
             </div>
 
             <div className={cx('event-detail__info-section')}>
-              {/* 공유/북마크 아이콘 */}
+              {/* 공유/캘린더/북마크 아이콘 */}
               <div className={cx('event-detail__header-actions')}>
                 <button className={cx('icon-btn')} onClick={handleShare}>
                   <ShareIcon color="var(--vapor-gray-500)" />
                 </button>
+                <CalendarExportButton event={eventData} />
                 <button className={cx('icon-btn')} onClick={handleBookmark}>
                   <BookmarkIcon
                     color={

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@vercel/analytics':
+    specifier: ^2.0.1
+    version: 2.0.1(next@12.1.2)(react@17.0.2)
   axios:
     specifier: ^0.26.1
     version: 0.26.1
@@ -2592,6 +2595,39 @@ packages:
   /@ungap/structured-clone@1.3.0:
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
     dev: true
+
+  /@vercel/analytics@2.0.1(next@12.1.2)(react@17.0.2):
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+    dependencies:
+      next: 12.1.2(@babel/core@7.28.5)(react-dom@17.0.2)(react@17.0.2)(sass@1.97.1)
+      react: 17.0.2
+    dev: false
 
   /@webassemblyjs/ast@1.14.1:
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}

--- a/styles/EventDetail.module.scss
+++ b/styles/EventDetail.module.scss
@@ -128,13 +128,13 @@
       .icon-btn {
         width: 36px;
         height: 36px;
-        background-color: rgba(255, 255, 255, 0.9);
+        background-color: var(--glass-overlay);
         backdrop-filter: saturate(150%) blur(8px);
         -webkit-backdrop-filter: saturate(150%) blur(8px);
         box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
 
         &:hover {
-          background-color: rgba(255, 255, 255, 1);
+          background-color: var(--glass-overlay-strong);
         }
       }
     }

--- a/styles/MyEvent.module.scss
+++ b/styles/MyEvent.module.scss
@@ -66,6 +66,12 @@
     padding-left: $mobile-padding;
     padding-right: $mobile-padding;
   }
+
+  @include mobile {
+    max-width: 100%;
+    padding-left: $mobile-padding;
+    padding-right: $mobile-padding;
+  }
 }
 
 .tab {

--- a/styles/Theme.scss
+++ b/styles/Theme.scss
@@ -10,6 +10,13 @@ html[data-theme='light'] {
   --gray-4: #{$light-gray-4};
   --gray-5: #{$light-gray-5};
 
+  // Translucent surfaces (sticky header / glass overlays).
+  // Pre-composed rgba so SCSS does not have to interpolate runtime variables.
+  --header-bg: hsla(0, 0%, 100%, 0.88);
+  --glass-overlay: rgba(255, 255, 255, 0.9);
+  --glass-overlay-strong: rgba(255, 255, 255, 1);
+  --notice-bg: rgba(0, 67, 255, 0.08);
+
   // KTB brand
   --ktb-tech-blue: #{$ktb-tech-blue};
   --ktb-tech-navy: #{$ktb-tech-navy};
@@ -46,6 +53,12 @@ html[data-theme='dark'] {
   --gray-3: #{$dark-gray-3};
   --gray-4: #{$dark-gray-4};
   --gray-5: #{$dark-gray-5};
+
+  // Translucent surfaces — dark equivalents of the light tokens.
+  --header-bg: hsla(225, 7%, 8%, 0.86);
+  --glass-overlay: rgba(20, 20, 28, 0.72);
+  --glass-overlay-strong: rgba(28, 28, 36, 0.9);
+  --notice-bg: rgba(0, 67, 255, 0.14);
 
   // KTB brand (same hex in dark — saturated blue still reads on dark)
   --ktb-tech-blue: #{$ktb-tech-blue};

--- a/styles/Theme.scss
+++ b/styles/Theme.scss
@@ -17,6 +17,11 @@ html[data-theme='light'] {
   --glass-overlay-strong: rgba(255, 255, 255, 1);
   --notice-bg: rgba(0, 67, 255, 0.08);
 
+  // Segmented control / pill toggle (e.g. 리스트/캘린더).
+  // active needs to sit visibly above track in both themes.
+  --toggle-track-bg: #F0F0F5;
+  --toggle-active-bg: #ffffff;
+
   // KTB brand
   --ktb-tech-blue: #{$ktb-tech-blue};
   --ktb-tech-navy: #{$ktb-tech-navy};
@@ -44,45 +49,59 @@ html[data-theme='light'] {
   --vapor-text-primary: #{$vapor-text-primary};
 }
 
+// ============================================================
+// DARK THEME — Wanted Design System palette
+// Extracted from Figma file qQPdpnglONbuWul4cvodyj, node 15625:32983
+// (Color → Semantic → Dark). Replaces the older "invert light scale"
+// approach which caused tokens like vapor-gray-950 to flip to white
+// and break components that expected a stable dark surface.
+// ============================================================
 html[data-theme='dark'] {
-  --primary: #{$dark-primary};
-  --background-1: #{$dark-background-1};
-  --background-2: #{$dark-background-2};
-  --gray-1: #{$dark-gray-1};
-  --gray-2: #{$dark-gray-2};
-  --gray-3: #{$dark-gray-3};
-  --gray-4: #{$dark-gray-4};
-  --gray-5: #{$dark-gray-5};
+  --primary: #{$wanted-dark-primary-normal};
+  --background-1: #{$wanted-dark-bg-base};
+  --background-2: #{$wanted-dark-bg-elevated};
+  --gray-1: #{$wanted-dark-label-strong};
+  --gray-2: #{$wanted-dark-label-alternative};
+  --gray-3: #{$wanted-dark-interaction-inactive};
+  --gray-4: #{$wanted-dark-line-solid};
+  --gray-5: #{$wanted-dark-line-alt};
 
-  // Translucent surfaces — dark equivalents of the light tokens.
-  --header-bg: hsla(225, 7%, 8%, 0.86);
-  --glass-overlay: rgba(20, 20, 28, 0.72);
-  --glass-overlay-strong: rgba(28, 28, 36, 0.9);
-  --notice-bg: rgba(0, 67, 255, 0.14);
+  // Translucent surfaces — rgba composed from Wanted background-normal/elevated
+  --header-bg: rgba(27, 28, 30, 0.86);              // #1B1C1E @ 86%
+  --glass-overlay: rgba(33, 34, 37, 0.72);          // #212225 @ 72%
+  --glass-overlay-strong: rgba(33, 34, 37, 0.94);   // #212225 @ 94%
+  --notice-bg: rgba(51, 133, 255, 0.12);            // #3385FF @ 12%
 
-  // KTB brand (same hex in dark — saturated blue still reads on dark)
-  --ktb-tech-blue: #{$ktb-tech-blue};
+  // Segmented control: track = elevated surface, active = one step brighter line.
+  --toggle-track-bg: #{$wanted-dark-bg-elevated};       // #212225
+  --toggle-active-bg: #{$wanted-dark-line-solid};       // #37383C
+
+  // KTB brand — brand blue stays for light/dark identity, but the
+  // dark variant uses the brighter Wanted primary-normal for legibility.
+  --ktb-tech-blue: #{$wanted-dark-primary-normal};      // #3385FF (was #0043FF)
   --ktb-tech-navy: #{$ktb-tech-navy};
-  --ktb-tech-navy-hover: #{$ktb-tech-navy-hover};
+  --ktb-tech-navy-hover: #{$wanted-dark-primary-strong}; // #1A75FF
   --ktb-tech-sky: #{$ktb-tech-sky};
 
-  // Vapor gray ramp (dark theme: 000 = near-black bg → 950 = white text)
-  --vapor-gray-000: #{$vapor-gray-950};
-  --vapor-gray-050: #{$vapor-gray-900};
-  --vapor-gray-100: #{$vapor-gray-800};
-  --vapor-gray-200: #{$vapor-gray-800};
-  --vapor-gray-300: #{$vapor-gray-700};
-  --vapor-gray-400: #{$vapor-gray-500};
-  --vapor-gray-500: #{$vapor-gray-400};
-  --vapor-gray-600: #{$vapor-gray-300};
-  --vapor-gray-700: #{$vapor-gray-200};
-  --vapor-gray-800: #{$vapor-gray-100};
-  --vapor-gray-900: #{$vapor-gray-050};
-  --vapor-gray-950: #{$vapor-gray-000};
+  // Vapor gray ramp — explicit dark values (NOT inverted from light).
+  // 000–050: page + elevated surfaces. 100–300: subtle dividers / borders.
+  // 400: hover border. 500–950: text scale from disabled → strongest.
+  --vapor-gray-000: #{$wanted-dark-bg-base};            // page bg              #1B1C1E
+  --vapor-gray-050: #{$wanted-dark-bg-elevated};        // alt surface          #212225
+  --vapor-gray-100: #{$wanted-dark-line-alt};           // placeholder bg       #2E2F33
+  --vapor-gray-200: #{$wanted-dark-line-neutral};       // subtle divider       #333438
+  --vapor-gray-300: #{$wanted-dark-line-solid};         // standard border      #37383C
+  --vapor-gray-400: #{$wanted-dark-interaction-inactive}; // border hover       #5A5C63
+  --vapor-gray-500: #{$wanted-dark-label-disable};      // icon, placeholder    #989BA2
+  --vapor-gray-600: #{$wanted-dark-label-alternative};  // hint text            #AEB0B6
+  --vapor-gray-700: #{$wanted-dark-label-neutral};      // secondary on alt     #C2C4C8
+  --vapor-gray-800: #{$wanted-dark-label-normal};       // secondary text       #F7F7F8
+  --vapor-gray-900: #{$wanted-dark-label-strong};       // body, heading        #FFFFFF
+  --vapor-gray-950: #{$wanted-dark-label-strong};       // strongest emphasis   #FFFFFF
 
-  // Semantic
-  --vapor-text-danger: #{$vapor-text-danger};
-  --vapor-text-success: #{$vapor-text-success};
-  --vapor-text-warning: #{$vapor-text-warning};
-  --vapor-text-primary: #{$vapor-text-primary};
+  // Semantic — Wanted status colors (brighter, more saturated for dark legibility)
+  --vapor-text-danger: #{$wanted-dark-status-negative};   // #FF6363
+  --vapor-text-success: #{$wanted-dark-status-positive};  // #1ED45A
+  --vapor-text-warning: #{$wanted-dark-status-cautionary}; // #FFA938
+  --vapor-text-primary: #{$wanted-dark-primary-normal};   // #3385FF
 }

--- a/styles/_color.scss
+++ b/styles/_color.scss
@@ -1,29 +1,35 @@
+// ========================================
+// Legacy theme vars (5-gray scale).
+// Dark values mapped to Wanted Design System semantic tokens (extracted from
+// figma.com/design/qQPdpnglONbuWul4cvodyj — node 15625:32983 Color/Semantic/Dark).
+// ========================================
+
 $light-primary: rgba(44, 76, 239, 1);
-$dark-primary: rgba(79, 108, 255, 1);
+$dark-primary: #3385FF;                  // Wanted: color-semantic-primary-normal (dark)
 
 $light-background-1: rgba(255, 255, 255, 1);
-$dark-background-1: rgba(13, 13, 13, 1);
+$dark-background-1: #1B1C1E;             // Wanted: background-normal-normal
 
 $light-background-2: rgba(242, 242, 242, 1);
-$dark-background-2: rgba(26, 26, 26, 1);
+$dark-background-2: #212225;             // Wanted: background-elevated-normal
 
 $light-gray-1: rgba(49, 50, 52, 1);
-$dark-gray-1: rgba(203, 203, 206, 1);
+$dark-gray-1: #FFFFFF;                   // Wanted: label-strong
 
 $light-gray-2: rgba(116, 117, 121, 1);
-$dark-gray-2: rgba(121, 122, 129, 1);
+$dark-gray-2: #AEB0B6;                   // Wanted: label-alternative (base)
 
 $light-gray-3: rgba(171, 172, 178, 1);
-$dark-gray-3: rgba(81, 83, 88, 1);
+$dark-gray-3: #5A5C63;                   // Wanted: interaction-inactive
 
 $light-gray-4: rgba(211, 212, 216, 1);
-$dark-gray-4: rgba(51, 52, 57, 1);
+$dark-gray-4: #37383C;                   // Wanted: line-solid-normal
 
 $light-gray-5: rgba(231, 232, 236, 1);
-$dark-gray-5: rgba(34, 35, 38, 1);
+$dark-gray-5: #2E2F33;                   // Wanted: line-solid-alternative
 
 // ========================================
-// KTB / Vapor design tokens (DESIGN.md)
+// KTB / Vapor design tokens (DESIGN.md — light theme)
 // ========================================
 
 // KTB brand
@@ -32,7 +38,7 @@ $ktb-tech-navy: #000040;
 $ktb-tech-navy-hover: #0238D1;
 $ktb-tech-sky: #78CDFF;
 
-// Vapor gray ramp
+// Vapor gray ramp (light)
 $vapor-gray-000: #ffffff;
 $vapor-gray-050: #F7F7FA;
 $vapor-gray-100: #F0F0F5;
@@ -51,3 +57,42 @@ $vapor-text-danger: #D91C29;
 $vapor-text-success: #08785E;
 $vapor-text-warning: #B45209;
 $vapor-text-primary: #1D6CE0;
+
+// ========================================
+// Wanted Design System — Dark Mode tokens
+// Extracted from Figma file qQPdpnglONbuWul4cvodyj, node 15625:32983
+// (Color → Semantic → Dark frame). These power the dark palette in Theme.scss
+// instead of inverting the light Vapor scale, which produced unreliable contrast.
+// ========================================
+
+// Background — page canvas + elevated surfaces
+$wanted-dark-bg-base:           #1B1C1E;   // background-normal-normal (page bg)
+$wanted-dark-bg-alt:            #0F0F10;   // background-normal-alternative (deepest)
+$wanted-dark-bg-elevated:       #212225;   // background-elevated-normal (cards, modals)
+$wanted-dark-bg-elevated-alt:   #141415;   // background-elevated-alternative
+
+// Line — borders and dividers
+$wanted-dark-line-solid:        #37383C;   // line-solid-normal (standard 1px border)
+$wanted-dark-line-neutral:      #333438;   // line-solid-neutral
+$wanted-dark-line-alt:          #2E2F33;   // line-solid-alternative (subtle)
+
+// Interaction — disabled/inactive states
+$wanted-dark-interaction-inactive: #5A5C63;
+$wanted-dark-interaction-disable:  #2E2F33;
+
+// Label — text colors (semantic)
+$wanted-dark-label-strong:      #FFFFFF;   // label-strong
+$wanted-dark-label-normal:      #F7F7F8;   // label-normal
+$wanted-dark-label-neutral:     #C2C4C8;   // label-neutral (base, 88% alpha in spec)
+$wanted-dark-label-alternative: #AEB0B6;   // label-alternative (base, 61% alpha in spec)
+$wanted-dark-label-disable:     #989BA2;   // label-disable (base, 16% alpha in spec)
+
+// Primary — brand blue scale for dark mode
+$wanted-dark-primary-normal:    #3385FF;   // primary-normal
+$wanted-dark-primary-strong:    #1A75FF;   // primary-strong
+$wanted-dark-primary-heavy:     #0066FF;   // primary-heavy
+
+// Status
+$wanted-dark-status-positive:   #1ED45A;
+$wanted-dark-status-cautionary: #FFA938;
+$wanted-dark-status-negative:   #FF6363;


### PR DESCRIPTION
# feat: 2.4.0 — 캘린더 내보내기 · 다크 모드 · SNS 배너 추가

## Summary

`feature/2.4.0-fix-260512` 브랜치 작업물의 PR입니다. 프론트엔드 단에서 완결되는 3가지 기능을 추가하고, 다크 모드 도입에 따른 디자인 시스템 정비 및 헤더/캘린더 등 기존 컴포넌트의 다크 톤 부조화를 정리했습니다.

- **3개 신규 기능**: 캘린더 내보내기(.ics + Google Calendar), 다크 모드 토글, 메인 페이지 SNS 팔로우 배너(Threads · Instagram)
- **1개 디자인 시스템 작업**: Wanted Design System 다크 팔레트를 Figma REST API로 추출하여 도입 (역순 매핑 방식 폐기)
- **다수 정리 작업**: 헤더 버튼 호버 일관화, 캘린더 chip 다크 시인성, 북마크 페이지 톤 등

---

## 주요 변경

### 1. 캘린더 내보내기 (`feat: 행사 상세 페이지 캘린더 내보내기 추가`)
- 이벤트 상세 페이지(`pages/event/detail/[eventId].tsx`)에 캘린더 내보내기 버튼 추가
- Apple Calendar(.ics 다운로드) / Google Calendar(URL) / Outlook(.ics) 지원
- `lib/utils/calendar.ts` — `isAllDayEvent`, `buildIcsForEvent`, `buildGoogleCalendarUrl`, `downloadIcsForEvent`, `openInCalendar` 유틸 신설
- RFC 5545 iCalendar 포맷 + `use_start_date_time_yn`/`use_end_date_time_yn`을 고려한 all-day 분기 처리
- 유닛 테스트: `lib/utils/__tests__/calendar.test.ts` (TZ-naive 입력 + form-encoded URL 검증)

### 2. 다크 모드 (`feat: 다크모드 토글 추가` + dark mode fix 커밋들)
- `WindowContext.handleWindowTheme` 가 실제로 DOM(`html[data-theme]`) + `localStorage('dev-event:theme')`를 토글하도록 리팩토링
- FOUC 방지: `pages/_document.tsx`에 인라인 `<script>` — 첫 페인트 전 `prefers-color-scheme` 또는 저장된 선호도로 `data-theme` 적용
- `_app.tsx`에서 강제 light 적용 제거
- `components/common/theme-toggle/ThemeToggle.tsx` 신설 — Sun/Moon 인라인 글리프, 헤더 우측 nav에 배치
- **다크 팔레트는 Wanted Design System 도입** (`#3385FF` 등). 기존 "라이트 Vapor 스케일을 역순 매핑" 방식이 `--vapor-gray-950 → #FFFFFF` 같은 함정(카드 active가 흰 박스로 뒤집힘)을 만들어, 이를 폐기하고 `_color.scss`에 명시적 `$wanted-dark-*` 변수를 추가하여 `Theme.scss`에서 시맨틱 매핑

#### 다크 부조화 해결 (`fix:` 커밋 2건 + working tree)
- 하드코딩 흰색을 시맨틱 토큰으로 교체: Header bg, NoticeModal, Item 모바일 글래스, EventDetail 글래스, CalendarExportButton, JobGroupTag 칩
- `--header-bg`, `--glass-overlay(-strong)`, `--notice-bg`, `--toggle-track-bg`, `--toggle-active-bg` 토큰 신설
- **CalendarView 전체 색상 토큰화** (#fff, #E1E1E8, #6C6E7E 등 30+ 하드코딩 → `var(--vapor-*)`)
- 캘린더 chip 다크 시인성: 인라인 `color: <tagHex>`가 라이트 bg 가정으로 튜닝되어 다크에서 dark-on-dark — `:global(html[data-theme='dark']) &` 셀렉터로 `color`/`background`를 `!important` override (border-left 의 tag color는 유지하여 카테고리 큐 보존)
- "행사 등록 요청"/"무료 구독하기" KTB Blue 버튼의 검정 글씨 → 하드코딩 `#ffffff` (`var(--vapor-gray-000)`이 다크에서 페이지 bg로 뒤집혀 검정 글씨가 파란 버튼에 표시되던 버그)
- 북마크 페이지 빈 상태(`MyEventEmpty`) 다크 톤 정리 — 하드코딩 색 → 시맨틱 토큰, hover transition 추가
- ThemeToggle 달 아이콘 — 공유 `MoonIcon`(24×24)이 18px로 렌더되며 시각적 클리핑 → 인라인 Lucide-style 글리프로 교체

### 3. SNS 팔로우 배너 (`feat: 메인 페이지 SNS 팔로우 배너 추가 (Threads · Instagram)`)
- `components/features/social-banner/SocialBanner.tsx` + `.module.scss` 신설
- Threads (단색 그라데이션) + Instagram (브랜드 그라데이션 + 우상단 shine) 2장 카드 grid (PC 2열, 모바일 1열)
- 카피:
  - Threads: `새 행사 소식, 가장 먼저 받기`
  - Instagram: `익숙한 피드에서 행사 소식 받기` (동일 콘텐츠임을 고려해 매체 사용 습관 축으로 차별화)
- CTA: `보러가기 →` (외부 링크 이동 의도를 명확히 — `팔로우`는 자동 액션 오해 소지)
- 배치: "전체 행사" 헤딩 **위쪽**으로 이동 → 필터/카드 흐름 단절 제거, 페이지 진입 시 SNS 채널 어필
- 흰 pill(CTA) 위 텍스트는 하드코딩 `#2B2D36` — brand surface 위 텍스트 패턴

### 4. Header 호버 인터랙션 일관화 (working tree)
- 로그인 버튼(`TextButton`)이 각진 모서리 + 다른 hover bg를 가져 ThemeToggle과 페어가 깨졌던 문제 해결
- Header 스코프에서 `.login button` 오버라이드 (`border-radius: 10px`, hover `var(--vapor-gray-100)`, focus ring)
- Profile 아이콘 버튼(`.profile-button`) 24×24 → **40×40** 으로 확장하여 ThemeToggle 동일 프레임, hover 효과 추가, dropdown menu top 44 → 48px
- `Profile.tsx` — 공유 `ProfileIcon`(viewBox 0-24에서 body가 y=22까지 차서 작게 렌더 시 클리핑 인식) → 인라인 Lucide-style `UserGlyph` 로 교체 (SunGlyph와 stroke 시스템 페어)

### 5. 디자인 시스템 문서화 (`docs:` 커밋 + working tree)
- `DESIGN.md` §2에 **Dark Mode Palette — Wanted Design System** 섹션 추가 (Background / Line / Interaction / Label / Primary / Status / Translucent 7개 카테고리 토큰 매핑 표)
- `Dark Mode Iteration Notes` — 3가지 예외 패턴 문서화:
  1. **항상 어두운 brand surface 위 텍스트**는 하드코딩 다크 값 (SNS 배너 흰 pill)
  2. **KTB Blue surface 위 텍스트**는 하드코딩 `#ffffff` (FillButton primary, EmailSubscribeButton)
  3. **인라인 동적 색상**(`CalendarGrid` chip)은 다크에서 `:global(html[data-theme='dark']) &` 로 contrast 회복
- `docs/superpowers/specs/`, `docs/superpowers/plans/` 에 캘린더 export / 다크 모드 / SNS 배너 mockup HTML + 디자인 스펙 + 구현 플랜 추가
- `figma-developer-mcp` 프로젝트 단 등록 (`.mcp.json`, `.gitignore`에 토큰 보호 추가)

---

## 파일 변경 요약

### 신규
- `lib/utils/calendar.ts`, `lib/utils/__tests__/calendar.test.ts`
- `components/common/calendar-export/CalendarExportButton.tsx` + `.module.scss`
- `components/common/theme-toggle/ThemeToggle.tsx` + `.module.scss`
- `components/features/social-banner/SocialBanner.tsx` + `.module.scss`
- `docs/superpowers/specs/*`, `docs/superpowers/plans/*` (다수)

### 수정
- 디자인 시스템: `styles/Theme.scss`, `styles/_color.scss`, `DESIGN.md`
- 컨텍스트/엔트리: `context/window.tsx`, `pages/_app.tsx`, `pages/_document.tsx`
- 다크 톤 정비: `components/layout/header/Header.{tsx,module.scss}`, `components/layout/header/Profile.tsx`, `components/common/modal/NoticeModal.module.scss`, `components/common/item/Item.module.scss`, `components/common/calendar-export/CalendarExportButton.module.scss`, `components/common/tag/JobGroupTag.module.scss`, `components/common/buttons/FillButton.module.scss`, `components/common/buttons/EmailSubscribeButton.module.scss`, `styles/EventDetail.module.scss`
- 캘린더: `components/events/calendar/CalendarView.module.scss`
- 북마크 빈 상태: `components/myEvent/MyEventEmpty.module.scss`
- SNS 배너 마운트/순서: `components/events/ScheduledEventList.tsx`
- 헤더에 ThemeToggle 마운트: `components/layout/header/Header.tsx`
- 이벤트 상세에 CalendarExportButton 마운트: `pages/event/detail/[eventId].tsx`
- 인프라: `.gitignore`, `.mcp.json`

---

## 테스트 / 검증

- `pnpm test` — `calendar.test.ts` 통과 (TZ-naive 입력 / form-encoded URL 검증)
- `npx tsc --noEmit` — 통과
- Playwright로 라이트/다크 모드 회귀 검증 — `/events`(리스트·캘린더 뷰), `/event/detail/[id]`, `/myevent` 모두 정상

## 체크리스트

- [x] 다크 모드 토글 동작 — 토글 → DOM `data-theme` + `localStorage` 영속화 → FOUC 없음
- [x] 캘린더 내보내기 — Apple/.ics 다운로드, Google Calendar URL 열림, Outlook .ics 동작
- [x] SNS 배너 — Threads/Instagram 새 탭으로 정확히 이동, hover 시 transform/elevation 정상
- [x] 헤더 — ThemeToggle ↔ 로그인 ↔ Profile 세 버튼이 동일한 hover/focus 시각 언어
- [x] 다크 모드에서 화이트 잔재 없음 (header, notice modal, glass overlay, calendar chip, 행사 등록 요청/무료 구독하기 버튼)
- [ ] **Reviewer 체크**: 디자인 토큰 매핑이 `DESIGN.md §2`와 일치하는지 1차 review
- [ ] **Reviewer 체크**: KTB Blue surface 텍스트가 하드코딩 `#ffffff` 인지 (역순 매핑 시기의 회귀 방지)