### PR TITLE
`[release/2.6.1]` 모바일 DEV EVENT 타이틀 한 줄 표시

### DIFF
--- a/styles/Brand.module.scss
+++ b/styles/Brand.module.scss
@@ -718,14 +718,15 @@ $text-muted: #aeb2bd;
     margin-top: -4px;
 
     h1 {
-      max-width: 360px;
+      max-width: none;
       margin: 0 auto 20px;
-      font-size: clamp(64px, 20vw, 78px);
-      line-height: 0.8;
+      font-size: clamp(46px, 14vw, 60px);
+      line-height: 0.9;
       letter-spacing: -0.07em;
+      white-space: nowrap;
 
       span {
-        display: block;
+        display: inline;
       }
     }
   }


### PR DESCRIPTION
## 작업 내용

- `/about` 모바일 히어로의 `DEV EVENT` 타이틀이 388px 화면에서 두 줄로 분리되는 문제를 수정했습니다.
- 모바일 제목 크기를 반응형 `clamp()` 값으로 조정했습니다.
- 제목의 줄바꿈을 방지하고 두 텍스트 영역을 인라인으로 표시했습니다.

## 확인

- [x] 388 × 844 뷰포트에서 `DEV EVENT` 한 줄 표시
- [x] 가로 스크롤 및 텍스트 오버플로 없음
- [x] `git diff --check` 통과
